### PR TITLE
build: Bundle k8s.io/* back in with sigs.k8s.io/* dependencies 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,6 @@ updates:
       k8s:
         patterns:
           - "k8s.io*"
-        update-types:
-          - patch
-      k8s-sigs:
-        patterns:
           - "sigs.k8s.io*"
 
   - package-ecosystem: "gomod"
@@ -30,10 +26,6 @@ updates:
       k8s:
         patterns:
           - "k8s.io*"
-        update-types:
-          - patch
-      k8s-sigs:
-        patterns:
           - "sigs.k8s.io*"
 
   - package-ecosystem: "gomod"
@@ -44,10 +36,6 @@ updates:
       k8s:
         patterns:
           - "k8s.io*"
-        update-types:
-          - patch
-      k8s-sigs:
-        patterns:
           - "sigs.k8s.io*"
 
   - package-ecosystem: "gomod"


### PR DESCRIPTION
This has to be inline with controller-runtime dependencies so we
can rely on that upgrading to upgrade k8s.io/* dependencies.
