### PR TITLE
refactor: move label helper functions to utils package

### DIFF
--- a/common/pkg/capi/utils/labels.go
+++ b/common/pkg/capi/utils/labels.go
@@ -1,3 +1,6 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/common/pkg/capi/utils/labels.go
+++ b/common/pkg/capi/utils/labels.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+)
+
+type LabelFn func(labels map[string]string)
+
+func NewLabels(fs ...LabelFn) map[string]string {
+	labels := map[string]string{}
+	for _, f := range fs {
+		f(labels)
+	}
+	return labels
+}
+
+func WithClusterName(clusterName string) LabelFn {
+	return func(labels map[string]string) {
+		labels[clusterv1.ClusterNameLabel] = clusterName
+	}
+}
+
+func WithMove() LabelFn {
+	return func(labels map[string]string) {
+		labels[clusterctlv1.ClusterctlMoveLabel] = ""
+	}
+}

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credentials_secret.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credentials_secret.go
@@ -13,9 +13,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	cabpkv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
-	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/utils"
 )
 
 const (
@@ -76,7 +76,7 @@ func generateCredentialsSecret(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      credentialSecretName(clusterName),
 			Namespace: namespace,
-			Labels:    newLabels(withMove(), withClusterName(clusterName)),
+			Labels:    utils.NewLabels(utils.WithMove(), utils.WithClusterName(clusterName)),
 		},
 		StringData: secretData,
 		Type:       corev1.SecretTypeOpaque,
@@ -115,26 +115,4 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 
 func credentialSecretName(clusterName string) string {
 	return fmt.Sprintf("%s-registry-creds", clusterName)
-}
-
-type labelFn func(labels map[string]string)
-
-func newLabels(fs ...labelFn) map[string]string {
-	labels := map[string]string{}
-	for _, f := range fs {
-		f(labels)
-	}
-	return labels
-}
-
-func withClusterName(clusterName string) labelFn {
-	return func(labels map[string]string) {
-		labels[clusterv1.ClusterNameLabel] = clusterName
-	}
-}
-
-func withMove() labelFn {
-	return func(labels map[string]string) {
-		labels[clusterctlv1.ClusterctlMoveLabel] = ""
-	}
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
Moving the utility functions that creates labels to `common/utils` package.
I like to use these function in another mutator.

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
Existing unit tests

**Special notes for your reviewer:**


