### PR TITLE
build: Specify go1.22.2 as toolchain to fix govulncheck issues

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,6 +5,8 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/ap
 
 go 1.21
 
+toolchain go1.22.2
+
 require (
 	github.com/nutanix-cloud-native/prism-go-client v0.3.4
 	github.com/onsi/gomega v1.32.0

--- a/common/go.mod
+++ b/common/go.mod
@@ -5,6 +5,8 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/co
 
 go 1.21
 
+toolchain go1.22.2
+
 replace github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api => ../api
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix
 
 go 1.21
 
+toolchain go1.22.2
+
 replace (
 	github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api => ./api
 	github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common => ./common


### PR DESCRIPTION
Nix (and therefore devbox) has been slow in rolling out go1.22.2, which
contains CVE fixes. Current version go1.22.1 causes govulncheck to
report valid vulnerabilities in `net/http` package. go1.21 introduced
toolchain management via `go.mod` file with `toolchain` directive. This
commit specifies go1.22.2 as the toolchain to use and hence fixes the
govulncheck issues.

This does mean that go versions have to be managed in multiple places so
this is a stop-gap until Nix releases go1.22.2 to nixpkgs-unstable
channel.
