### PR TITLE
build: create .envrc.e2e file from caren e2e config

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,6 +8,7 @@ export DEVBOX_NO_ENVRC_UPDATE=1
 eval "$(devbox generate direnv --print-envrc --env-file .dev-envrc)"
 
 dotenv_if_exists '.envrc.local'
+dotenv_if_exists '.envrc.e2e'
 
 # check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
 # for more details

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ capd-kubeconfig
 ct_previous_*/
 
 .envrc.local*
+.envrc.e2e*
 
 public/
 resources/

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -49,5 +49,5 @@ endif
 
 .PHONY: .envrc.e2e
 .envrc.e2e:
-	gojq --yaml-input --raw-output '.variables | to_entries | map("\(.key)=\(.value|tostring)")|.[]' < test/e2e/config/caren.yaml | envsubst > .envrc.e2e
+	gojq --yaml-input --raw-output '.variables | to_entries | map("export \(.key)=\(.value|tostring)")|.[]' < test/e2e/config/caren.yaml | envsubst > .envrc.e2e
 	direnv reload

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -46,3 +46,8 @@ else
 	release-please release-pr \
 	  --repo-url $(GITHUB_ORG)/$(GITHUB_REPOSITORY) --token "$$(gh auth token)"
 endif
+
+.PHONY: .envrc.local
+.envrc.local:
+	gojq --yaml-input --raw-output '.variables | to_entries | map("\(.key)=\(.value|tostring)")|.[]' < test/e2e/config/caren.yaml | envsubst > .envrc.local
+	direnv reload

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -47,7 +47,7 @@ else
 	  --repo-url $(GITHUB_ORG)/$(GITHUB_REPOSITORY) --token "$$(gh auth token)"
 endif
 
-.PHONY: .envrc.local
-.envrc.local:
-	gojq --yaml-input --raw-output '.variables | to_entries | map("\(.key)=\(.value|tostring)")|.[]' < test/e2e/config/caren.yaml | envsubst > .envrc.local
+.PHONY: .envrc.e2e
+.envrc.e2e:
+	gojq --yaml-input --raw-output '.variables | to_entries | map("\(.key)=\(.value|tostring)")|.[]' < test/e2e/config/caren.yaml | envsubst > .envrc.e2e
 	direnv reload


### PR DESCRIPTION
**What problem does this PR solve?**:
Following up with https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/538 adds a helper makefile target that creates `.envrc.local` file from `test/e2e/config/caren.yaml`

This helps keeping the local env file in sync with changes in the e2e tests.
it also overriding env variables in `test/e2e/config/caren.yaml`

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
```
❯ make .envrc.local
direnv: loading ~/gitrepos/cluster-api-runtime-extensions-nutanix/.envrc
Info: New devbox available: 0.8.5 -> v0.10.5. Please run `devbox version update`.
direnv: using devbox
direnv: export +AR +AS +CAPI_DIAGNOSTICS_ADDRESS +CAPI_INSECURE_DIAGNOSTICS +CC +CLUSTER_TOPOLOGY 
... 
...
....
~KUBERNETES_VERSION ~PATH
❯ cat .envrc.local
AMI_LOOKUP_BASEOS=rocky-9.1
AMI_LOOKUP_FORMAT=konvoy-ami-{{.BaseOS}}-release-?{{.K8sVersion}}-*
AMI_LOOKUP_ORG=999867407951
CAPI_DIAGNOSTICS_ADDRESS=:8080
CAPI_INSECURE_DIAGNOSTICS=true
CLUSTER_TOPOLOGY=true
EXP_CLUSTER_RESOURCE_SET=true
EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION=true
EXP_MACHINE_POOL=true
EXP_MACHINE_SET_PREFLIGHT_CHECKS=true
EXP_RUNTIME_SDK=true
KUBERNETES_VERSION=foobar
KUBERNETES_VERSION_DOCKER=v1.29.4
KUBERNETES_VERSION_MANAGEMENT=v1.29.4
NODE_DRAIN_TIMEOUT=60s
POD_CIDR=192.168.0.0/16
SERVICE_CIDR=10.128.0.0/12

❯ env | grep KUBERNETES_VERSION
KUBERNETES_VERSION=foobar
E2E_DEFAULT_KUBERNETES_VERSION=foobar
KUBERNETES_VERSION_DOCKER=v1.29.4
KUBERNETES_VERSION_MANAGEMENT=v1.29.4

```
**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
