### PR TITLE
build: update aws credentials on kind bootstrap cluster

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -18,6 +18,8 @@ endif
 	kubectl rollout restart deployment cluster-api-runtime-extensions-nutanix
 	kubectl rollout status deployment cluster-api-runtime-extensions-nutanix
 
+.PHONY: dev.update-webhook-image-on-kind
+dev.update-webhook-image-on-kind: export KUBECONFIG := $(KIND_KUBECONFIG)
 dev.update-webhook-image-on-kind:
 ifndef SKIP_BUILD
 	$(MAKE) release-snapshot
@@ -27,3 +29,12 @@ endif
 	kubectl set image deployment cluster-api-runtime-extensions-nutanix webhook=ko.local/cluster-api-runtime-extensions-nutanix:$$(gojq -r .version dist/metadata.json)
 	kubectl rollout restart deployment cluster-api-runtime-extensions-nutanix
 	kubectl rollout status deployment cluster-api-runtime-extensions-nutanix
+
+
+.PHONY: dev.update-bootstrap-credentials-aws
+dev.update-bootstrap-credentials-aws: export KUBECONFIG := $(KIND_KUBECONFIG)
+dev.update-bootstrap-credentials-aws: export AWS_B64ENCODED_CREDENTIALS := $(shell clusterawsadm bootstrap credentials encode-as-profile)
+dev.update-bootstrap-credentials-aws:
+	kubectl patch secret capa-manager-bootstrap-credentials -n capa-system -p='{"data":{"credentials": "$(AWS_B64ENCODED_CREDENTIALS)"}}'
+	kubectl rollout restart deployment capa-controller-manager -n capa-system
+	kubectl rollout status deployment capa-controller-manager -n capa-system

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -33,8 +33,7 @@ endif
 
 .PHONY: dev.update-bootstrap-credentials-aws
 dev.update-bootstrap-credentials-aws: export KUBECONFIG := $(KIND_KUBECONFIG)
-dev.update-bootstrap-credentials-aws: export AWS_B64ENCODED_CREDENTIALS := $(shell clusterawsadm bootstrap credentials encode-as-profile)
 dev.update-bootstrap-credentials-aws:
-	kubectl patch secret capa-manager-bootstrap-credentials -n capa-system -p='{"data":{"credentials": "$(AWS_B64ENCODED_CREDENTIALS)"}}'
+	kubectl patch secret capa-manager-bootstrap-credentials -n capa-system -p="{\"data\":{\"credentials\": \"$$(clusterawsadm bootstrap credentials encode-as-profile)\"}}"
 	kubectl rollout restart deployment capa-controller-manager -n capa-system
 	kubectl rollout status deployment capa-controller-manager -n capa-system


### PR DESCRIPTION
creates makefile target to update the expired aws credentials and restart capa-controller.
make dev.update-bootstrap-credentials-aws reads similar to our existing command dkp update bootstrap credentials aws