### PR TITLE
build: Add metadata for latest v0.7.0 release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,3 +19,6 @@ releaseSeries:
 - major: 0
   minor: 6
   contract: v1beta1
+- major: 0
+  minor: 7
+  contract: v1beta1

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -109,8 +109,8 @@ providers:
 - name: caren
   type: RuntimeExtensionProvider
   versions:
-  - name: "{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.5}"
-    value: "https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/releases/download/{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.5}/runtime-extension-components.yaml"
+  - name: "{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.7}"
+    value: "https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/releases/download/{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.7}/runtime-extension-components.yaml"
     type: "url"
     contract: v1beta1
     files:
@@ -120,7 +120,7 @@ providers:
       new: "--v=8"
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
-  - name: v0.6.99 # "vNext"; use manifests from local source files
+  - name: v0.8.99 # "vNext"; use manifests from local source files
     value: "file://../../../runtime-extension-components.yaml"
     type: "url"
     contract: v1beta1

--- a/test/e2e/data/shared/v1beta1-caren/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1-caren/metadata.yaml
@@ -7,3 +7,9 @@ releaseSeries:
 - major: 0
   minor: 6
   contract: v1beta1
+- major: 0
+  minor: 7
+  contract: v1beta1
+- major: 0
+  minor: 8
+  contract: v1beta1


### PR DESCRIPTION
Also update e2e config to use v0.7.x for local CAREN builds.
