### PR TITLE
test(e2e): Use same versions of providers from module dependencies

### DIFF
--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -11,8 +11,8 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/core-components.yaml"
+  - name: "${CAPI_VERSION}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_VERSION}/core-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -24,8 +24,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/bootstrap-components.yaml"
+  - name: "${CAPI_VERSION}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_VERSION}/bootstrap-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -37,8 +37,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/control-plane-components.yaml"
+  - name: "${CAPI_VERSION}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_VERSION}/control-plane-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -50,8 +50,8 @@ providers:
 - name: aws
   type: InfrastructureProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api-provider-aws/v2@v2.4}"
-    value: "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/{go://sigs.k8s.io/cluster-api-provider-aws/v2@v2.4}/infrastructure-components.yaml"
+  - name: "${CAPA_VERSION}"
+    value: "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/${CAPA_VERSION}/infrastructure-components.yaml"
     type: "url"
     contract: v1beta1
     files:
@@ -73,8 +73,8 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api@v1.6}"
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.6}/infrastructure-components-development.yaml"
+  - name: "${CAPD_VERSION}"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPD_VERSION}/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     files:
@@ -96,8 +96,8 @@ providers:
 - name: helm
   type: AddonProvider
   versions:
-  - name: "{go://sigs.k8s.io/cluster-api-addon-provider-helm@latest-v0.1}"
-    value: "https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/{go://sigs.k8s.io/cluster-api-addon-provider-helm@latest-v0.1}/addon-components.yaml"
+  - name: "${CAAPH_VERSION}"
+    value: "https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/releases/download/${CAAPH_VERSION}/addon-components.yaml"
     type: "url"
     contract: v1beta1
     files:

--- a/test/e2e/data/shared/v1beta1-caaph/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1-caaph/metadata.yaml
@@ -9,5 +9,5 @@
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
   - major: 0
-    minor: 1
+    minor: 2
     contract: v1beta1

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -260,9 +260,9 @@ func initBootstrapCluster(
 		clusterctl.InitManagementClusterAndWatchControllerLogsInput{
 			ClusterProxy:              bootstrapClusterProxy,
 			ClusterctlConfigPath:      clusterctlConfig,
-			InfrastructureProviders:   config.InfrastructureProviders(),
-			AddonProviders:            config.AddonProviders(),
-			RuntimeExtensionProviders: config.RuntimeExtensionProviders(),
+			InfrastructureProviders:   config.GetProviderLatestVersionsByContract("*", config.InfrastructureProviders()...),
+			AddonProviders:            config.GetProviderLatestVersionsByContract("*", config.AddonProviders()...),
+			RuntimeExtensionProviders: config.GetProviderLatestVersionsByContract("*", config.RuntimeExtensionProviders()...),
 			LogFolder: filepath.Join(
 				artifactFolder,
 				"clusters",


### PR DESCRIPTION
This provides a stable test setup for e2e that is unaffected by ongoing
upstream releases.
