### PR TITLE
fix: log mutation failure errors

### DIFF
--- a/common/pkg/capi/clustertopology/patches/generator.go
+++ b/common/pkg/capi/clustertopology/patches/generator.go
@@ -59,6 +59,10 @@ func MutateIfApplicable[T runtime.Object](
 
 	// Apply the mutation.
 	if err := mutFn(typed); err != nil {
+		log.WithValues(
+			"objKind", obj.GetObjectKind().GroupVersionKind(),
+			"objName", obj.GetName(),
+		).Error(err, "failed to apply mutation")
 		return fmt.Errorf("failed to apply mutation: %w", err)
 	}
 


### PR DESCRIPTION
**What problem does this PR solve?**:
When a mutation fails the CAREN logs does not have any information. 
we have to refer to capi-controller's logs to see error returned by CAREN hooks. 
We should log mutation failure logs in CAREN.

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
By forcing an error and checking the logs.

```
E0510 02:17:47.751160       1 generator.go:65] "failed to apply mutation" err="forced logging of error" template="infrastructure.cluster.x-k8s.io/v1beta1/DockerMachineTemplate" holder="controlplane.cluster.x-k8s.io/v1beta1/KubeadmControlPlane/default/shalin-docker-jsbhl" holderRef={"apiVersion":"controlplane.cluster.x-k8s.io/v1beta1","kind":"KubeadmControlPlane","namespace":"default","name":"shalin-docker-jsbhl","fieldPath":"spec.machineTemplate.infrastructureRef"} variableName="clusterConfig" variableFieldPath=["controlPlane","docker","customImage"] variableValue="" objKind="infrastructure.cluster.x-k8s.io/v1beta1, Kind=DockerMachineTemplate" objName="docker-quick-start-control-plane"
```
**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
should we also log error at top level `GeneratePatches` functions. https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/blob/main/common/pkg/capi/clustertopology/handlers/mutation/meta.go#L103
