### PR TITLE
feat: set default instance profile for AWS CP and worker nodes

### DIFF
--- a/api/v1alpha1/aws_node_types.go
+++ b/api/v1alpha1/aws_node_types.go
@@ -14,6 +14,9 @@ import (
 const (
 	AWSControlPlaneInstanceType InstanceType = "m5.xlarge"
 	AWSWorkerInstanceType       InstanceType = "m5.2xlarge"
+
+	AWSControlPlaneInstanceProfile IAMInstanceProfile = "control-plane.cluster-api-provider-aws.sigs.k8s.io"
+	AWSWorkerInstanceProfile       IAMInstanceProfile = "nodes.cluster-api-provider-aws.sigs.k8s.io"
 )
 
 type AWSNodeSpec struct {
@@ -34,13 +37,15 @@ type AWSNodeSpec struct {
 
 func NewAWSControlPlaneNodeSpec() *AWSNodeSpec {
 	return &AWSNodeSpec{
-		InstanceType: ptr.To(AWSControlPlaneInstanceType),
+		InstanceType:       ptr.To(AWSControlPlaneInstanceType),
+		IAMInstanceProfile: ptr.To(AWSControlPlaneInstanceProfile),
 	}
 }
 
 func NewAWSWorkerNodeSpec() *AWSNodeSpec {
 	return &AWSNodeSpec{
-		InstanceType: ptr.To(AWSWorkerInstanceType),
+		InstanceType:       ptr.To(AWSWorkerInstanceType),
+		IAMInstanceProfile: ptr.To(AWSWorkerInstanceProfile),
 	}
 }
 
@@ -75,7 +80,7 @@ func (a AWSNodeSpec) VariableSchema() clusterv1.VariableSchema {
 			Description: "AWS Node configuration",
 			Type:        "object",
 			Properties: map[string]clusterv1.JSONSchemaProps{
-				"iamInstanceProfile":       IAMInstanceProfile("").VariableSchema().OpenAPIV3Schema,
+				"iamInstanceProfile":       a.IAMInstanceProfile.VariableSchema().OpenAPIV3Schema,
 				"instanceType":             a.InstanceType.VariableSchema().OpenAPIV3Schema,
 				"ami":                      AMISpec{}.VariableSchema().OpenAPIV3Schema,
 				"additionalSecurityGroups": AdditionalSecurityGroup{}.VariableSchema().OpenAPIV3Schema,
@@ -87,11 +92,12 @@ func (a AWSNodeSpec) VariableSchema() clusterv1.VariableSchema {
 
 type IAMInstanceProfile string
 
-func (IAMInstanceProfile) VariableSchema() clusterv1.VariableSchema {
+func (i IAMInstanceProfile) VariableSchema() clusterv1.VariableSchema {
 	return clusterv1.VariableSchema{
 		OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 			Type:        "string",
 			Description: "The IAM instance profile to use for the cluster Machines",
+			Default:     variables.MustMarshal(i),
 		},
 	}
 }

--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/aws-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/aws-cluster-class.yaml
@@ -105,7 +105,6 @@ metadata:
 spec:
   template:
     spec:
-      iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
       instanceType: PLACEHOLDER
       sshKeyName: ""
 ---
@@ -118,7 +117,6 @@ metadata:
 spec:
   template:
     spec:
-      iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
       instanceType: PLACEHOLDER
       sshKeyName: ""
 ---

--- a/hack/examples/overlays/clusterclasses/aws/kustomization.yaml.tmpl
+++ b/hack/examples/overlays/clusterclasses/aws/kustomization.yaml.tmpl
@@ -59,3 +59,8 @@ patches:
       - op: "add"
         path: "/spec/template/spec/instanceType"
         value: "PLACEHOLDER"
+  - target:
+        kind: AWSMachineTemplate
+    patch: |-
+      - op: "remove"
+        path: "/spec/template/spec/iamInstanceProfile"


### PR DESCRIPTION
Moved: https://github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pull/54

**What problem does this PR solve?:**
This is a stacked PR: https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/504

sets defaults for aws instance profiles CP: `control-plane.cluster-api-provider-aws.sigs.k8s.io` and Workers: `nodes.cluster-api-provider-aws.sigs.k8s.io`
removes instanceProfile field in AWSMachineTemplates
**Which issue(s) this PR fixes:**
Fixes #

**How Has This Been Tested?:**

Tested manually be creating AWS cluster.

Created AWS cluster without adding instanceProfile variable, CAREN patched AWSMachineTemplate with default instanceProfile.

**Special notes for your reviewer:**

Looking into ways to unit test the defaults.