### PR TITLE
fix: add omitempty to CCM Credentials struct

### DIFF
--- a/api/v1alpha1/addon_types.go
+++ b/api/v1alpha1/addon_types.go
@@ -311,7 +311,7 @@ func (CSI) VariableSchema() clusterv1.VariableSchema {
 type CCM struct {
 	// A reference to the Secret for credential information for the target Prism Central instance
 	// +optional
-	Credentials *corev1.LocalObjectReference `json:"credentials"`
+	Credentials *corev1.LocalObjectReference `json:"credentials,omitempty"`
 }
 
 func (CCM) VariableSchema() clusterv1.VariableSchema {


### PR DESCRIPTION
<!--
 Copyright 2023 D2iQ, Inc. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
**What problem does this PR solve?**:
Im updating the version in Konvoy and noticed that it not added:
```
      ccm:
        credentials: null
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
I'll try to find some linter that can catch this in the future.
