### PR TITLE
refactor: create storage classes directly instead of using CRS

### DIFF
--- a/pkg/handlers/generic/lifecycle/utils/scs.go
+++ b/pkg/handlers/generic/lifecycle/utils/scs.go
@@ -84,10 +84,10 @@ func CreateStorageClassOnRemote(
 	if err != nil {
 		return fmt.Errorf("error creating client for remote cluster: %w", err)
 	}
-	for _, o := range allStorageClasses {
-		err = client.ServerSideApply(ctx, remoteClient, o)
+	for _, sc := range allStorageClasses {
+		err = client.ServerSideApply(ctx, remoteClient, sc)
 		if err != nil {
-			return fmt.Errorf("error creating client for remote cluster: %w", err)
+			return fmt.Errorf("error creating storage class %v on remote cluster %w", sc, err)
 		}
 	}
 	return nil

--- a/pkg/handlers/generic/lifecycle/utils/scs.go
+++ b/pkg/handlers/generic/lifecycle/utils/scs.go
@@ -66,7 +66,7 @@ func CreateStorageClassOnRemote(
 	defaultStorageConfig *v1alpha1.DefaultStorage,
 	csiProvider string,
 	provisioner v1alpha1.StorageProvisioner,
-	storageClassParameters map[string]string,
+	defaultParameters map[string]string,
 ) error {
 	allStorageClasses := make([]*storagev1.StorageClass, 0, len(configs))
 	for _, config := range configs {
@@ -76,7 +76,7 @@ func CreateStorageClassOnRemote(
 			config,
 			provisioner,
 			setAsDefault,
-			storageClassParameters,
+			defaultParameters,
 		))
 	}
 	clusterKey := ctrlclient.ObjectKeyFromObject(cluster)


### PR DESCRIPTION
**What problem does this PR solve?**:

**Which issue(s) this PR fixes**:
Removes our dependency for Cluster Resource Sets entirely for Nutanix Clusters

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

Create a cluster and check if storage class is created.


```sh
02:55 PM  faiqus @ archlinux  ~/go/src/github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix  faiq/storageclass-direct? 
$ kubectl --kubeconfig=faiqcsi.conf get sc
NAME                       PROVISIONER       RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
nutanix-volume (default)   csi.nutanix.com   Delete          WaitForFirstConsumer   false                  3m

02:56 PM  faiqus @ archlinux  ~/go/src/github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix  faiq/storageclass-direct? 
$ kubectl get clusterresourcesets
No resources found in default namespace.

02:56 PM  faiqus @ archlinux  ~/go/src/github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix  faiq/storageclass-direct? 
$ kubectl get clusterresourcesets -A
No resources found

02:56 PM  faiqus @ archlinux  ~/go/src/github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix  faiq/storageclass-direct? 
$ kubectl get helmreleaseproxy -A
NAMESPACE   NAME                                   CLUSTER   READY   REASON   STATUS     REVISION
default     cilium-faiqcsi-ndb7v                   faiqcsi   True             deployed   1
default     cluster-autoscaler-faiqcsi-v58lv       faiqcsi   True             deployed   1
default     node-feature-discovery-faiqcsi-q9n2w   faiqcsi   True             deployed   1
default     nutanix-cloud-provider-faiqcsi-2d4zq   faiqcsi   True             deployed   1
default     nutanix-csi-snapshot-faiqcsi-wjmjr     faiqcsi   True             deployed   1
default     nutanix-csi-storage-faiqcsi-6567j      faiqcsi   True             deployed   1
```

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
