### PR TITLE
ci: Fix pages workflow concurrency

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -22,7 +22,7 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: "pages-${{github.event.pull_request.number || github.ref_name}}"
   cancel-in-progress: false
 
 # Default to bash


### PR DESCRIPTION
Grouping on PR number or git ref (branch or tag). Without this all pages
builds were included in the same concurrency group, meaning that concurrent
PR builds were leading to skipped workflows. As this is a required check, that
meant that PRs could not be merged without opening/closing the PR - not a
fun thing to have to do!
