### PR TITLE
test: Add more context to panic in envtest helper

### DIFF
--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -202,7 +202,9 @@ func getModulePath(moduleDir, moduleName string) string {
 	cmd.Dir = moduleDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		panic(err)
+		// We include the combined output because the error is usually
+		// an exit code, which does not explain why the command failed.
+		panic(fmt.Sprintf("err=%q, output=%q", err, out))
 	}
 	return strings.TrimSpace(string(out))
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
Adds context to panic message:

**Before:**
```log
  [PANICKED] Test Panicked
  In [BeforeSuite] at: /home/dlipovetsky/nutanix/capi-runtime-extensions/test/helpers/envtest.go:205 @ 05/09/24 08:05:57.622

  exit status 1
```

**After:**
```log
  [PANICKED] Test Panicked
  In [BeforeSuite] at: /home/dlipovetsky/nutanix/capi-runtime-extensions/test/helpers/envtest.go:205 @ 05/09/24 08:05:12.059

  err="exit status 1", output="go: module sigs.k8s.io/cluster-api-provider-aws/v2: not a known dependency\n"
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
