### PR TITLE
refactor: Replace direct usage of CAAPH API with vendored types

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,9 +49,14 @@ linters-settings:
   depguard:
     rules:
       main:
+        list-mode: lax # Allow everything unless explicitly denied below.
         deny:
           - pkg: k8s.io/kubernetes
             desc: "do not use k8s.io/kubernetes directly"
+          - pkg: sigs.k8s.io/cluster-api-provider-
+            desc: "do not use CAPI providers directly, instead vendor necessary APIs"
+          - pkg: sigs.k8s.io/cluster-api-addon-provider-
+            desc: "do not use CAPI providers directly, instead vendor necessary APIs"
   errcheck:
     exclude-functions:
       - encoding/json.Marshal

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	k8s.io/kubelet v0.29.3
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	sigs.k8s.io/cluster-api v1.6.3
-	sigs.k8s.io/cluster-api-addon-provider-helm v0.1.1-alpha.1
 	sigs.k8s.io/cluster-api/test v1.6.3
 	sigs.k8s.io/controller-runtime v0.17.2
 	sigs.k8s.io/yaml v1.4.0
@@ -93,6 +92,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1099,8 +1099,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 h1:TgtAeesdhpm2S
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0/go.mod h1:VHVDI/KrK4fjnV61bE2g3sA7tiETLn8sooImelsCx3Y=
 sigs.k8s.io/cluster-api v1.6.3 h1:VOlPNg92PQLlhBVLc5pg+cbAuPvGOOBujeFLk9zgnoo=
 sigs.k8s.io/cluster-api v1.6.3/go.mod h1:4FzfgPPiYaFq8X9F9j2SvmggH/4OOLEDgVJuWDqKLig=
-sigs.k8s.io/cluster-api-addon-provider-helm v0.1.1-alpha.1 h1:HfBfswOZk/oUsNfkp5mT7eW/fIY//xGAvjSq9yCO0Gc=
-sigs.k8s.io/cluster-api-addon-provider-helm v0.1.1-alpha.1/go.mod h1:SgeAkpyhAzK5GBPeqfYHbThpMptSXVhDcLyWbM6UTik=
 sigs.k8s.io/cluster-api/test v1.6.3 h1:ZCboLCTpKWzSbf+f7MpQT7EN8aeH9DNhJC1T9/vAuAM=
 sigs.k8s.io/cluster-api/test v1.6.3/go.mod h1:AKs25dgW6AnyGaQBoWuXfWnBs+FT7vJmAI/aox64DEI=
 sigs.k8s.io/controller-runtime v0.17.2 h1:FwHwD1CTUemg0pW2otk7/U5/i5m2ymzvOXdbeGOUvw0=

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -21,13 +21,13 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
-	addonsv1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	capie2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	capibootstrap "sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	addonsv1 "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/test/framework/bootstrap"
 	clusterctltemp "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/test/framework/clusterctl"
 )

--- a/test/e2e/helmreleaseproxy_helpers.go
+++ b/test/e2e/helmreleaseproxy_helpers.go
@@ -11,12 +11,13 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	addonsv1 "sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capie2e "sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	addonsv1 "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 )
 
 // WaitForHelmReleaseProxyReadyInput is the input for WaitForHelmReleaseProxyReady.


### PR DESCRIPTION
Also introduces linting rules to prevent happening this in future.