### PR TITLE
fix: use provided options for serverside apply

### DIFF
--- a/common/pkg/k8s/client/apply.go
+++ b/common/pkg/k8s/client/apply.go
@@ -25,11 +25,13 @@ func ServerSideApply(
 	obj ctrlclient.Object,
 	opts ...ctrlclient.PatchOption,
 ) error {
+	options := []ctrlclient.PatchOption{ctrlclient.FieldOwner(FieldOwner)}
+	options = append(options, opts...)
 	err := c.Patch(
 		ctx,
 		obj,
 		ctrlclient.Apply,
-		ctrlclient.FieldOwner(FieldOwner),
+		options...,
 	)
 	if err != nil {
 		return fmt.Errorf("server-side apply failed: %w", err)


### PR DESCRIPTION
**What problem does this PR solve?**:
I noticed that the Patch options passed to the `ServerSideApply` helper functions were not used. 
As a result the `ForceOwnership` options from handlers such as https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/blob/main/pkg/handlers/generic/lifecycle/utils/secrets.go#L67 was ignored.

