### PR TITLE
ci: Add permissions to add PR review comments for reviewdog actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -74,6 +74,8 @@ jobs:
       matrix:
         module: [api, common, .]
       fail-fast: false
+    permissions:
+      pull-requests: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -101,6 +103,8 @@ jobs:
 
   lint-gha:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -138,7 +142,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit-3|${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run pre-commit
         run: devbox run -- make pre-commit


### PR DESCRIPTION
This makes it easier to see what golangci-lint checks have failed.
