### PR TITLE
refactor: Use colon to separate context from wrapped error

### DIFF
--- a/common/pkg/capi/clustertopology/handlers/mutation/meta.go
+++ b/common/pkg/capi/clustertopology/handlers/mutation/meta.go
@@ -75,7 +75,7 @@ func (mgp metaGeneratePatches) CreateClusterGetter(
 			err = mgp.cl.Get(ctx, clusterKey, &cluster)
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch cluster %w", err)
+			return nil, fmt.Errorf("failed to fetch cluster: %w", err)
 		}
 		return &cluster, nil
 	}

--- a/hack/tools/helm-cm/main.go
+++ b/hack/tools/helm-cm/main.go
@@ -81,7 +81,7 @@ func createConfigMapFromDir(kustomizeDir string) (*corev1.ConfigMap, error) {
 	if !path.IsAbs(fullPath) {
 		wd, err := os.Getwd()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get wd %w", err)
+			return nil, fmt.Errorf("failed to get wd: %w", err)
 		}
 		fullPath = path.Join(wd, kustomizeDir)
 	}

--- a/pkg/handlers/generic/lifecycle/ccm/aws/handler.go
+++ b/pkg/handlers/generic/lifecycle/ccm/aws/handler.go
@@ -64,7 +64,7 @@ func (a *AWSCCM) Apply(
 	log.Info("Creating AWS CCM ConfigMap for Cluster")
 	version, err := semver.ParseTolerant(cluster.Spec.Topology.Version)
 	if err != nil {
-		return fmt.Errorf("failed to parse version from cluster %w", err)
+		return fmt.Errorf("failed to parse version from cluster: %w", err)
 	}
 	minorVersion := fmt.Sprintf("%d.%d", version.Major, version.Minor)
 	configMapForMinorVersion := a.config.kubernetesMinorVersionToCCMConfigMapNames[minorVersion]

--- a/pkg/handlers/generic/lifecycle/ccm/nutanix/handler.go
+++ b/pkg/handlers/generic/lifecycle/ccm/nutanix/handler.go
@@ -119,7 +119,7 @@ func (p *provider) Apply(
 
 	helmChart, err := p.helmChartInfoGetter.For(ctx, log, config.NutanixCCM)
 	if err != nil {
-		return fmt.Errorf("failed to get values for nutanix-ccm-config %w", err)
+		return fmt.Errorf("failed to get values for nutanix-ccm-config: %w", err)
 	}
 
 	// The configMap will contain the Helm values, but templated with fields that need to be filled in.

--- a/pkg/handlers/generic/lifecycle/utils/scs.go
+++ b/pkg/handlers/generic/lifecycle/utils/scs.go
@@ -87,7 +87,7 @@ func CreateStorageClassOnRemote(
 	for _, sc := range allStorageClasses {
 		err = client.ServerSideApply(ctx, remoteClient, sc, client.ForceOwnership)
 		if err != nil {
-			return fmt.Errorf("error creating storage class %v on remote cluster %w", sc, err)
+			return fmt.Errorf("error creating storage class %v on remote cluster: %w", sc, err)
 		}
 	}
 	return nil

--- a/pkg/handlers/generic/lifecycle/utils/utils.go
+++ b/pkg/handlers/generic/lifecycle/utils/utils.go
@@ -87,7 +87,7 @@ func EnsureCRSForClusterFromObjects(
 
 	err := client.ServerSideApply(ctx, c, crs, client.ForceOwnership)
 	if err != nil {
-		return fmt.Errorf("failed to server side apply %w", err)
+		return fmt.Errorf("failed to server side apply: %w", err)
 	}
 
 	return nil
@@ -141,7 +141,7 @@ func EnsureNamespace(ctx context.Context, c ctrlclient.Client, ns *corev1.Namesp
 	}
 	err := client.ServerSideApply(ctx, c, ns)
 	if err != nil {
-		return fmt.Errorf("failed to server side apply %w", err)
+		return fmt.Errorf("failed to server side apply: %w", err)
 	}
 
 	return nil

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip.go
@@ -150,7 +150,7 @@ func getTemplateFromConfigMap(
 func needHackCommands(cluster *clusterv1.Cluster) (bool, error) {
 	version, err := semver.ParseTolerant(cluster.Spec.Topology.Version)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse version from cluster %w", err)
+		return false, fmt.Errorf("failed to parse version from cluster: %w", err)
 	}
 
 	return version.Minor >= 29, nil


### PR DESCRIPTION
**What problem does this PR solve?**:
The colon makes the overall message more readable.

**Before:**
```log
failed to fetch cluster no kind is registered for the type v1beta1.Cluster in scheme "pkg/runtime/scheme.go:100"
```

**After:**:
```log
failed to fetch cluster: no kind is registered for the type v1beta1.Cluster in scheme "pkg/runtime/scheme.go:100"
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
