### PR TITLE
feat: give mutators a clusterGetter function

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -120,7 +120,7 @@ func main() {
 		awsclusterconfig.NewVariable(),
 		awsworkerconfig.NewVariable(),
 		awsmutation.MetaPatchHandler(mgr),
-		awsmutation.MetaWorkerPatchHandler(),
+		awsmutation.MetaWorkerPatchHandler(mgr),
 	}
 
 	// dockerMetaHandlers combines all Docker patch and variable handlers under a single handler.
@@ -129,7 +129,7 @@ func main() {
 		dockerclusterconfig.NewVariable(),
 		dockerworkerconfig.NewVariable(),
 		dockermutation.MetaPatchHandler(mgr),
-		dockermutation.MetaWorkerPatchHandler(),
+		dockermutation.MetaWorkerPatchHandler(mgr),
 	}
 
 	// nutanixMetaHandlers combines all Nutanix patch and variable handlers under a single handler.
@@ -138,7 +138,7 @@ func main() {
 		nutanixclusterconfig.NewVariable(),
 		nutanixworkerconfig.NewVariable(),
 		nutanixmutation.MetaPatchHandler(mgr),
-		nutanixmutation.MetaWorkerPatchHandler(),
+		nutanixmutation.MetaWorkerPatchHandler(mgr),
 	}
 
 	var allHandlers []handlers.Named

--- a/common/pkg/capi/clustertopology/handlers/mutation/meta.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta.go
@@ -5,10 +5,13 @@ package mutation
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/exp/runtime/topologymutation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +27,8 @@ type MutateFunc func(
 	clusterKey client.ObjectKey,
 ) error
 
