### PR TITLE
ci: free up disk space before running tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      # The default disk size of these runners is ~14GB, this is not enough to run the e2e tests.
+      # Cleanup the disk, see upstream discussion https://github.com/actions/runner-images/issues/2840.
+      - name: Cleanup Disk Space
+        run: |
+          echo "Before removing files:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          echo "After removing files:"
+          df -h
+
       - name: Run e2e tests
         run: devbox run -- make e2e-test E2E_LABEL='provider:${{ inputs.provider }}' E2E_SKIP='${{ inputs.skip }}' E2E_FOCUS='${{ inputs.focus }}'
         env:


### PR DESCRIPTION
**What problem does this PR solve?**:
Noticed `no space left on device` [error messages](https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/actions/runs/9008250141/job/24773942020?pr=638#step:5:276) in e2e tests which cases the tests to fail.

This PR runs a step to clean up the disk, replicated from upstream issue https://github.com/actions/runner-images/issues/2840

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
