### PR TITLE
refactor: standardize the code for getting Helm values

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/helm-addon-installation.yaml
@@ -8,6 +8,8 @@ metadata:
   name: '{{ .Values.hooks.nfd.helmAddonStrategy.defaultValueTemplateConfigMap.name }}'
 data:
   values.yaml: |-
+    image:
+      tag: v{{ .Chart.Version }}-minimal
     master:
       extraLabelNs:
         - nvidia.com

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/helm-addon-installation.yaml
@@ -8,8 +8,6 @@ metadata:
   name: '{{ .Values.hooks.nfd.helmAddonStrategy.defaultValueTemplateConfigMap.name }}'
 data:
   values.yaml: |-
-    image:
-      tag: v{{ .Chart.Version }}-minimal
     master:
       extraLabelNs:
         - nvidia.com

--- a/pkg/handlers/generic/lifecycle/ccm/aws/handler.go
+++ b/pkg/handlers/generic/lifecycle/ccm/aws/handler.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 
 	"github.com/blang/semver/v4"
+	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
@@ -58,11 +58,8 @@ func (a *AWSCCM) Apply(
 	ctx context.Context,
 	cluster *clusterv1.Cluster,
 	_ *v1alpha1.ClusterConfigSpec,
+	log logr.Logger,
 ) error {
-	log := ctrl.LoggerFrom(ctx).WithValues(
-		"cluster",
-		cluster.Name,
-	)
 	log.Info("Creating AWS CCM ConfigMap for Cluster")
 	version, err := semver.ParseTolerant(cluster.Spec.Topology.Version)
 	if err != nil {

--- a/pkg/handlers/generic/lifecycle/ccm/handler.go
+++ b/pkg/handlers/generic/lifecycle/ccm/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -25,7 +26,12 @@ const (
 )
 
 type CCMProvider interface {
-	Apply(context.Context, *clusterv1.Cluster, *v1alpha1.ClusterConfigSpec) error
+	Apply(
+		context.Context,
+		*clusterv1.Cluster,
+		*v1alpha1.ClusterConfigSpec,
+		logr.Logger,
+	) error
 }
 
 type CCMHandler struct {
@@ -120,7 +126,7 @@ func (c *CCMHandler) AfterControlPlaneInitialized(
 		return
 	}
 
-	err = handler.Apply(ctx, &req.Cluster, &clusterConfigVar)
+	err = handler.Apply(ctx, &req.Cluster, &clusterConfigVar, log)
 	if err != nil {
 		log.Error(
 			err,

--- a/pkg/handlers/generic/lifecycle/clusterautoscaler/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/clusterautoscaler/strategy_crs.go
@@ -20,19 +20,10 @@ import (
 )
 
 type crsConfig struct {
-	defaultsNamespace string
-
 	defaultClusterAutoscalerConfigMap string
 }
 
 func (c *crsConfig) AddFlags(prefix string, flags *pflag.FlagSet) {
-	flags.StringVar(
-		&c.defaultsNamespace,
-		prefix+".defaults-namespace",
-		corev1.NamespaceDefault,
-		"namespace of the ConfigMap used to deploy cluster-autoscaler",
-	)
-
 	flags.StringVar(
 		&c.defaultClusterAutoscalerConfigMap,
 		prefix+".default-cluster-autoscaler-configmap-name",

--- a/pkg/handlers/generic/lifecycle/cni/cilium/strategy_helmaddon.go
+++ b/pkg/handlers/generic/lifecycle/cni/cilium/strategy_helmaddon.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -19,6 +18,7 @@ import (
 	caaphv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/k8s/client"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/lifecycle/config"
+	lifecycleutils "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/lifecycle/utils"
 )
 
 const (
@@ -52,10 +52,15 @@ func (s helmAddonStrategy) apply(
 	log logr.Logger,
 ) error {
 	log.Info("Retrieving Cilium installation values template for cluster")
-	valuesTemplateConfigMap, err := s.retrieveValuesTemplateConfigMap(ctx, defaultsNamespace)
+	values, err := lifecycleutils.RetrieveValuesTemplate(
+		ctx,
+		s.client,
+		s.config.defaultValuesTemplateConfigMapName,
+		defaultsNamespace,
+	)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to retrieve Cilium installation values template ConfigMap for cluster: %w",
+			"failed to retrieve Cilium installation values template for cluster: %w",
 			err,
 		)
 	}
@@ -78,7 +83,7 @@ func (s helmAddonStrategy) apply(
 			ReleaseNamespace: defaultCiliumNamespace,
 			ReleaseName:      defaultCiliumReleaseName,
 			Version:          s.helmChart.Version,
-			ValuesTemplate:   valuesTemplateConfigMap.Data["values.yaml"],
+			ValuesTemplate:   values,
 		},
 	}
 
@@ -94,29 +99,4 @@ func (s helmAddonStrategy) apply(
 	}
 
 	return nil
-}
-
-func (s helmAddonStrategy) retrieveValuesTemplateConfigMap(
-	ctx context.Context,
-	defaultsNamespace string,
-) (*corev1.ConfigMap, error) {
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: defaultsNamespace,
-			Name:      s.config.defaultValuesTemplateConfigMapName,
-		},
-	}
-	configMapObjName := ctrlclient.ObjectKeyFromObject(
-		configMap,
-	)
-	err := s.client.Get(ctx, configMapObjName, configMap)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"failed to retrieve installation values template ConfigMap %q: %w",
-			configMapObjName,
-			err,
-		)
-	}
-
-	return configMap, nil
 }

--- a/pkg/handlers/generic/lifecycle/csi/aws-ebs/handler.go
+++ b/pkg/handlers/generic/lifecycle/csi/aws-ebs/handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,6 +61,7 @@ func (a *AWSEBS) Apply(
 	provider v1alpha1.CSIProvider,
 	defaultStorageConfig *v1alpha1.DefaultStorage,
 	req *runtimehooksv1.AfterControlPlaneInitializedRequest,
+	_ logr.Logger,
 ) error {
 	strategy := provider.Strategy
 	switch strategy {

--- a/pkg/handlers/generic/lifecycle/csi/handler.go
+++ b/pkg/handlers/generic/lifecycle/csi/handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,6 +29,7 @@ type CSIProvider interface {
 		v1alpha1.CSIProvider,
 		*v1alpha1.DefaultStorage,
 		*runtimehooksv1.AfterControlPlaneInitializedRequest,
+		logr.Logger,
 	) error
 }
 
@@ -124,6 +126,7 @@ func (c *CSIHandler) AfterControlPlaneInitialized(
 			provider,
 			csiProviders.DefaultStorage,
 			req,
+			log,
 		)
 		if err != nil {
 			log.Error(

--- a/pkg/handlers/generic/lifecycle/nfd/strategy_helmaddon.go
+++ b/pkg/handlers/generic/lifecycle/nfd/strategy_helmaddon.go
@@ -61,12 +61,6 @@ func (s helmAddonStrategy) apply(
 		)
 	}
 
-	values := valuesTemplateConfigMap.Data["values.yaml"]
-	values += fmt.Sprintf(`
-image:
-  tag: v%s-minimal
-`, s.helmChart.Version)
-
 	hcp := &caaphv1.HelmChartProxy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: caaphv1.GroupVersion.String(),

--- a/pkg/handlers/generic/lifecycle/nfd/strategy_helmaddon.go
+++ b/pkg/handlers/generic/lifecycle/nfd/strategy_helmaddon.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -19,6 +18,7 @@ import (
 	caaphv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/k8s/client"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/lifecycle/config"
+	lifecycleutils "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/lifecycle/utils"
 )
 
 const (
@@ -53,10 +53,15 @@ func (s helmAddonStrategy) apply(
 	log logr.Logger,
 ) error {
 	log.Info("Retrieving NFD installation values template for cluster")
-	valuesTemplateConfigMap, err := s.retrieveValuesTemplateConfigMap(ctx, defaultsNamespace)
+	values, err := lifecycleutils.RetrieveValuesTemplate(
+		ctx,
+		s.client,
+		s.config.defaultValuesTemplateConfigMapName,
+		defaultsNamespace,
+	)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to retrieve NFD installation values template ConfigMap for cluster: %w",
+			"failed to retrieve NFD installation values template for cluster: %w",
 			err,
 		)
 	}
@@ -95,29 +100,4 @@ func (s helmAddonStrategy) apply(
 	}
 
 	return nil
-}
-
-func (s helmAddonStrategy) retrieveValuesTemplateConfigMap(
-	ctx context.Context,
-	defaultsNamespace string,
-) (*corev1.ConfigMap, error) {
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: defaultsNamespace,
-			Name:      s.config.defaultValuesTemplateConfigMapName,
-		},
-	}
-	configMapObjName := ctrlclient.ObjectKeyFromObject(
-		configMap,
-	)
-	err := s.client.Get(ctx, configMapObjName, configMap)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"failed to retrieve installation values template ConfigMap %q: %w",
-			configMapObjName,
-			err,
-		)
-	}
-
-	return configMap, nil
 }

