### PR TITLE
docs: Update docsy module

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -6,5 +6,5 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/do
 go 1.20
 
 require (
-	github.com/google/docsy v0.9.1 // indirect
+	github.com/google/docsy v0.10.0 // indirect
 )

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,4 +1,4 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
-github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
-github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
+github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/docs/layouts/_internal/google_analytics_async.html
+++ b/docs/layouts/_internal/google_analytics_async.html
@@ -1,1 +1,0 @@
-{{/* FIXME: drop this template once Docsy is updated to 0.10.0 */}}


### PR DESCRIPTION
Of course, the day after I apply a workaround to fix a hugo
incompatibility, docsy release a compatible module version...

This commit updates the docsy module and removes the workaround.
