### PR TITLE
build: Make module-relative "go list -m" compatible with GOWORK

### DIFF
--- a/make/apis.mk
+++ b/make/apis.mk
@@ -51,7 +51,7 @@ api.sync.%: ; $(info $(M) syncing external API: $(PROVIDER_MODULE_$*)/$(PROVIDER
 	  --exclude='*webhook*.go' \
 	  --exclude='*test.go'     \
 	  --exclude='s3bucket.go'  \
-	  $$(cd $(PROVIDER_MODULE_DIR) && go list -m -f '{{ .Dir }}' $(PROVIDER_MODULE_$*))/$(PROVIDER_API_PATH_$*)/$(PROVIDER_API_VERSION_$*)/*.go \
+	  $$(cd $(PROVIDER_MODULE_DIR) && GOWORK=off go list -m -f '{{ .Dir }}' $(PROVIDER_MODULE_$*))/$(PROVIDER_API_PATH_$*)/$(PROVIDER_API_VERSION_$*)/*.go \
 	  $(PROVIDER_API_DIR)
 	find $(PROVIDER_API_DIR) -type d -exec chmod 0755 {} \;
 	find $(PROVIDER_API_DIR) -type f -exec chmod 0644 {} \;

--- a/make/clusterctl.mk
+++ b/make/clusterctl.mk
@@ -1,11 +1,11 @@
 # Copyright 2023 Nutanix. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-export CAPI_VERSION := $(shell go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api)
-export CAPD_VERSION := $(shell go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api/test)
-export CAPA_VERSION := $(shell cd hack/third-party/capa && go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-provider-aws/v2)
-export CAPX_VERSION := $(shell cd hack/third-party/capx && go list -m -f '{{ .Version }}' github.com/nutanix-cloud-native/cluster-api-provider-nutanix)
-export CAAPH_VERSION := $(shell cd hack/third-party/caaph && go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-addon-provider-helm)
+export CAPI_VERSION := $(shell GOWORK=off go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api)
+export CAPD_VERSION := $(shell GOWORK=off go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api/test)
+export CAPA_VERSION := $(shell cd hack/third-party/capa && GOWORK=off go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-provider-aws/v2)
+export CAPX_VERSION := $(shell cd hack/third-party/capx && GOWORK=off go list -m -f '{{ .Version }}' github.com/nutanix-cloud-native/cluster-api-provider-nutanix)
+export CAAPH_VERSION := $(shell cd hack/third-party/caaph && GOWORK=off go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-addon-provider-helm)
 
 # Leave Nutanix credentials empty here and set it when creating the clusters
 .PHONY: clusterctl.init

--- a/make/go.mk
+++ b/make/go.mk
@@ -137,9 +137,9 @@ endif
 .PHONY: lint.%
 lint.%: ## Runs golangci-lint for a specific module
 lint.%: ; $(info $(M) linting $* module)
-	$(if $(filter-out root,$*),cd $* && )golines -w $$(go list -tags e2e ./... | grep -v external | sed "s|^$$(go list -m)|.|")
+	$(if $(filter-out root,$*),cd $* && )golines -w $$(GOWORK=off go list -tags e2e ./... | grep -v external | sed "s|^$$(GOWORK=off go list -m)|.|")
 	$(if $(filter-out root,$*),cd $* && )golangci-lint run --fix --config=$(GOLANGCI_CONFIG_FILE)
-	$(if $(filter-out root,$*),cd $* && )golines -w $$(go list -tags e2e ./... | grep -v external | sed "s|^$$(go list -m)|.|")
+	$(if $(filter-out root,$*),cd $* && )golines -w $$(GOWORK=off go list -tags e2e ./... | grep -v external | sed "s|^$$(GOWORK=off go list -m)|.|")
 
 .PHONY: mod-tidy
 mod-tidy: ## Run go mod tidy for all modules

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	goruntime "runtime"
@@ -200,7 +201,7 @@ func getFilePathsToCAPICRDs() []string {
 func getModulePath(moduleDir, moduleName string) string {
 	cmd := exec.Command("go", "list", "-m", "-f", "{{ .Dir }}", moduleName)
 	cmd.Dir = moduleDir
-	cmd.Env = append(cmd.Env, "GOWORK=off")
+	cmd.Env = append(os.Environ(), "GOWORK=off")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		// We include the combined output because the error is usually

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -200,6 +200,7 @@ func getFilePathsToCAPICRDs() []string {
 func getModulePath(moduleDir, moduleName string) string {
 	cmd := exec.Command("go", "list", "-m", "-f", "{{ .Dir }}", moduleName)
 	cmd.Dir = moduleDir
+	cmd.Env = append(cmd.Env, "GOWORK=off")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		// We include the combined output because the error is usually


### PR DESCRIPTION
**What problem does this PR solve?**:
When GOWORK is enabled, "go list -m" always lists all modules in the workspace. To list the module for the current working directory, we disable GOWORK.

This is sound whether or not you use Go workspaces.

**Before**
```shell
> pwd
/capi-runtime-extensions/api
> go env GOWORK
/capi-runtime-extensions/go.work
> go list -m
github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix
github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api
github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common
github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/docs
github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/external/caaph
github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/external/capa
github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/external/capx
```

**After**
```shell
> pwd
/capi-runtime-extensions/api
> GOWORK=off go list -m
github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
It seems like `go list` is working as designed. Here's a vscode-go maintainer [recommending](https://github.com/golang/go/issues/50745#issuecomment-1509351885) `GOWORK=off` when "module separation" is needed.