### PR TITLE
refactor: rename docker-quick-start to just docker

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml
@@ -3,23 +3,23 @@ kind: ClusterClass
 metadata:
   labels:
     cluster.x-k8s.io/provider: docker
-  name: docker-quick-start
+  name: docker
 spec:
   controlPlane:
     machineInfrastructure:
       ref:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
-        name: docker-quick-start-control-plane
+        name: docker-control-plane
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
-      name: docker-quick-start-control-plane
+      name: docker
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DockerClusterTemplate
-      name: docker-quick-start-cluster
+      name: docker
   patches:
   - external:
       discoverVariablesExtension: dockerclusterconfigvars.cluster-api-runtime-extensions-nutanix
@@ -37,19 +37,19 @@ spec:
           ref:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
             kind: KubeadmConfigTemplate
-            name: docker-quick-start-default-worker-bootstraptemplate
+            name: docker
         infrastructure:
           ref:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: DockerMachineTemplate
-            name: docker-quick-start-default-worker-machinetemplate
+            name: docker-worker
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: docker
-  name: docker-quick-start-cluster
+  name: docker
 spec:
   template:
     spec: {}
@@ -59,7 +59,7 @@ kind: KubeadmControlPlaneTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: docker
-  name: docker-quick-start-control-plane
+  name: docker
 spec:
   template:
     spec:
@@ -75,7 +75,7 @@ kind: DockerMachineTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: docker
-  name: docker-quick-start-control-plane
+  name: docker-control-plane
 spec:
   template:
     spec:
@@ -88,7 +88,7 @@ kind: DockerMachineTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: docker
-  name: docker-quick-start-default-worker-machinetemplate
+  name: docker-worker
 spec:
   template:
     spec:
@@ -101,7 +101,7 @@ kind: KubeadmConfigTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: docker
-  name: docker-quick-start-default-worker-bootstraptemplate
+  name: docker
 spec:
   template:
     spec:

--- a/examples/capi-quick-start/docker-cluster-calico-crs.yaml
+++ b/examples/capi-quick-start/docker-cluster-calico-crs.yaml
@@ -14,7 +14,7 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:-10.128.0.0/12}
   topology:
-    class: docker-quick-start
+    class: docker
     controlPlane:
       metadata: {}
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}

--- a/examples/capi-quick-start/docker-cluster-calico-helm-addon.yaml
+++ b/examples/capi-quick-start/docker-cluster-calico-helm-addon.yaml
@@ -14,7 +14,7 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:-10.128.0.0/12}
   topology:
-    class: docker-quick-start
+    class: docker
     controlPlane:
       metadata: {}
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}

--- a/examples/capi-quick-start/docker-cluster-cilium-crs.yaml
+++ b/examples/capi-quick-start/docker-cluster-cilium-crs.yaml
@@ -14,7 +14,7 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:-10.128.0.0/12}
   topology:
-    class: docker-quick-start
+    class: docker
     controlPlane:
       metadata: {}
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}

--- a/examples/capi-quick-start/docker-cluster-cilium-helm-addon.yaml
+++ b/examples/capi-quick-start/docker-cluster-cilium-helm-addon.yaml
@@ -14,7 +14,7 @@ spec:
       cidrBlocks:
       - ${SERVICE_CIDR:-10.128.0.0/12}
   topology:
-    class: docker-quick-start
+    class: docker
     controlPlane:
       metadata: {}
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}

--- a/hack/examples/bases/docker/cluster/kustomization.yaml.tmpl
+++ b/hack/examples/bases/docker/cluster/kustomization.yaml.tmpl
@@ -23,7 +23,7 @@ patches:
       path: "/metadata/namespace"
     - op: "replace"
       path: "/spec/topology/class"
-      value: "docker-quick-start"
+      value: "docker"
     - op: "remove"
       path: "/spec/topology/workers/machinePools"
 - target:

--- a/hack/examples/bases/docker/clusterclass/kustomization.yaml.tmpl
+++ b/hack/examples/bases/docker/clusterclass/kustomization.yaml.tmpl
@@ -13,8 +13,6 @@ configurations:
 sortOptions:
   order: fifo
 
-namePrefix: docker-
-
 labels:
 - includeSelectors: false
   pairs:
@@ -47,3 +45,46 @@ patches:
   patch: |-
     - op: "remove"
       path: "/spec/workers/machinePools"
+# Rename all resources
+- target:
+    kind: ClusterClass
+    name: .*
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: docker
+- target:
+    kind: DockerClusterTemplate
+    name: .*
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: docker
+- target:
+    kind: KubeadmControlPlaneTemplate
+    name: .*
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: docker
+- target:
+    kind: DockerMachineTemplate
+    name: quick-start-control-plane
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: docker-control-plane
+- target:
+    kind: DockerMachineTemplate
+    name: quick-start-default-worker-machinetemplate
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: docker-worker
+- target:
+    kind: KubeadmConfigTemplate
+    name: .*
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: docker

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -80,7 +80,7 @@ providers:
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
     - sourcePath: "../../../charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml"
-      targetName: clusterclass-docker-quick-start.yaml
+      targetName: clusterclass-docker.yaml
     - sourcePath: "../../../examples/capi-quick-start/docker-cluster-cilium-helm-addon.yaml"
       targetName: cluster-template-topology-cilium-helm-addon.yaml
     - sourcePath: "../../../examples/capi-quick-start/docker-cluster-cilium-crs.yaml"


### PR DESCRIPTION
**What problem does this PR solve?**:
Alternative name ideas are welcome!

Wanted to propose this change, to me "quick start" sounds like non-production and implies you need something else to get full functionality. Thats not really the case here since these will be the default templates that all patches apply to. 

Keep in mind that clients will automatically get these templates when deploying with the helm chart, so it should probably be pretty generic.

**We can also think about a version suffix to these.**
**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
If we agree, I will follow up with additional PRs for the other providers.