--- a/pkg/handlers/generic/lifecycle/nfd/strategy_helmaddon.go
+++ b/pkg/handlers/generic/lifecycle/nfd/strategy_helmaddon.go
@@ -66,6 +66,11 @@ func (s helmAddonStrategy) apply(
 		)
 	}
 
+	values += fmt.Sprintf(`
+image:
+  tag: v%s-minimal
+`, s.helmChart.Version)
+
 	hcp := &caaphv1.HelmChartProxy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: caaphv1.GroupVersion.String(),

--- a/pkg/handlers/generic/lifecycle/utils/utils.go
+++ b/pkg/handlers/generic/lifecycle/utils/utils.go
@@ -122,11 +122,11 @@ func RetrieveValuesTemplateConfigMap(
 	ctx context.Context,
 	c ctrlclient.Client,
 	configMapName,
-	defaultsNamespace string,
+	namespace string,
 ) (*corev1.ConfigMap, error) {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: defaultsNamespace,
+			Namespace: namespace,
 			Name:      configMapName,
 		},
 	}
@@ -142,6 +142,19 @@ func RetrieveValuesTemplateConfigMap(
 		)
 	}
 	return configMap, nil
+}
+
+func RetrieveValuesTemplate(
+	ctx context.Context,
+	c ctrlclient.Client,
+	configMapName,
+	namespace string,
+) (string, error) {
+	configMap, err := RetrieveValuesTemplateConfigMap(ctx, c, configMapName, namespace)
+	if err != nil {
+		return "", err
+	}
+	return configMap.Data["values.yaml"], nil
 }
 
 func CreateConfigMapForCRS(configMapName, configMapNamespace string,


### PR DESCRIPTION
I noticed there were 3 copies of `retrieveValuesTemplateConfigMap()` in addition to the one generic one in `lifecycleutils`, refactored all of these methods to reuse the existing function.

~While refactoring I saw that for NFD the handler was adding a value, moved the templating to the helm values. This copies the pattern in other addons, but also makes it easier to override at cluster creation time (kind of as a last resort if there is a bug in the handler code)~ Reverted in 5f24ee0e2acc99e383e021bc5203994fc53c2308, we don't get the standard`.Chart.Version` when CAAPH templates the values, will file a separate PR to gotemplate this in the handler.

I also added `RetrieveValuesTemplate` to get the data instead of having `valuesTemplateConfigMap.Data["values.yaml"]` in every handler.