### PR TITLE
build: set dockerhub credentials for Nutanix examples

### DIFF
--- a/examples/capi-quick-start/nutanix-cluster-calico-crs.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-calico-crs.yaml
@@ -3,6 +3,17 @@ kind: Secret
 metadata:
   labels:
     cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}-dockerhub-credentials
+stringData:
+  password: ${DOCKER_HUB_PASSWORD}
+  username: ${DOCKER_HUB_USERNAME}
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: nutanix
   name: ${CLUSTER_NAME}-pe-creds-for-csi
 stringData:
   key: ${NUTANIX_PRISM_ELEMENT_ENDPOINT}:${NUTANIX_PORT}:${NUTANIX_USER}:${NUTANIX_PASSWORD}
@@ -92,6 +103,11 @@ spec:
               systemDiskSize: 40Gi
               vcpuSockets: 2
               vcpusPerSocket: 1
+        imageRegistries:
+        - credentials:
+            secretRef:
+              name: ${CLUSTER_NAME}-dockerhub-credentials
+          url: https://docker.io
         nutanix:
           controlPlaneEndpoint:
             host: ${CONTROL_PLANE_ENDPOINT_IP}

--- a/examples/capi-quick-start/nutanix-cluster-calico-helm-addon.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-calico-helm-addon.yaml
@@ -3,6 +3,17 @@ kind: Secret
 metadata:
   labels:
     cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}-dockerhub-credentials
+stringData:
+  password: ${DOCKER_HUB_PASSWORD}
+  username: ${DOCKER_HUB_USERNAME}
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: nutanix
   name: ${CLUSTER_NAME}-pe-creds-for-csi
 stringData:
   key: ${NUTANIX_PRISM_ELEMENT_ENDPOINT}:${NUTANIX_PORT}:${NUTANIX_USER}:${NUTANIX_PASSWORD}
@@ -92,6 +103,11 @@ spec:
               systemDiskSize: 40Gi
               vcpuSockets: 2
               vcpusPerSocket: 1
+        imageRegistries:
+        - credentials:
+            secretRef:
+              name: ${CLUSTER_NAME}-dockerhub-credentials
+          url: https://docker.io
         nutanix:
           controlPlaneEndpoint:
             host: ${CONTROL_PLANE_ENDPOINT_IP}

--- a/examples/capi-quick-start/nutanix-cluster-cilium-crs.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-cilium-crs.yaml
@@ -3,6 +3,17 @@ kind: Secret
 metadata:
   labels:
     cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}-dockerhub-credentials
+stringData:
+  password: ${DOCKER_HUB_PASSWORD}
+  username: ${DOCKER_HUB_USERNAME}
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: nutanix
   name: ${CLUSTER_NAME}-pe-creds-for-csi
 stringData:
   key: ${NUTANIX_PRISM_ELEMENT_ENDPOINT}:${NUTANIX_PORT}:${NUTANIX_USER}:${NUTANIX_PASSWORD}
@@ -92,6 +103,11 @@ spec:
               systemDiskSize: 40Gi
               vcpuSockets: 2
               vcpusPerSocket: 1
+        imageRegistries:
+        - credentials:
+            secretRef:
+              name: ${CLUSTER_NAME}-dockerhub-credentials
+          url: https://docker.io
         nutanix:
           controlPlaneEndpoint:
             host: ${CONTROL_PLANE_ENDPOINT_IP}

--- a/examples/capi-quick-start/nutanix-cluster-cilium-helm-addon.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-cilium-helm-addon.yaml
@@ -3,6 +3,17 @@ kind: Secret
 metadata:
   labels:
     cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}-dockerhub-credentials
+stringData:
+  password: ${DOCKER_HUB_PASSWORD}
+  username: ${DOCKER_HUB_USERNAME}
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: nutanix
   name: ${CLUSTER_NAME}-pe-creds-for-csi
 stringData:
   key: ${NUTANIX_PRISM_ELEMENT_ENDPOINT}:${NUTANIX_PORT}:${NUTANIX_USER}:${NUTANIX_PASSWORD}
@@ -92,6 +103,11 @@ spec:
               systemDiskSize: 40Gi
               vcpuSockets: 2
               vcpusPerSocket: 1
+        imageRegistries:
+        - credentials:
+            secretRef:
+              name: ${CLUSTER_NAME}-dockerhub-credentials
+          url: https://docker.io
         nutanix:
           controlPlaneEndpoint:
             host: ${CONTROL_PLANE_ENDPOINT_IP}

--- a/hack/examples/additional-resources/dockerhub-secret.yaml
+++ b/hack/examples/additional-resources/dockerhub-secret.yaml
@@ -1,0 +1,12 @@
+# Copyright 2023 D2iQ, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${CLUSTER_NAME}-dockerhub-credentials
+stringData:
+  username: ${DOCKER_HUB_USERNAME}
+  password: ${DOCKER_HUB_PASSWORD}
+type: Opaque

--- a/hack/examples/bases/nutanix/cluster/kustomization.yaml.tmpl
+++ b/hack/examples/bases/nutanix/cluster/kustomization.yaml.tmpl
@@ -5,6 +5,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- ../../../additional-resources/dockerhub-secret.yaml
 - ../../../additional-resources/nutanix/csi-secret.yaml
 - https://raw.githubusercontent.com/nutanix-cloud-native/cluster-api-provider-nutanix/1a7cd69ba35de01e56dcf2dda7f31973111d2317/templates/cluster-template-topology.yaml
 
@@ -58,3 +59,10 @@ patches:
 - target:
     kind: Cluster
   path: ../../../patches/nutanix/remove-ccm/cluster-label.yaml
+
+# A Nutanix cluster uses SNAT for outbound traffic by default.
+# Because Dockerhub only sees a single request IP the rate limit gets hit for almost every cluster.
+# Add a patch to set imageRegistry with docker.io credentials.
+- target:
+    kind: Cluster
+  path: ../../../patches/dockerhub-image-registry.yaml

--- a/hack/examples/patches/dockerhub-image-registry.yaml
+++ b/hack/examples/patches/dockerhub-image-registry.yaml
@@ -1,0 +1,10 @@
+# Copyright 2024 D2iQ, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+- op: "add"
+  path: "/spec/topology/variables/0/value/imageRegistries"
+  value:
+    - url: https://docker.io
+      credentials:
+        secretRef:
+          name: ${CLUSTER_NAME}-dockerhub-credentials


### PR DESCRIPTION
Adding dockerhub credentials in the examples, to make it easier to bring up Nutanix clusters. Otherwise, the limit is hit for almost every cluster.