### PR TITLE
fix: Do not return error if serviceLoadBalancer field is not set

### DIFF
--- a/api/v1alpha1/addon_types.go
+++ b/api/v1alpha1/addon_types.go
@@ -72,7 +72,7 @@ type Addons struct {
 	// +kubebuilder:validation:Optional
 	CSIProviders *CSI `json:"csi,omitempty"`
 
-	// +optional
+	// +kubebuilder:validation:Optional
 	ServiceLoadBalancer *ServiceLoadBalancer `json:"serviceLoadBalancer,omitempty"`
 }
 

--- a/pkg/handlers/generic/lifecycle/serviceloadbalancer/handler.go
+++ b/pkg/handlers/generic/lifecycle/serviceloadbalancer/handler.go
@@ -69,12 +69,20 @@ func (c *ServiceLoadBalancerHandler) AfterControlPlaneInitialized(
 	)
 
 	varMap := variables.ClusterVariablesToVariablesMap(req.Cluster.Spec.Topology.Variables)
-
 	slb, err := variables.Get[v1alpha1.ServiceLoadBalancer](
 		varMap,
 		c.variableName,
 		c.variablePath...)
 	if err != nil {
+		if variables.IsNotFoundError(err) {
+			log.
+				Info(
+					"Skipping ServiceLoadBalancer, field is not specified",
+					"error",
+					err,
+				)
+			return
+		}
 		log.Error(
 			err,
 			"failed to read ServiceLoadBalancer provider from cluster definition",


### PR DESCRIPTION
**What problem does this PR solve?**:
I noticed that the error handling was incorrect.

I also noticed that the field tag did not get updated in https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/issues/604, so I made that update here.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
