### PR TITLE
feat: Added e2e test for capx cluster

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,9 @@ jobs:
         run: devbox run -- make e2e-test E2E_LABEL='provider:${{ inputs.provider }}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUTANIX_ENDPOINT: ${{ secrets.NUTANIX_ENDPOINT }}
+          NUTANIX_PASSWORD: ${{ secrets.NUTANIX_PASSWORD }}
+          NUTANIX_USER: ${{ secrets.NUTANIX_USER }}
 
       - if: success() || failure() # always run even if the previous step fails
         name: Publish e2e test report

--- a/pkg/handlers/generic/lifecycle/csi/nutanix-csi/handler.go
+++ b/pkg/handlers/generic/lifecycle/csi/nutanix-csi/handler.go
@@ -215,7 +215,14 @@ func (n *NutanixCSI) handleHelmAddonApply(
 		},
 	}
 
-	if err = client.ServerSideApply(ctx, n.client, snapshotChart, client.ForceOwnership); err != nil {
+	if err = controllerutil.SetOwnerReference(&req.Cluster, snapshotChart, n.client.Scheme()); err != nil {
+		return fmt.Errorf(
+			"failed to set owner reference on nutanix-csi-snapshot installation HelmChartProxy: %w",
+			err,
+		)
+	}
+
+	if err = client.ServerSideApply(ctx, n.client, snapshotChart); err != nil {
 		return fmt.Errorf(
 			"failed to apply nutanix-csi-snapshot installation HelmChartProxy: %w",
 			err,

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -93,6 +93,29 @@ providers:
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
 
+- name: nutanix
+  type: InfrastructureProvider
+  versions:
+  - name: "${CAPX_VERSION}"
+    value: "https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/releases/download/${CAPX_VERSION}/infrastructure-components.yaml"
+    type: "url"
+    contract: v1beta1
+    files:
+    - sourcePath: "../data/shared/v1beta1-capx/metadata.yaml"
+    - sourcePath: "../../../charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml"
+      targetName: clusterclass-nutanix-quick-start.yaml
+    - sourcePath: "../../../examples/capi-quick-start/nutanix-cluster-cilium-helm-addon.yaml"
+      targetName: cluster-template-topology-cilium-helm-addon.yaml
+    - sourcePath: "../../../examples/capi-quick-start/nutanix-cluster-cilium-crs.yaml"
+      targetName: cluster-template-topology-cilium-crs.yaml
+    - sourcePath: "../../../examples/capi-quick-start/nutanix-cluster-calico-helm-addon.yaml"
+      targetName: cluster-template-topology-calico-helm-addon.yaml
+    - sourcePath: "../../../examples/capi-quick-start/nutanix-cluster-calico-crs.yaml"
+      targetName: cluster-template-topology-calico-crs.yaml
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+
 - name: helm
   type: AddonProvider
   versions:
@@ -161,6 +184,32 @@ variables:
   AMI_LOOKUP_FORMAT: "konvoy-ami-{{.BaseOS}}-release-?{{.K8sVersion}}-*"
   AMI_LOOKUP_BASEOS: "rocky-9.1"
   AMI_LOOKUP_ORG: "999867407951"
+  # To run Nutanix provider tests, set following variables here or as an env var
+  # # IP/FQDN of Prism Central.
+  # NUTANIX_ENDPOINT: ""
+  # # Port of Prism Central. Default: 9440
+  # NUTANIX_PORT: 9440
+  # # Disable Prism Central certificate checking. Default: false
+  # NUTANIX_INSECURE: false
+  # # Prism Central user
+  # NUTANIX_USER: ""
+  # # Prism Central password
+  # NUTANIX_PASSWORD: ""
+  # # Host IP to be assigned to the CAPX Kubernetes cluster.
+  # CONTROL_PLANE_ENDPOINT_IP: ""
+  # # Port of the CAPX Kubernetes cluster. Default: 6443
+  # CONTROL_PLANE_ENDPOINT_PORT: 6443
+  # # Name of the Prism Element cluster.
+  # NUTANIX_PRISM_ELEMENT_CLUSTER_NAME: ""
+  # # Name of the OS image pre-uploaded in PC.
+  # NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME: ""
+  # # Name of the subnet to be assigned to the VMs.
+  # NUTANIX_SUBNET_NAME: ""
+  # # Name of the storage container to CSI driver
+  # NUTANIX_STORAGE_CONTAINER_NAME: ""
+  # # Username/Password of dockerhub account to avoid download rate limiting
+  # DOCKER_HUB_USERNAME: ""
+  # DOCKER_HUB_PASSWORD: ""
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/e2e/data/shared/v1beta1-capx/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1-capx/metadata.yaml
@@ -1,0 +1,15 @@
+# Copyright 2024 D2iQ, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# TODO(release-blocker): update this file only when a new major or minor version is released
+
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 1
+    minor: 4
+    contract: v1beta1

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var _ = Describe("Quick start", Serial, func() {
-	for _, provider := range []string{"Docker", "AWS"} {
+	for _, provider := range []string{"Docker", "AWS", "Nutanix"} {
 		lowercaseProvider := strings.ToLower(provider)
 		for _, cniProvider := range []string{"Cilium", "Calico"} {
 			for _, addonStrategy := range []string{"HelmAddon", "ClusterResourceSet"} {
@@ -94,6 +94,7 @@ var _ = Describe("Quick start", Serial, func() {
 										framework.KubeadmControlPlaneOwnerReferenceAssertions,
 										framework.KubernetesReferenceAssertions,
 										AWSInfraOwnerReferenceAssertions,
+										NutanixInfraOwnerReferenceAssertions,
 										AddonReferenceAssertions,
 									)
 


### PR DESCRIPTION
    We need to set following vars in either env or caren.yaml
    
      # IP/FQDN of Prism Central.
      NUTANIX_ENDPOINT: ""
      # Port of Prism Central. Default: 9440
      NUTANIX_PORT: 9440
      # Disable Prism Central certificate checking. Default: false
      NUTANIX_INSECURE: false
      # Prism Central user
      NUTANIX_USER: ""
      # Prism Central password
      NUTANIX_PASSWORD: ""
      # Host IP to be assigned to the CAPX Kubernetes cluster.
      CONTROL_PLANE_ENDPOINT_IP: ""
      # Port of the CAPX Kubernetes cluster. Default: 6443
      CONTROL_PLANE_ENDPOINT_PORT: 6443
      # Name of the Prism Element cluster.
      NUTANIX_PRISM_ELEMENT_CLUSTER_NAME: ""
      # Name of the OS image pre-uploaded in PC.
      NUTANIX_MACHINE_TEMPLATE_IMAGE_NAME: ""
      # Name of the subnet to be assigned to the VMs.
      NUTANIX_SUBNET_NAME: ""
      # Name of the storage container to CSI driver
      NUTANIX_STORAGE_CONTAINER_NAME: ""
      # Username/Password of dockerhub account to avoid download rate limiting
      DOCKER_HUB_USERNAME: ""
      DOCKER_HUB_PASSWORD: ""

<!--
 Copyright 2023 D2iQ, Inc. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
**What problem does this PR solve?**:
Adds Nutanix provider to quick start test

**Which issue(s) this PR fixes**:
Fixes #https://jira.nutanix.com/browse/D2IQ-100400 

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
<pre>
make e2e-test
</pre>

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
