### PR TITLE
feat: get default sans via cluster object in patch handler for docker

### DIFF
--- a/api/v1alpha1/clusterconfig_types.go
+++ b/api/v1alpha1/clusterconfig_types.go
@@ -4,6 +4,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"maps"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,13 @@ const (
 	CCMProviderAWS     = "aws"
 	CCMProviderNutanix = "nutanix"
 )
+
+var DefaultDockerCertSANs = []string{
+	"localhost",
+	"127.0.0.1",
+	"0.0.0.0",
+	"host.docker.internal",
+}
 
 // +kubebuilder:object:root=true
 
@@ -262,7 +270,10 @@ type ExtraAPIServerCertSANs []string
 func (ExtraAPIServerCertSANs) VariableSchema() clusterv1.VariableSchema {
 	return clusterv1.VariableSchema{
 		OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-			Description: "Extra Subject Alternative Names for the API Server signing cert",
+			Description: fmt.Sprintf(
+				"Extra Subject Alternative Names for the API Server signing cert. For Docker %v are injected automatically.",
+				DefaultDockerCertSANs,
+			),
 			Type:        "array",
 			UniqueItems: true,
 			Items: &clusterv1.JSONSchemaProps{

--- a/api/v1alpha1/clusterconfig_types.go
+++ b/api/v1alpha1/clusterconfig_types.go
@@ -6,6 +6,7 @@ package v1alpha1
 import (
 	"fmt"
 	"maps"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -271,8 +272,8 @@ func (ExtraAPIServerCertSANs) VariableSchema() clusterv1.VariableSchema {
 	return clusterv1.VariableSchema{
 		OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 			Description: fmt.Sprintf(
-				"Extra Subject Alternative Names for the API Server signing cert. For Docker %v are injected automatically.",
-				DefaultDockerCertSANs,
+				"Extra Subject Alternative Names for the API Server signing cert. For Docker %s are injected automatically.",
+				strings.Join(DefaultDockerCertSANs, ","),
 			),
 			Type:        "array",
 			UniqueItems: true,

--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml
@@ -65,12 +65,7 @@ spec:
     spec:
       kubeadmConfigSpec:
         clusterConfiguration:
-          apiServer:
-            certSANs:
-            - localhost
-            - 127.0.0.1
-            - 0.0.0.0
-            - host.docker.internal
+          apiServer: {}
           controllerManager:
             extraArgs:
               enable-hostpath-provisioner: "true"

--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml
@@ -65,7 +65,6 @@ spec:
     spec:
       kubeadmConfigSpec:
         clusterConfiguration:
-          apiServer: {}
           controllerManager:
             extraArgs:
               enable-hostpath-provisioner: "true"

--- a/common/pkg/capi/utils/utils.go
+++ b/common/pkg/capi/utils/utils.go
@@ -45,3 +45,10 @@ func ManagementCluster(ctx context.Context, c client.Client) (*clusterv1.Cluster
 
 	return cluster, nil
 }
+
+func GetProvider(cluster *clusterv1.Cluster) string {
+	if cluster == nil {
+		return ""
+	}
+	return cluster.GetLabels()[clusterv1.ProviderNameLabel]
+}

--- a/hack/examples/bases/docker/clusterclass/kustomization.yaml.tmpl
+++ b/hack/examples/bases/docker/clusterclass/kustomization.yaml.tmpl
@@ -23,6 +23,11 @@ labels:
 patches:
 # Delete the patch and variable definitions.
 - target:
+    kind: KubeadmControlPlaneTemplate
+  patch: |-
+    - op: "remove"
+      path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/certSANs"
+- target:
     kind: ClusterClass
   patch: |-
     - op: "remove"

--- a/hack/examples/bases/docker/clusterclass/kustomization.yaml.tmpl
+++ b/hack/examples/bases/docker/clusterclass/kustomization.yaml.tmpl
@@ -26,7 +26,7 @@ patches:
     kind: KubeadmControlPlaneTemplate
   patch: |-
     - op: "remove"
-      path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/certSANs"
+      path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer"
 - target:
     kind: ClusterClass
   patch: |-

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
@@ -81,8 +81,9 @@ func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 		)
 	}
 	defaultAPICertSANs := getDefaultAPIServerSANs(cluster)
-	//nolint: gocritic // this is more readable
-	apiCertSANs := append(extraAPIServerCertSANsVar, defaultAPICertSANs...)
+	apiCertSANs := make([]string, len(extraAPIServerCertSANsVar))
+	copy(apiCertSANs, extraAPIServerCertSANsVar)
+	apiCertSANs = append(apiCertSANs, defaultAPICertSANs...)
 	if len(apiCertSANs) == 0 {
 		log.Info("No APIServerSANs to apply")
 		return nil

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
@@ -54,7 +54,7 @@ func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 	obj *unstructured.Unstructured,
 	vars map[string]apiextensionsv1.JSON,
 	holderRef runtimehooksv1.HolderReference,
-	clusterKey client.ObjectKey,
+	_ client.ObjectKey,
 	clusterGetter mutation.ClusterGetter,
 ) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
@@ -70,6 +70,7 @@ func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 			err,
 			"failed to get cluster config variable from extraAPIServerCertSANs mutation handler",
 		)
+		return err
 	}
 	if !found {
 		log.V(5).Info("Extra API server cert SANs variable not defined")
@@ -80,10 +81,10 @@ func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 			err,
 			"failed to get cluster from extraAPIServerCertSANs mutation handler",
 		)
+		return err
 	}
 	defaultAPICertSANs := getDefaultAPIServerSANs(cluster)
-	apiCertSANs := slices.Clone[[]string](extraAPIServerCertSANsVar)
-	apiCertSANs = append(apiCertSANs, defaultAPICertSANs...)
+	apiCertSANs := slices.Concat(extraAPIServerCertSANsVar, defaultAPICertSANs)
 	slices.Sort(apiCertSANs)
 	apiCertSANs = slices.Compact(apiCertSANs)
 	log = log.WithValues(

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
@@ -84,11 +84,8 @@ func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 	defaultAPICertSANs := getDefaultAPIServerSANs(cluster)
 	apiCertSANs := slices.Clone[[]string](extraAPIServerCertSANsVar)
 	apiCertSANs = append(apiCertSANs, defaultAPICertSANs...)
+	slices.Sort(apiCertSANs)
 	apiCertSANs = slices.Compact(apiCertSANs)
-	if len(apiCertSANs) == 0 {
-		log.Info("No APIServerSANs to apply")
-		return nil
-	}
 	log = log.WithValues(
 		"variableName",
 		h.variableName,

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject.go
@@ -5,6 +5,7 @@ package extraapiservercertsans
 
 import (
 	"context"
+	"slices"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -81,9 +82,9 @@ func (h *extraAPIServerCertSANsPatchHandler) Mutate(
 		)
 	}
 	defaultAPICertSANs := getDefaultAPIServerSANs(cluster)
-	apiCertSANs := make([]string, len(extraAPIServerCertSANsVar))
-	copy(apiCertSANs, extraAPIServerCertSANsVar)
+	apiCertSANs := slices.Clone[[]string](extraAPIServerCertSANsVar)
 	apiCertSANs = append(apiCertSANs, defaultAPICertSANs...)
+	apiCertSANs = slices.Compact(apiCertSANs)
 	if len(apiCertSANs) == 0 {
 		log.Info("No APIServerSANs to apply")
 		return nil

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject_test.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Generate Extra API server certificate patches", func() {
 							GenericClusterConfig: v1alpha1.GenericClusterConfig{
 								ExtraAPIServerCertSANs: v1alpha1.ExtraAPIServerCertSANs{
 									"a.b.c.example.com",
+									"a.b.c.example.com",
 									"d.e.f.example.com",
 								},
 							},
@@ -109,11 +110,11 @@ var _ = Describe("Generate Extra API server certificate patches", func() {
 						gomega.HaveKeyWithValue(
 							"certSANs",
 							[]interface{}{
-								"a.b.c.example.com",
-								"localhost",
-								"127.0.0.1",
 								"0.0.0.0",
+								"127.0.0.1",
+								"a.b.c.example.com",
 								"host.docker.internal",
+								"localhost",
 							},
 						),
 					),

--- a/pkg/handlers/generic/mutation/extraapiservercertsans/inject_test.go
+++ b/pkg/handlers/generic/mutation/extraapiservercertsans/inject_test.go
@@ -4,10 +4,12 @@
 package extraapiservercertsans
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -27,6 +29,11 @@ func TestExtraAPIServerCertSANsPatch(t *testing.T) {
 	RunSpecs(t, "Extra API server certificate mutator suite")
 }
 
+type testObj struct {
+	patchTest capitest.PatchTestDef
+	cluster   clusterv1.Cluster
+}
+
 var _ = Describe("Generate Extra API server certificate patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
 		clientScheme := runtime.NewScheme()
@@ -37,39 +44,107 @@ var _ = Describe("Generate Extra API server certificate patches", func() {
 		return mutation.NewMetaGeneratePatchesHandler("", cl, NewPatch()).(mutation.GeneratePatches)
 	}
 
-	testDefs := []capitest.PatchTestDef{
+	testDefs := []testObj{
 		{
-			Name: "unset variable",
+			patchTest: capitest.PatchTestDef{
+				Name: "extra API server cert SANs set with AWS",
+				Vars: []runtimehooksv1.Variable{
+					capitest.VariableWithValue(
+						clusterconfig.MetaVariableName,
+						v1alpha1.ClusterConfigSpec{
+							GenericClusterConfig: v1alpha1.GenericClusterConfig{
+								ExtraAPIServerCertSANs: v1alpha1.ExtraAPIServerCertSANs{
+									"a.b.c.example.com",
+									"d.e.f.example.com",
+								},
+							},
+							AWS: &v1alpha1.AWSSpec{},
+						},
+					),
+				},
+				RequestItem: request.NewKubeadmControlPlaneTemplateRequestItem(""),
+				ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
+					Operation: "add",
+					Path:      "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration",
+					ValueMatcher: gomega.HaveKeyWithValue(
+						"apiServer",
+						gomega.HaveKeyWithValue(
+							"certSANs",
+							[]interface{}{"a.b.c.example.com", "d.e.f.example.com"},
+						),
+					),
+				}},
+			},
+			cluster: clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: metav1.NamespaceDefault,
+					Labels: map[string]string{
+						clusterv1.ProviderNameLabel: "aws",
+					},
+				},
+			},
 		},
 		{
-			Name: "extra API server cert SANs set",
-			Vars: []runtimehooksv1.Variable{
-				capitest.VariableWithValue(
-					clusterconfig.MetaVariableName,
-					v1alpha1.ExtraAPIServerCertSANs{"a.b.c.example.com", "d.e.f.example.com"},
-					VariableName,
-				),
-			},
-			RequestItem: request.NewKubeadmControlPlaneTemplateRequestItem(""),
-			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
-				Operation: "add",
-				Path:      "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration",
-				ValueMatcher: gomega.HaveKeyWithValue(
-					"apiServer",
-					gomega.HaveKeyWithValue(
-						"certSANs",
-						[]interface{}{"a.b.c.example.com", "d.e.f.example.com"},
+			patchTest: capitest.PatchTestDef{
+				Name: "extra API server cert SANs set with Docker",
+				Vars: []runtimehooksv1.Variable{
+					capitest.VariableWithValue(
+						clusterconfig.MetaVariableName,
+						v1alpha1.ClusterConfigSpec{
+							GenericClusterConfig: v1alpha1.GenericClusterConfig{
+								ExtraAPIServerCertSANs: v1alpha1.ExtraAPIServerCertSANs{
+									"a.b.c.example.com",
+								},
+							},
+						},
 					),
-				),
-			}},
+				},
+				RequestItem: request.NewKubeadmControlPlaneTemplateRequestItem(""),
+				ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
+					Operation: "add",
+					Path:      "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration",
+					ValueMatcher: gomega.HaveKeyWithValue(
+						"apiServer",
+						gomega.HaveKeyWithValue(
+							"certSANs",
+							[]interface{}{
+								"a.b.c.example.com",
+								"localhost",
+								"127.0.0.1",
+								"0.0.0.0",
+								"host.docker.internal",
+							},
+						),
+					),
+				}},
+			},
+			cluster: clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: metav1.NamespaceDefault,
+					Labels: map[string]string{
+						clusterv1.ProviderNameLabel: "docker",
+					},
+				},
+			},
 		},
 	}
 
 	// create test node for each case
 	for testIdx := range testDefs {
 		tt := testDefs[testIdx]
-		It(tt.Name, func() {
-			capitest.AssertGeneratePatches(GinkgoT(), patchGenerator, &tt)
+		It(tt.patchTest.Name, func() {
+			clientScheme := runtime.NewScheme()
+			utilruntime.Must(clientgoscheme.AddToScheme(clientScheme))
+			utilruntime.Must(clusterv1.AddToScheme(clientScheme))
+			cl, err := helpers.TestEnv.GetK8sClientWithScheme(clientScheme)
+			gomega.Expect(err).To(gomega.BeNil())
+			err = cl.Create(context.Background(), &tt.cluster)
+			gomega.Expect(err).To(gomega.BeNil())
+			capitest.AssertGeneratePatches(GinkgoT(), patchGenerator, &tt.patchTest)
+			err = cl.Delete(context.Background(), &tt.cluster)
+			gomega.Expect(err).To(gomega.BeNil())
 		})
 	}
 })


### PR DESCRIPTION
<!--
 Copyright 2023 D2iQ, Inc. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
**What problem does this PR solve?**:

https://jira.nutanix.com/browse/D2IQ-100340 Adds docker sans through mutation handler using the new functionality in #514 


**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

Tested manually by creating a docker cluster.

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
Depends on #514.