### PR TITLE
build: Add envtest setup to e2e envrc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 REPO_ROOT := $(CURDIR)
 
 # Versions for tools that are not managed by devbox.
-ENVTEST_VERSION=1.29.x
+# The `!` suffix forces checking the remote API server
+# for the latest patch version of the specified minor.
+ENVTEST_VERSION=1.29.x!
 
 include make/all.mk

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -50,4 +50,5 @@ endif
 .PHONY: .envrc.e2e
 .envrc.e2e:
 	gojq --yaml-input --raw-output '.variables | to_entries | map("export \(.key)=\(.value|tostring)")|.[]' < test/e2e/config/caren.yaml | envsubst > .envrc.e2e
+	setup-envtest use -p env $(ENVTEST_VERSION) >> .envrc.e2e
 	direnv reload


### PR DESCRIPTION
This enables running envtest based Ginkgo tests more easily in your terminal or
in vscode if you have the direnv plugin installed.
