### PR TITLE
build: Temporary lint config fix until next golangci-lint release

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,11 +101,10 @@ issues:
     - source: "// \\+kubebuilder:"
       linters:
         - lll
-    # Idiomatic to use init functions to register APIs with scheme
-    # Path is relative to api module root.
-    - path: "v1alpha1"
-      linters:
-        - gochecknoinits
+    # Temporary workaround until https://github.com/golangci/golangci-lint/pull/4698 is
+    # available in released version of golangci-lint
+    - path: "(test/e2e/e2e_suite_test.go|v1alpha1)"
+      text: "don't use `init` function"
     # Idiomatic to use pass holderRef by value
     - text: "hugeParam: holderRef is heavy"
       linters:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -32,7 +32,7 @@ import (
 	clusterctltemp "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/framework/clusterctl"
 )
 
-func init() { //nolint:gochecknoinits // Idiomatically used to set up flags.
+func init() {
 	flag.StringVar(&configPath, "e2e.config", "", "path to the e2e config file")
 	flag.StringVar(
 		&artifactFolder,


### PR DESCRIPTION
See https://github.com/golangci/golangci-lint/issues/4697 for details
and waiting on https://github.com/golangci/golangci-lint/pull/4698 to be
released before we can revert this fix.
