### PR TITLE
docs: Upgrade hugo to latest

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -17,7 +17,7 @@
     "gotestsum@latest",
     "govulncheck@latest",
     "helm-docs@latest",
-    "hugo@0.124.1",
+    "hugo@latest",
     "kind@latest",
     "ko@latest",
     "kubebuilder@latest",

--- a/devbox.lock
+++ b/devbox.lock
@@ -341,51 +341,51 @@
         }
       }
     },
-    "hugo@0.124.1": {
-      "last_modified": "2024-04-01T22:53:36-04:00",
-      "resolved": "github:NixOS/nixpkgs/080a4a27f206d07724b88da096e27ef63401a504#hugo",
+    "hugo@latest": {
+      "last_modified": "2024-04-26T22:17:36-04:00",
+      "resolved": "github:NixOS/nixpkgs/698fd43e541a6b8685ed408aaf7a63561018f9f8#hugo",
       "source": "devbox-search",
-      "version": "0.124.1",
+      "version": "0.125.4",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/svp323dq8pkvkdpgwm6kacirvj306gk7-hugo-0.124.1",
+              "path": "/nix/store/2ssds5l4s15xfgljv2ygjhqpn949lxj4-hugo-0.125.4",
               "default": true
             }
           ],
-          "store_path": "/nix/store/svp323dq8pkvkdpgwm6kacirvj306gk7-hugo-0.124.1"
+          "store_path": "/nix/store/2ssds5l4s15xfgljv2ygjhqpn949lxj4-hugo-0.125.4"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/23g4yy8nljj46iahh4h6hr9q5sbwl0sx-hugo-0.124.1",
+              "path": "/nix/store/nln80v8vsw5h3hv7kihglb12fy077flb-hugo-0.125.4",
               "default": true
             }
           ],
-          "store_path": "/nix/store/23g4yy8nljj46iahh4h6hr9q5sbwl0sx-hugo-0.124.1"
+          "store_path": "/nix/store/nln80v8vsw5h3hv7kihglb12fy077flb-hugo-0.125.4"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/nhfnhk99rwq5ving0adayix38m4kfkpq-hugo-0.124.1",
+              "path": "/nix/store/n6az4gns36nrq9sbiqf2kf7kgn1kjyfm-hugo-0.125.4",
               "default": true
             }
           ],
-          "store_path": "/nix/store/nhfnhk99rwq5ving0adayix38m4kfkpq-hugo-0.124.1"
+          "store_path": "/nix/store/n6az4gns36nrq9sbiqf2kf7kgn1kjyfm-hugo-0.125.4"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/4rwm1ni7hnhjlpn1v3w6g376hzkks7za-hugo-0.124.1",
+              "path": "/nix/store/k53ijl83p62i6lqia2jjky8l136x42i7-hugo-0.125.4",
               "default": true
             }
           ],
-          "store_path": "/nix/store/4rwm1ni7hnhjlpn1v3w6g376hzkks7za-hugo-0.124.1"
+          "store_path": "/nix/store/k53ijl83p62i6lqia2jjky8l136x42i7-hugo-0.125.4"
         }
       }
     },

--- a/docs/layouts/_internal/google_analytics_async.html
+++ b/docs/layouts/_internal/google_analytics_async.html
@@ -1,0 +1,1 @@
+{{/* FIXME: drop this template once Docsy is updated to 0.10.0 */}}


### PR DESCRIPTION
There is an incompatibility in docsy with latest hugo so follow
https://github.com/open-telemetry/opentelemetry.io/pull/4392/files to
workaround this.

Once a compatible version of docsy is released, we can delete the layout
override file.
