### PR TITLE
build: Ensure provider metadata is up to date when releasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ node_modules/
 /runtime-extension-components.yaml
 /_artifacts/
 test/e2e/config/caren-envsubst.yaml
+/release-metadata.yaml

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,8 @@ release:
     **Full Changelog**: https://github.com/nutanix-cloud-native/{{.ProjectName}}/compare/{{ .PreviousTag }}...{{ .Tag }}
   extra_files:
     - glob: ./examples/capi-quick-start/*.yaml
-    - glob: metadata.yaml
+    - glob: release-metadata.yaml
+      name_template: metadata.yaml
     - glob: runtime-extension-components.yaml
 
 before:
@@ -41,7 +42,11 @@ before:
         {{ if .IsSnapshot }}--set-string image.repository=ko.local/{{ .ProjectName }}{{ end }} \
       )
       EOF'
-    - sed -i 's/\${/$${/g' runtime-extension-components.yaml
+    - sed -i -e 's/\${/$${/g' -e 's/v0.0.0-dev/v{{ trimprefix .Version "v" }}/g' runtime-extension-components.yaml
+    - |
+      sh -ec 'gojq --yaml-input --yaml-output \
+        ".releaseSeries |= (. + [{contract: \"v1beta1\", major: {{ .Major }}, minor: {{ .Minor }}}] | unique)" \
+        metadata.yaml >release-metadata.yaml'
 
 builds:
   - id: cluster-api-runtime-extensions-nutanix


### PR DESCRIPTION
When a new minor release is created, the metadata attached to the
release needs to include the release series provider compatibility
mapping. This commit ensures that if a new minor release is cut that the
`metadata.yaml` attached to the release is cotrect for that release.

I have manually fixed v0.8.1 and v0.7.0 releases and with this commit we
won't need to do it manually ever again!
