### PR TITLE
build: Only allow patch updates to k8s libs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
       k8s:
         patterns:
           - "k8s.io*"
+        update-types:
+          - patch
+      k8s-sigs:
+        patterns:
           - "sigs.k8s.io*"
 
   - package-ecosystem: "gomod"
@@ -26,6 +30,10 @@ updates:
       k8s:
         patterns:
           - "k8s.io*"
+        update-types:
+          - patch
+      k8s-sigs:
+        patterns:
           - "sigs.k8s.io*"
 
   - package-ecosystem: "gomod"
@@ -36,6 +44,10 @@ updates:
       k8s:
         patterns:
           - "k8s.io*"
+        update-types:
+          - patch
+      k8s-sigs:
+        patterns:
           - "sigs.k8s.io*"
 
   - package-ecosystem: "gomod"


### PR DESCRIPTION
This is because controller-runtime still requires 0.29.x dependencies
so cannot upgrde to 0.30.0.