+type ClusterGetter func(context.Context) (*clusterv1.Cluster, error)
+
 type MetaMutator interface {
 	Mutate(
 		ctx context.Context,
@@ -31,20 +36,24 @@ type MetaMutator interface {
 		vars map[string]apiextensionsv1.JSON,
 		holderRef runtimehooksv1.HolderReference,
 		clusterKey client.ObjectKey,
+		getCluster ClusterGetter,
 	) error
 }
 
 type metaGeneratePatches struct {
 	name     string
 	mutators []MetaMutator
+	cl       client.Client
 }
 
 func NewMetaGeneratePatchesHandler(
 	name string,
+	cl client.Client,
 	mutators ...MetaMutator,
 ) handlers.Named {
 	return metaGeneratePatches{
 		name:     name,
+		cl:       cl,
 		mutators: mutators,
 	}
 }
@@ -53,13 +62,32 @@ func (mgp metaGeneratePatches) Name() string {
 	return mgp.name
 }
 
+func (mgp metaGeneratePatches) CreateClusterGetter(
+	clusterKey client.ObjectKey,
+) func(context.Context) (*clusterv1.Cluster, error) {
+	return func(ctx context.Context) (*clusterv1.Cluster, error) {
+		var (
+			cluster clusterv1.Cluster
+			err     error
+			once    sync.Once
+		)
+		once.Do(func() {
+			err = mgp.cl.Get(ctx, clusterKey, &cluster)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch cluster %w", err)
+		}
+		return &cluster, nil
+	}
+}
+
 func (mgp metaGeneratePatches) GeneratePatches(
 	ctx context.Context,
 	req *runtimehooksv1.GeneratePatchesRequest,
 	resp *runtimehooksv1.GeneratePatchesResponse,
 ) {
 	clusterKey := handlers.ClusterKeyFromReq(req)
-
+	clusterGetter := mgp.CreateClusterGetter(clusterKey)
 	topologymutation.WalkTemplates(
 		ctx,
 		unstructured.UnstructuredJSONScheme,
@@ -72,7 +100,7 @@ func (mgp metaGeneratePatches) GeneratePatches(
 			holderRef runtimehooksv1.HolderReference,
 		) error {
 			for _, h := range mgp.mutators {
-				if err := h.Mutate(ctx, obj.(*unstructured.Unstructured), vars, holderRef, clusterKey); err != nil {
+				if err := h.Mutate(ctx, obj.(*unstructured.Unstructured), vars, holderRef, clusterKey, clusterGetter); err != nil {
 					return err
 				}
 			}

--- a/common/pkg/capi/clustertopology/handlers/mutation/meta_test.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta_test.go
@@ -37,6 +37,7 @@ func (h *testHandler) Mutate(
 	_ map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ ClusterGetter,
 ) error {
 	if h.returnErr {
 		return fmt.Errorf("This is a failure")
@@ -219,7 +220,7 @@ func TestMetaGeneratePatches(t *testing.T) {
 
 			g := gomega.NewWithT(t)
 
-			h := NewMetaGeneratePatchesHandler("", tt.mutaters...).(GeneratePatches)
+			h := NewMetaGeneratePatchesHandler("", nil, tt.mutaters...).(GeneratePatches)
 
 			resp := &runtimehooksv1.GeneratePatchesResponse{}
 			h.GeneratePatches(context.Background(), &runtimehooksv1.GeneratePatchesRequest{

--- a/pkg/handlers/aws/mutation/ami/inject.go
+++ b/pkg/handlers/aws/mutation/ami/inject.go
@@ -15,6 +15,7 @@ import (
 
 	capav1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
 )
@@ -48,6 +49,7 @@ func (h *awsAMISpecPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/aws/mutation/ami/inject_control_plane_test.go
+++ b/pkg/handlers/aws/mutation/ami/inject_control_plane_test.go
@@ -13,11 +13,15 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Generate AMI patches for ControlPlane", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewControlPlanePatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("",
+			helpers.TestEnv.Client,
+			NewControlPlanePatch(),
+		).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/ami/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/ami/inject_worker_test.go
@@ -14,11 +14,12 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Generate AMI patches for Worker", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewWorkerPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewWorkerPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/cni/calico/inject.go
+++ b/pkg/handlers/aws/mutation/cni/calico/inject.go
@@ -16,6 +16,7 @@ import (
 
 	capav1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -56,6 +57,7 @@ func (h *calicoPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/aws/mutation/cni/calico/inject_test.go
+++ b/pkg/handlers/aws/mutation/cni/calico/inject_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func TestCalicoPatch(t *testing.T) {
@@ -25,7 +26,7 @@ func TestCalicoPatch(t *testing.T) {
 
 var _ = Describe("Generate AWS Calico CNI ingress patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/controlplaneloadbalancer/inject.go
+++ b/pkg/handlers/aws/mutation/controlplaneloadbalancer/inject.go
@@ -14,6 +14,7 @@ import (
 
 	capav1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -54,6 +55,7 @@ func (h *awsControlPlaneLoadBalancer) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/aws/mutation/controlplaneloadbalancer/inject_test.go
+++ b/pkg/handlers/aws/mutation/controlplaneloadbalancer/inject_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func TestControlPlaneLoadBalancerPatch(t *testing.T) {
@@ -25,7 +26,7 @@ func TestControlPlaneLoadBalancerPatch(t *testing.T) {
 
 var _ = Describe("Generate AWS ControlPlane LoadBalancer patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_control_plane.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_control_plane.go
@@ -14,6 +14,7 @@ import (
 
 	capav1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -55,6 +56,7 @@ func (h *awsIAMInstanceProfileControlPlanePatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_control_plane_test.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_control_plane_test.go
@@ -13,11 +13,16 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Generate IAMInstanceProfile patches for ControlPlane", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewControlPlanePatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler(
+			"",
+			helpers.TestEnv.Client,
+			NewControlPlanePatch(),
+		).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker.go
@@ -14,6 +14,7 @@ import (
 
 	capav1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -49,6 +50,7 @@ func (h *awsIAMInstanceProfileWorkerPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker_test.go
@@ -14,11 +14,12 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Generate IAMInstanceProfile patches for Worker", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewWorkerPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewWorkerPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/instancetype/inject_control_plane.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_control_plane.go
@@ -14,6 +14,7 @@ import (
 
 	capav1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -55,6 +56,7 @@ func (h *awsInstanceTypeControlPlanePatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/aws/mutation/instancetype/inject_control_plane_test.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_control_plane_test.go
@@ -13,11 +13,16 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Generate InstanceType patches for ControlPlane", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewControlPlanePatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler(
+			"",
+			helpers.TestEnv.Client,
+			NewControlPlanePatch(),
+		).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/instancetype/inject_worker.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_worker.go
@@ -14,6 +14,7 @@ import (
 
 	capav1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -49,6 +50,7 @@ func (h *awsInstanceTypeWorkerPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/aws/mutation/instancetype/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_worker_test.go
@@ -14,11 +14,12 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Generate InstanceType patches for Worker", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewWorkerPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewWorkerPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/metapatch_handler.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler.go
@@ -37,12 +37,13 @@ func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"awsClusterConfigPatch",
+		mgr.GetClient(),
 		patchHandlers...,
 	)
 }
 
 // MetaWorkerPatchHandler returns a meta patch handler for mutating CAPA workers.
-func MetaWorkerPatchHandler() handlers.Named {
+func MetaWorkerPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers := []mutation.MetaMutator{
 		iaminstanceprofile.NewWorkerPatch(),
 		instancetype.NewWorkerPatch(),
@@ -52,6 +53,7 @@ func MetaWorkerPatchHandler() handlers.Named {
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"awsWorkerConfigPatch",
+		mgr.GetClient(),
 		patchHandlers...,
 	)
 }

--- a/pkg/handlers/aws/mutation/network/inject.go
+++ b/pkg/handlers/aws/mutation/network/inject.go
@@ -14,6 +14,7 @@ import (
 
 	capav1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -54,6 +55,7 @@ func (h *awsNetworkPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/aws/mutation/network/inject_test.go
+++ b/pkg/handlers/aws/mutation/network/inject_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func TestNetworkPatch(t *testing.T) {
@@ -24,7 +25,7 @@ func TestNetworkPatch(t *testing.T) {
 
 var _ = Describe("Generate AWS Network patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/region/inject.go
+++ b/pkg/handlers/aws/mutation/region/inject.go
@@ -14,6 +14,7 @@ import (
 
 	capav1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -54,6 +55,7 @@ func (h *awsRegionPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/aws/mutation/region/inject_test.go
+++ b/pkg/handlers/aws/mutation/region/inject_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func TestRegionPatch(t *testing.T) {
@@ -25,7 +26,7 @@ func TestRegionPatch(t *testing.T) {
 var _ = Describe("Generate AWS Region patches", func() {
 	// only add aws region patch
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/securitygroups/inject.go
+++ b/pkg/handlers/aws/mutation/securitygroups/inject.go
@@ -15,6 +15,7 @@ import (
 
 	capav1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
 )
@@ -48,6 +49,7 @@ func (h *awsSecurityGroupSpecPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/aws/mutation/securitygroups/inject_control_plane_test.go
+++ b/pkg/handlers/aws/mutation/securitygroups/inject_control_plane_test.go
@@ -14,11 +14,16 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Generate SecurityGroup patches for ControlPlane", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewControlPlanePatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler(
+			"",
+			helpers.TestEnv.Client,
+			NewControlPlanePatch(),
+		).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/aws/mutation/securitygroups/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/securitygroups/inject_worker_test.go
@@ -15,11 +15,12 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Generate AWS SecurityGroups patches for Worker", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewWorkerPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewWorkerPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/docker/mutation/customimage/inject_control_plane.go
+++ b/pkg/handlers/docker/mutation/customimage/inject_control_plane.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -60,6 +61,7 @@ func (h *customImageControlPlanePatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/docker/mutation/customimage/inject_control_plane_test.go
+++ b/pkg/handlers/docker/mutation/customimage/inject_control_plane_test.go
@@ -14,11 +14,15 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	dockerclusterconfig "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/docker/clusterconfig"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Docker CustomImage patches for ControlPlane", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewControlPlanePatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("",
+			helpers.TestEnv.Client,
+			NewControlPlanePatch(),
+		).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/docker/mutation/customimage/inject_worker.go
+++ b/pkg/handlers/docker/mutation/customimage/inject_worker.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -52,6 +53,7 @@ func (h *customImageWorkerPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/docker/mutation/customimage/inject_worker_test.go
+++ b/pkg/handlers/docker/mutation/customimage/inject_worker_test.go
@@ -14,11 +14,12 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	dockerworkerconfig "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/docker/workerconfig"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Docker CustomImage patches for workers", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewWorkerPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewWorkerPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/docker/mutation/metapatch_handler.go
+++ b/pkg/handlers/docker/mutation/metapatch_handler.go
@@ -23,18 +23,20 @@ func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"dockerClusterConfigPatch",
+		mgr.GetClient(),
 		patchHandlers...,
 	)
 }
 
 // MetaWorkerPatchHandler returns a meta patch handler for mutating CAPD workers.
-func MetaWorkerPatchHandler() handlers.Named {
+func MetaWorkerPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers := []mutation.MetaMutator{
 		customimage.NewWorkerPatch(),
 	}
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"dockerWorkerConfigPatch",
+		mgr.GetClient(),
 		patchHandlers...,
 	)
 }

--- a/pkg/handlers/generic/mutation/auditpolicy/inject.go
+++ b/pkg/handlers/generic/mutation/auditpolicy/inject.go
@@ -15,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 )
@@ -36,6 +37,7 @@ func (h *auditPolicyPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/generic/mutation/auditpolicy/inject_test.go
+++ b/pkg/handlers/generic/mutation/auditpolicy/inject_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func TestAuditPolicyPatch(t *testing.T) {
@@ -21,7 +22,7 @@ func TestAuditPolicyPatch(t *testing.T) {
 
 var _ = Describe("Generate Audit Policy patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/generic/mutation/containerdmetrics/inject.go
+++ b/pkg/handlers/generic/mutation/containerdmetrics/inject.go
@@ -13,6 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 )
@@ -29,6 +30,7 @@ func (h *containerdMetricsPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ ctrlclient.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/generic/mutation/containerdmetrics/inject_test.go
+++ b/pkg/handlers/generic/mutation/containerdmetrics/inject_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func TestContainerdMetricsPatch(t *testing.T) {
@@ -23,7 +24,7 @@ func TestContainerdMetricsPatch(t *testing.T) {
 var _ = Describe("Generate containerd metrics patches", func() {
 	// only add aws region patch
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/generic/mutation/containerdrestart/inject.go
+++ b/pkg/handlers/generic/mutation/containerdrestart/inject.go
@@ -13,6 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 )
@@ -29,6 +30,7 @@ func (h *containerdRestartPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	clusterKey ctrlclient.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/generic/mutation/containerdrestart/inject_test.go
+++ b/pkg/handlers/generic/mutation/containerdrestart/inject_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func TestContainerdRestartPatch(t *testing.T) {
@@ -23,7 +24,7 @@ func TestContainerdRestartPatch(t *testing.T) {
 var _ = Describe("Generate Containerd restart patches", func() {
 	// only add aws region patch
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/generic/mutation/etcd/inject.go
+++ b/pkg/handlers/generic/mutation/etcd/inject.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -51,6 +52,7 @@ func (h *etcdPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/generic/mutation/etcd/inject_test.go
+++ b/pkg/handlers/generic/mutation/etcd/inject_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func TestEtcdPolicyPatch(t *testing.T) {
@@ -24,7 +25,7 @@ func TestEtcdPolicyPatch(t *testing.T) {
 
 var _ = Describe("Generate etcd patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
@@ -13,7 +13,6 @@ import (
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
@@ -52,7 +51,7 @@ func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
-	clusterKey ctrlclient.ObjectKey,
+	clusterKey client.ObjectKey,
 	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
@@ -13,8 +13,10 @@ import (
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -50,12 +52,12 @@ func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
-	_ client.ObjectKey,
+	clusterKey ctrlclient.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,
 	)
-
 	extraAPIServerCertSANsVar, found, err := variables.Get[v1alpha1.ExtraAPIServerCertSANs](
 		vars,
 		h.variableName,
@@ -66,6 +68,10 @@ func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 	}
 	if !found {
 		log.V(5).Info("Extra API server cert SANs variable not defined")
+	}
+	apiCertSANs := extraAPIServerCertSANsVar
+	if len(apiCertSANs) == 0 {
+		log.Info("No APIServerSANs to apply")
 		return nil
 	}
 

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/inject.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/inject.go
@@ -19,6 +19,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -68,6 +69,7 @@ func (h *imageRegistriesPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	clusterKey ctrlclient.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Generate Image registry patches", func() {
 		// Using direct client will enable reading it immediately.
 		client, err := testEnv.GetK8sClient()
 		gomega.Expect(err).To(gomega.BeNil())
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch(client)).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", client, NewPatch(client)).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/generic/mutation/kubernetesimagerepository/inject.go
+++ b/pkg/handlers/generic/mutation/kubernetesimagerepository/inject.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -51,6 +52,7 @@ func (h *imageRepositoryPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/generic/mutation/kubernetesimagerepository/inject_test.go
+++ b/pkg/handlers/generic/mutation/kubernetesimagerepository/inject_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func TestKubernetesImageRepositoryPatch(t *testing.T) {
@@ -24,7 +25,7 @@ func TestKubernetesImageRepositoryPatch(t *testing.T) {
 
 var _ = Describe("Generate Kubernetes Image Repository patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/generic/mutation/mirrors/inject.go
+++ b/pkg/handlers/generic/mutation/mirrors/inject.go
@@ -16,6 +16,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -60,6 +61,7 @@ func (h *globalMirrorPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	clusterKey ctrlclient.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/generic/mutation/mirrors/inject_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/inject_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Generate Global mirror patches", func() {
 		// Using direct client will enable reading it immediately.
 		client, err := testEnv.GetK8sClient()
 		gomega.Expect(err).To(gomega.BeNil())
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch(client)).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", client, NewPatch(client)).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/generic/mutation/users/inject.go
+++ b/pkg/handlers/generic/mutation/users/inject.go
@@ -16,6 +16,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -54,6 +55,7 @@ func (h *usersPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ ctrlclient.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx, "holderRef", holderRef)
 

--- a/pkg/handlers/generic/mutation/users/inject_test.go
+++ b/pkg/handlers/generic/mutation/users/inject_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func Test_generateBootstrapUser(t *testing.T) {
@@ -145,7 +146,7 @@ func TestUsersPatch(t *testing.T) {
 
 var _ = Describe("Generate Users patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/nutanix/mutation/controlplaneendpoint/inject.go
+++ b/pkg/handlers/nutanix/mutation/controlplaneendpoint/inject.go
@@ -17,6 +17,7 @@ import (
 
 	capxv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -57,6 +58,7 @@ func (h *nutanixControlPlaneEndpoint) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/nutanix/mutation/controlplaneendpoint/inject_test.go
+++ b/pkg/handlers/nutanix/mutation/controlplaneendpoint/inject_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
 	nutanixclusterconfig "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/nutanix/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 func TestControlPlaneEndpointPatch(t *testing.T) {
@@ -25,7 +26,7 @@ func TestControlPlaneEndpointPatch(t *testing.T) {
 
 var _ = Describe("Generate Nutanix ControlPlane endpoint patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/nutanix/mutation/machinedetails/inject.go
+++ b/pkg/handlers/nutanix/mutation/machinedetails/inject.go
@@ -15,6 +15,7 @@ import (
 
 	capxv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
 )
@@ -48,6 +49,7 @@ func (h *nutanixMachineDetailsPatchHandler) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	_ client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/nutanix/mutation/machinedetails/inject_control_plane_test.go
+++ b/pkg/handlers/nutanix/mutation/machinedetails/inject_control_plane_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
 	nutanixclusterconfig "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/nutanix/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var (
@@ -98,7 +99,11 @@ var (
 
 var _ = Describe("Generate Nutanix Machine Details patches for ControlPlane", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewControlPlanePatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler(
+			"",
+			helpers.TestEnv.Client,
+			NewControlPlanePatch(),
+		).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/nutanix/mutation/machinedetails/inject_worker_test.go
+++ b/pkg/handlers/nutanix/mutation/machinedetails/inject_worker_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
 	nutanixclusterconfig "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/nutanix/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 var _ = Describe("Generate Nutanix Machine Details patches for Worker", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewWorkerPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewWorkerPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/pkg/handlers/nutanix/mutation/metapatch_handler.go
+++ b/pkg/handlers/nutanix/mutation/metapatch_handler.go
@@ -27,18 +27,20 @@ func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"nutanixClusterConfigPatch",
+		mgr.GetClient(),
 		patchHandlers...,
 	)
 }
 
 // MetaWorkerPatchHandler returns a meta patch handler for mutating CAPA workers.
-func MetaWorkerPatchHandler() handlers.Named {
+func MetaWorkerPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers := []mutation.MetaMutator{
 		machinedetails.NewWorkerPatch(),
 	}
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"nutanixWorkerConfigPatch",
+		mgr.GetClient(),
 		patchHandlers...,
 	)
 }

--- a/pkg/handlers/nutanix/mutation/prismcentralendpoint/inject.go
+++ b/pkg/handlers/nutanix/mutation/prismcentralendpoint/inject.go
@@ -19,6 +19,7 @@ import (
 
 	capxv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/patches/selectors"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
@@ -59,6 +60,7 @@ func (h *nutanixPrismCentralEndpoint) Mutate(
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
 	clusterKey client.ObjectKey,
+	_ mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"holderRef", holderRef,

--- a/pkg/handlers/nutanix/mutation/prismcentralendpoint/inject_test.go
+++ b/pkg/handlers/nutanix/mutation/prismcentralendpoint/inject_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
 	nutanixclusterconfig "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/nutanix/clusterconfig"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
 
 //
@@ -31,7 +32,7 @@ func TestPrismCentralEndpointPatch(t *testing.T) {
 
 var _ = Describe("Generate Nutanix Prism Central Endpoint patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
-		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
 	}
 
 	testDefs := []capitest.PatchTestDef{

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -131,10 +132,17 @@ func (t *TestEnvironmentConfiguration) Build() (*TestEnvironment, error) {
 }
 
 // GetK8sClient returns a “live” k8s client that does will not invoke against controller cache.
-// If a test is writeing an object, they are not immediately available to read since controller caches
+// If a test is writing an object, they are not immediately available to read since controller caches
 // are not synchronized yet.
 func (t *TestEnvironment) GetK8sClient() (client.Client, error) {
 	return client.New(t.Manager.GetConfig(), client.Options{Scheme: scheme.Scheme})
+}
+
+// GetK8sClientWithScheme - same as GetK8sClient but can pass in a configurable scheme.
+func (t *TestEnvironment) GetK8sClientWithScheme(
+	clientScheme *runtime.Scheme,
+) (client.Client, error) {
+	return client.New(t.Manager.GetConfig(), client.Options{Scheme: clientScheme})
 }
 
 // StartManager starts the test controller against the local API server.


### PR DESCRIPTION
<!--
 Copyright 2023 D2iQ, Inc. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
**What problem does this PR solve?**:
Adds a reusable function across mutators to return a cluster. This is lazily evaluated and happens once per mutation

**Which issue(s) this PR fixes**:


**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
tested manually be creating a docker cluster 

```
apiVersion: v1
items:
- apiVersion: controlplane.cluster.x-k8s.io/v1beta1
  kind: KubeadmControlPlane
  metadata:
    annotations:
      cluster.x-k8s.io/cloned-from-groupkind: KubeadmControlPlaneTemplate.controlplane.cluster.x-k8s.io
      cluster.x-k8s.io/cloned-from-name: docker-quick-start-control-plane
    creationTimestamp: "2024-04-15T21:20:06Z"
    finalizers:
    - kubeadm.controlplane.cluster.x-k8s.io
    generation: 1
    labels:
      cluster.x-k8s.io/cluster-name: docker-cluster-cilium-helm-addon
      topology.cluster.x-k8s.io/owned: ""
    name: docker-cluster-cilium-helm-addon-kr6lc
    namespace: default
    ownerReferences:
    - apiVersion: cluster.x-k8s.io/v1beta1
      blockOwnerDeletion: true
      controller: true
      kind: Cluster
      name: docker-cluster-cilium-helm-addon
      uid: d7d3b9b5-3a4c-4a2f-b5b1-1b46b3c6f9e9
    resourceVersion: "2512"
    uid: 11809f5a-5202-4fac-bd7b-7c96b17d437c
  spec:
    kubeadmConfigSpec:
      clusterConfiguration:
        apiServer:
          certSANs:
          - localhost
          - 127.0.0.1
          - 0.0.0.0
          - host.docker.internal
```

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
