### PR TITLE
refactor: Consistently import CAPI v1beta1 package as clusterv1 alias

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - importas
     - lll
     - misspell
     - nolintlint
@@ -85,6 +86,11 @@ linters-settings:
     dot-import-whitelist:
       - github.com/onsi/ginkgo/v2
       - github.com/onsi/gomega
+  importas:
+    no-unaliased: false
+    alias:
+      - pkg: "sigs.k8s.io/cluster-api/api/v1beta1"
+        alias: clusterv1
 
 issues:
   exclude-rules:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,7 +17,7 @@ import (
 	logsv1 "k8s.io/component-base/logs/api/v1"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/klog/v2"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	crsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -47,7 +47,7 @@ func main() {
 	clientScheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(clientScheme))
 	utilruntime.Must(crsv1.AddToScheme(clientScheme))
-	utilruntime.Must(capiv1.AddToScheme(clientScheme))
+	utilruntime.Must(clusterv1.AddToScheme(clientScheme))
 	utilruntime.Must(caaphv1.AddToScheme(clientScheme))
 
 	mgrOptions := &ctrl.Options{

--- a/common/pkg/capi/apis/schemes.go
+++ b/common/pkg/capi/apis/schemes.go
@@ -6,7 +6,7 @@ package apis
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	capdv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
@@ -25,7 +25,7 @@ func CAPIRegisterFuncs() []func(*runtime.Scheme) error {
 	return []func(*runtime.Scheme) error{
 		bootstrapv1.AddToScheme,
 		controlplanev1.AddToScheme,
-		capiv1.AddToScheme,
+		clusterv1.AddToScheme,
 	}
 }
 

--- a/common/pkg/capi/clustertopology/handlers/helpers.go
+++ b/common/pkg/capi/clustertopology/handlers/helpers.go
@@ -4,7 +4,7 @@
 package handlers
 
 import (
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -13,7 +13,7 @@ func ClusterKeyFromReq(req *runtimehooksv1.GeneratePatchesRequest) client.Object
 	for i := range req.Items {
 		item := req.Items[i]
 		if item.HolderReference.Kind == "Cluster" &&
-			item.HolderReference.APIVersion == capiv1.GroupVersion.String() {
+			item.HolderReference.APIVersion == clusterv1.GroupVersion.String() {
 			return client.ObjectKey{
 				Namespace: item.HolderReference.Namespace,
 				Name:      item.HolderReference.Name,

--- a/common/pkg/testutils/capitest/patches.go
+++ b/common/pkg/testutils/capitest/patches.go
@@ -14,7 +14,7 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	"gomodules.xyz/jsonpatch/v2"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
@@ -53,7 +53,7 @@ func ValidateGeneratePatches[T mutation.GeneratePatches](
 				tt.RequestItem,
 				{
 					HolderReference: runtimehooksv1.HolderReference{
-						APIVersion: capiv1.GroupVersion.String(),
+						APIVersion: clusterv1.GroupVersion.String(),
 						Kind:       "Cluster",
 						Namespace:  request.Namespace,
 						Name:       request.ClusterName,
@@ -109,7 +109,7 @@ func AssertGeneratePatches[T mutation.GeneratePatches](
 			tt.RequestItem,
 			{
 				HolderReference: runtimehooksv1.HolderReference{
-					APIVersion: capiv1.GroupVersion.String(),
+					APIVersion: clusterv1.GroupVersion.String(),
 					Kind:       "Cluster",
 					Namespace:  request.Namespace,
 					Name:       request.ClusterName,

--- a/pkg/handlers/generic/lifecycle/clusterautoscaler/strategy_helmaddon.go
+++ b/pkg/handlers/generic/lifecycle/clusterautoscaler/strategy_helmaddon.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -90,7 +90,7 @@ func (s helmAddonStrategy) apply(
 			RepoURL:   s.helmChart.Repository,
 			ChartName: s.helmChart.Name,
 			ClusterSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{capiv1.ClusterNameLabel: targetCluster.Name},
+				MatchLabels: map[string]string{clusterv1.ClusterNameLabel: targetCluster.Name},
 			},
 			ReleaseNamespace: req.Cluster.Namespace,
 			ReleaseName:      fmt.Sprintf(defaultHelmReleaseNameTemplate, req.Cluster.Name),

--- a/pkg/handlers/generic/lifecycle/cni/calico/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/cni/calico/strategy_crs.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -110,7 +110,7 @@ func (s crsStrategy) apply(
 
 func (s crsStrategy) ensureCNICRSForCluster(
 	ctx context.Context,
-	cluster *capiv1.Cluster,
+	cluster *clusterv1.Cluster,
 	defaultsNamespace string,
 	defaultInstallationConfigMapName string,
 	tigeraConfigMap *corev1.ConfigMap,
@@ -163,7 +163,7 @@ func (s crsStrategy) ensureCNICRSForCluster(
 
 func (s crsStrategy) ensureTigeraOperatorConfigMap(
 	ctx context.Context,
-	cluster *capiv1.Cluster,
+	cluster *clusterv1.Cluster,
 	defaultsNamespace string,
 ) (*corev1.ConfigMap, error) {
 	defaultTigeraOperatorConfigMap := &corev1.ConfigMap{
@@ -196,7 +196,7 @@ func (s crsStrategy) ensureTigeraOperatorConfigMap(
 }
 
 func generateTigeraOperatorConfigMap(
-	defaultTigeraOperatorConfigMap *corev1.ConfigMap, cluster *capiv1.Cluster,
+	defaultTigeraOperatorConfigMap *corev1.ConfigMap, cluster *clusterv1.Cluster,
 ) *corev1.ConfigMap {
 	namespacedTigeraConfigMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -216,7 +216,7 @@ func generateTigeraOperatorConfigMap(
 
 func generateProviderCNIManifestsConfigMap(
 	installationConfigMap *corev1.ConfigMap,
-	cluster *capiv1.Cluster,
+	cluster *clusterv1.Cluster,
 ) (*corev1.ConfigMap, error) {
 	defaultManifestStrings := make([]string, 0, len(installationConfigMap.Data))
 	for _, v := range installationConfigMap.Data {

--- a/pkg/handlers/generic/lifecycle/cni/calico/strategy_helmaddon.go
+++ b/pkg/handlers/generic/lifecycle/cni/calico/strategy_helmaddon.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -93,7 +93,7 @@ func (s helmAddonStrategy) apply(
 			RepoURL:   s.helmChart.Repository,
 			ChartName: s.helmChart.Name,
 			ClusterSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{capiv1.ClusterNameLabel: req.Cluster.Name},
+				MatchLabels: map[string]string{clusterv1.ClusterNameLabel: req.Cluster.Name},
 			},
 			ReleaseNamespace: defaultTigerOperatorNamespace,
 			ReleaseName:      defaultTigeraOperatorReleaseName,

--- a/pkg/handlers/generic/lifecycle/cni/cilium/strategy_helmaddon.go
+++ b/pkg/handlers/generic/lifecycle/cni/cilium/strategy_helmaddon.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -73,7 +73,7 @@ func (s helmAddonStrategy) apply(
 			RepoURL:   s.helmChart.Repository,
 			ChartName: s.helmChart.Name,
 			ClusterSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{capiv1.ClusterNameLabel: req.Cluster.Name},
+				MatchLabels: map[string]string{clusterv1.ClusterNameLabel: req.Cluster.Name},
 			},
 			ReleaseNamespace: defaultCiliumNamespace,
 			ReleaseName:      defaultCiliumReleaseName,

--- a/pkg/handlers/generic/lifecycle/cni/cluster.go
+++ b/pkg/handlers/generic/lifecycle/cni/cluster.go
@@ -6,7 +6,7 @@ package cni
 import (
 	"errors"
 
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 var ErrMultiplePodsCIDRBlocks = errors.New("cluster has more than 1 Pods network CIDR blocks")
@@ -14,7 +14,7 @@ var ErrMultiplePodsCIDRBlocks = errors.New("cluster has more than 1 Pods network
 // PodCIDR will return the Pods network CIDR.
 // If not set returns an empty string.
 // If more than 1 CIDRBlocks is defined will return an error.
-func PodCIDR(cluster *capiv1.Cluster) (string, error) {
+func PodCIDR(cluster *clusterv1.Cluster) (string, error) {
 	var subnets []string
 	if cluster.Spec.ClusterNetwork != nil &&
 		cluster.Spec.ClusterNetwork.Pods != nil {

--- a/pkg/handlers/generic/lifecycle/nfd/strategy_helmaddon.go
+++ b/pkg/handlers/generic/lifecycle/nfd/strategy_helmaddon.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -80,7 +80,7 @@ image:
 			RepoURL:   s.helmChart.Repository,
 			ChartName: s.helmChart.Name,
 			ClusterSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{capiv1.ClusterNameLabel: req.Cluster.Name},
+				MatchLabels: map[string]string{clusterv1.ClusterNameLabel: req.Cluster.Name},
 			},
 			ReleaseNamespace: defaultHelmReleaseNamespace,
 			ReleaseName:      defaultHelmReleaseName,

--- a/pkg/handlers/generic/mutation/httpproxy/inject.go
+++ b/pkg/handlers/generic/mutation/httpproxy/inject.go
@@ -10,7 +10,7 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -133,7 +133,7 @@ func (h *httpProxyPatchHandler) detectNoProxy(
 	ctx context.Context,
 	clusterKey ctrlclient.ObjectKey,
 ) ([]string, error) {
-	cluster := &capiv1.Cluster{}
+	cluster := &clusterv1.Cluster{}
 	if err := h.client.Get(ctx, clusterKey, cluster); err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (h *httpProxyPatchHandler) detectNoProxy(
 // generateNoProxy creates default NO_PROXY values that should be applied on cluster
 // in any environment and are preventing the use of proxy for cluster internal
 // networking.
-func generateNoProxy(cluster *capiv1.Cluster) []string {
+func generateNoProxy(cluster *clusterv1.Cluster) []string {
 	noProxy := []string{
 		"localhost",
 		"127.0.0.1",

--- a/pkg/handlers/generic/mutation/httpproxy/inject_test.go
+++ b/pkg/handlers/generic/mutation/httpproxy/inject_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/storage/names"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
@@ -26,21 +26,21 @@ func TestGenerateNoProxy(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		cluster         *capiv1.Cluster
+		cluster         *clusterv1.Cluster
 		expectedNoProxy []string
 	}{{
 		name:    "no networking config",
-		cluster: &capiv1.Cluster{},
+		cluster: &clusterv1.Cluster{},
 		expectedNoProxy: []string{
 			"localhost", "127.0.0.1", "kubernetes", "kubernetes.default",
 			".svc", ".svc.cluster.local",
 		},
 	}, {
 		name: "custom pod network",
-		cluster: &capiv1.Cluster{
-			Spec: capiv1.ClusterSpec{
-				ClusterNetwork: &capiv1.ClusterNetwork{
-					Pods: &capiv1.NetworkRanges{
+		cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
+				ClusterNetwork: &clusterv1.ClusterNetwork{
+					Pods: &clusterv1.NetworkRanges{
 						CIDRBlocks: []string{"10.0.0.0/24", "10.0.1.0/24"},
 					},
 				},
@@ -52,8 +52,8 @@ func TestGenerateNoProxy(t *testing.T) {
 		},
 	}, {
 		name: "Unknown infrastructure cluster",
-		cluster: &capiv1.Cluster{
-			Spec: capiv1.ClusterSpec{
+		cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
 				InfrastructureRef: &v1.ObjectReference{
 					Kind: "SomeFakeInfrastructureCluster",
 				},
@@ -65,8 +65,8 @@ func TestGenerateNoProxy(t *testing.T) {
 		},
 	}, {
 		name: "AWS cluster",
-		cluster: &capiv1.Cluster{
-			Spec: capiv1.ClusterSpec{
+		cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
 				InfrastructureRef: &v1.ObjectReference{
 					Kind: "AWSCluster",
 				},
@@ -78,8 +78,8 @@ func TestGenerateNoProxy(t *testing.T) {
 		},
 	}, {
 		name: "AWS managed (EKS) cluster",
-		cluster: &capiv1.Cluster{
-			Spec: capiv1.ClusterSpec{
+		cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
 				InfrastructureRef: &v1.ObjectReference{
 					Kind: "AWSManagedCluster",
 				},
@@ -91,8 +91,8 @@ func TestGenerateNoProxy(t *testing.T) {
 		},
 	}, {
 		name: "Azure cluster",
-		cluster: &capiv1.Cluster{
-			Spec: capiv1.ClusterSpec{
+		cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
 				InfrastructureRef: &v1.ObjectReference{
 					Kind: "AzureCluster",
 				},
@@ -104,8 +104,8 @@ func TestGenerateNoProxy(t *testing.T) {
 		},
 	}, {
 		name: "Azure managed (AKS) cluster",
-		cluster: &capiv1.Cluster{
-			Spec: capiv1.ClusterSpec{
+		cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
 				InfrastructureRef: &v1.ObjectReference{
 					Kind: "AzureCluster",
 				},
@@ -117,8 +117,8 @@ func TestGenerateNoProxy(t *testing.T) {
 		},
 	}, {
 		name: "GCP cluster",
-		cluster: &capiv1.Cluster{
-			Spec: capiv1.ClusterSpec{
+		cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
 				InfrastructureRef: &v1.ObjectReference{
 					Kind: "GCPCluster",
 				},
@@ -130,10 +130,10 @@ func TestGenerateNoProxy(t *testing.T) {
 		},
 	}, {
 		name: "custom service network",
-		cluster: &capiv1.Cluster{
-			Spec: capiv1.ClusterSpec{
-				ClusterNetwork: &capiv1.ClusterNetwork{
-					Services: &capiv1.NetworkRanges{
+		cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
+				ClusterNetwork: &clusterv1.ClusterNetwork{
+					Services: &clusterv1.NetworkRanges{
 						CIDRBlocks: []string{"172.16.0.0/24", "172.16.1.0/24"},
 					},
 				},
@@ -145,9 +145,9 @@ func TestGenerateNoProxy(t *testing.T) {
 		},
 	}, {
 		name: "custom servicedomain",
-		cluster: &capiv1.Cluster{
-			Spec: capiv1.ClusterSpec{
-				ClusterNetwork: &capiv1.ClusterNetwork{
+		cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
+				ClusterNetwork: &clusterv1.ClusterNetwork{
 					ServiceDomain: "foo.bar",
 				},
 			},
@@ -158,13 +158,13 @@ func TestGenerateNoProxy(t *testing.T) {
 		},
 	}, {
 		name: "all options",
-		cluster: &capiv1.Cluster{
-			Spec: capiv1.ClusterSpec{
-				ClusterNetwork: &capiv1.ClusterNetwork{
-					Pods: &capiv1.NetworkRanges{
+		cluster: &clusterv1.Cluster{
+			Spec: clusterv1.ClusterSpec{
+				ClusterNetwork: &clusterv1.ClusterNetwork{
+					Pods: &clusterv1.NetworkRanges{
 						CIDRBlocks: []string{"10.10.0.0/16"},
 					},
-					Services: &capiv1.NetworkRanges{
+					Services: &clusterv1.NetworkRanges{
 						CIDRBlocks: []string{"172.16.0.0/16"},
 					},
 					ServiceDomain: "foo.bar",

--- a/pkg/handlers/nutanix/mutation/controlplaneendpoint/inject.go
+++ b/pkg/handlers/nutanix/mutation/controlplaneendpoint/inject.go
@@ -9,7 +9,7 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -123,7 +123,7 @@ func (h *nutanixControlPlaneEndpoint) Mutate(
 				"patchedObjectName", client.ObjectKeyFromObject(obj),
 			).Info("setting controlPlaneEndpoint in NutanixCluster spec")
 
-			obj.Spec.Template.Spec.ControlPlaneEndpoint = capiv1.APIEndpoint{
+			obj.Spec.Template.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
 				Host: controlPlaneEndpointVar.Host,
 				Port: controlPlaneEndpointVar.Port,
 			}

--- a/test/e2e/addon_helpers.go
+++ b/test/e2e/addon_helpers.go
@@ -8,7 +8,7 @@ package e2e
 import (
 	"context"
 
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
@@ -16,7 +16,7 @@ import (
 
 type WaitForAddonsToBeReadyInWorkloadClusterInput struct {
 	AddonsConfig                v1alpha1.Addons
-	WorkloadCluster             *capiv1.Cluster
+	WorkloadCluster             *clusterv1.Cluster
 	ClusterProxy                framework.ClusterProxy
 	DeploymentIntervals         []interface{}
 	DaemonSetIntervals          []interface{}

--- a/test/e2e/clusterresourceset_helpers.go
+++ b/test/e2e/clusterresourceset_helpers.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,7 +22,7 @@ import (
 type waitForClusterResourceSetToApplyResourcesInClusterInput struct {
 	name         string
 	clusterProxy framework.ClusterProxy
-	cluster      *capiv1.Cluster
+	cluster      *clusterv1.Cluster
 	intervals    []interface{}
 }
 

--- a/test/e2e/cni_helpers.go
+++ b/test/e2e/cni_helpers.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
@@ -20,7 +20,7 @@ import (
 
 type WaitForCNIToBeReadyInWorkloadClusterInput struct {
 	CNI                         *v1alpha1.CNI
-	WorkloadCluster             *capiv1.Cluster
+	WorkloadCluster             *clusterv1.Cluster
 	ClusterProxy                framework.ClusterProxy
 	DeploymentIntervals         []interface{}
 	DaemonSetIntervals          []interface{}
@@ -75,7 +75,7 @@ func WaitForCNIToBeReadyInWorkloadCluster(
 
 type waitForCalicoToBeReadyInWorkloadClusterInput struct {
 	strategy                    v1alpha1.AddonStrategy
-	workloadCluster             *capiv1.Cluster
+	workloadCluster             *clusterv1.Cluster
 	clusterProxy                framework.ClusterProxy
 	deploymentIntervals         []interface{}
 	daemonSetIntervals          []interface{}
@@ -179,7 +179,7 @@ func waitForCalicoToBeReadyInWorkloadCluster(
 
 type waitForCiliumToBeReadyInWorkloadClusterInput struct {
 	strategy                    v1alpha1.AddonStrategy
-	workloadCluster             *capiv1.Cluster
+	workloadCluster             *clusterv1.Cluster
 	clusterProxy                framework.ClusterProxy
 	deploymentIntervals         []interface{}
 	daemonSetIntervals          []interface{}

--- a/test/e2e/nfd_helpers.go
+++ b/test/e2e/nfd_helpers.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
@@ -20,7 +20,7 @@ import (
 
 type WaitForNFDToBeReadyInWorkloadClusterInput struct {
 	NFD                         *v1alpha1.NFD
-	WorkloadCluster             *capiv1.Cluster
+	WorkloadCluster             *clusterv1.Cluster
 	ClusterProxy                framework.ClusterProxy
 	DeploymentIntervals         []interface{}
 	DaemonSetIntervals          []interface{}


### PR DESCRIPTION
Pulling this change out from #514.
