### PR TITLE
refactor: Write configuration under /etc/caren

### DIFF
--- a/pkg/common/containerd.go
+++ b/pkg/common/containerd.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import "path/filepath"
+
+const (
+	// ConfigDirOnRemote is the directory on the machine where we write CAREN configuration (e.g. scripts, patches
+	// etc) as files.
+	// These files are later applied by one or more commands that run on the machine.
+	ConfigDirOnRemote = "/etc/caren"
+
+	// ContainerdScriptsDirOnRemote is the directory where we write scripts that relate to containerd as files.
+	// It is a subdirectory of the root config directory.
+	ContainerdScriptsDirOnRemote = ConfigDirOnRemote + "/containerd"
+
+	// ContainerdPatchDirOnRemote is the directory where we write containerd configuration patches as files.
+	// It is a subdirectory of the containerd config directory.
+	ContainerdPatchDirOnRemote = ConfigDirOnRemote + "/containerd/patches"
+)
+
+// ConfigFilePathOnRemote returns the absolute path of a file that CAREN deploys onto the machine.
+func ConfigFilePathOnRemote(relativePath string) string {
+	return filepath.Join(ConfigDirOnRemote, relativePath)
+}
+
+// ContainerPathOnRemote returns the absolute path of a script that relates to containerd on the machine.
+func ContainerdScriptPathOnRemote(relativePath string) string {
+	return filepath.Join(ContainerdScriptsDirOnRemote, relativePath)
+}
+
+// ContainerdPatchPathOnRemote returns the absolute path of a containerd configuration patch on the machine.
+func ContainerdPatchPathOnRemote(relativePath string) string {
+	return filepath.Join(ContainerdPatchDirOnRemote, relativePath)
+}

--- a/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/apply_patches.go
+++ b/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/apply_patches.go
@@ -9,12 +9,18 @@ import (
 	"text/template"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/common"
 )
 
 const (
-	tomlMergeImage                              = "ghcr.io/mesosphere/toml-merge:v0.2.0"
-	ContainerdPatchesDirOnRemote                = "/etc/caren/containerd/patches"
-	containerdApplyPatchesScriptOnRemote        = "/etc/caren/containerd/apply-patches.sh"
+	tomlMergeImage = "ghcr.io/mesosphere/toml-merge:v0.2.0"
+)
+
+var (
+	containerdApplyPatchesScriptOnRemote = common.ContainerdScriptPathOnRemote(
+		"apply-patches.sh",
+	)
 	containerdApplyPatchesScriptOnRemoteCommand = "/bin/bash " + containerdApplyPatchesScriptOnRemote
 )
 
@@ -32,7 +38,7 @@ func generateContainerdApplyPatchesScript() (bootstrapv1.File, string, error) {
 		PatchDir       string
 	}{
 		TOMLMergeImage: tomlMergeImage,
-		PatchDir:       ContainerdPatchesDirOnRemote,
+		PatchDir:       common.ContainerdPatchDirOnRemote,
 	}
 
 	var b bytes.Buffer

--- a/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/inject_test.go
+++ b/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/inject_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Generate Containerd apply patches and restart patches", func()
 
 func Test_generateContainerdApplyPatchesScript(t *testing.T) {
 	wantFile := bootstrapv1.File{
-		Path:        "/etc/containerd/apply-patches.sh",
+		Path:        "/etc/caren/containerd/apply-patches.sh",
 		Owner:       "",
 		Permissions: "0700",
 		Encoding:    "",
@@ -126,7 +126,7 @@ IFS=$'\n\t'
 # using -e does not work with globs.
 # See https://github.com/koalaman/shellcheck/wiki/SC2144 for an explanation of the following loop.
 patches_exist=false
-for file in "/etc/containerd/cre.d"/*.toml; do
+for file in "/etc/caren/containerd/patches"/*.toml; do
   if [ -e "${file}" ]; then
     patches_exist=true
   fi
@@ -135,7 +135,7 @@ for file in "/etc/containerd/cre.d"/*.toml; do
 done
 
 if [ "${patches_exist}" = false ]; then
-  echo "No TOML files found in the patch directory: /etc/containerd/cre.d - nothing to do"
+  echo "No TOML files found in the patch directory: /etc/caren/containerd/patches - nothing to do"
   exit 0
 fi
 
@@ -158,10 +158,10 @@ readonly tmp_ctr_mount_dir="$(mktemp -d)"
 
 # Mount the toml-merge image filesystem and run the toml-merge binary to merge the TOML files.
 ctr --namespace k8s.io images mount "${TOML_MERGE_IMAGE}" "${tmp_ctr_mount_dir}"
-"${tmp_ctr_mount_dir}/usr/local/bin/toml-merge" -i --patch-file "/etc/containerd/cre.d/*.toml" /etc/containerd/config.toml
+"${tmp_ctr_mount_dir}/usr/local/bin/toml-merge" -i --patch-file "/etc/caren/containerd/patches/*.toml" /etc/containerd/config.toml
 `,
 	}
-	wantCmd := "/bin/bash /etc/containerd/apply-patches.sh"
+	wantCmd := "/bin/bash /etc/caren/containerd/apply-patches.sh"
 	file, cmd, _ := generateContainerdApplyPatchesScript()
 	assert.Equal(t, wantFile, file)
 	assert.Equal(t, wantCmd, cmd)

--- a/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/inject_test.go
+++ b/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/inject_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Generate Containerd apply patches and restart patches", func()
 							"path", containerdApplyPatchesScriptOnRemote,
 						),
 						gomega.HaveKeyWithValue(
-							"path", ContainerdRestartScriptOnRemote,
+							"path", containerdRestartScriptOnRemote,
 						),
 					),
 				},
@@ -51,7 +51,7 @@ var _ = Describe("Generate Containerd apply patches and restart patches", func()
 					Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
 					ValueMatcher: gomega.HaveExactElements(
 						containerdApplyPatchesScriptOnRemoteCommand,
-						ContainerdRestartScriptOnRemoteCommand,
+						containerdRestartScriptOnRemoteCommand,
 					),
 				},
 			},
@@ -78,7 +78,7 @@ var _ = Describe("Generate Containerd apply patches and restart patches", func()
 							"path", containerdApplyPatchesScriptOnRemote,
 						),
 						gomega.HaveKeyWithValue(
-							"path", ContainerdRestartScriptOnRemote,
+							"path", containerdRestartScriptOnRemote,
 						),
 					),
 				},
@@ -87,7 +87,7 @@ var _ = Describe("Generate Containerd apply patches and restart patches", func()
 					Path:      "/spec/template/spec/preKubeadmCommands",
 					ValueMatcher: gomega.HaveExactElements(
 						containerdApplyPatchesScriptOnRemoteCommand,
-						ContainerdRestartScriptOnRemoteCommand,
+						containerdRestartScriptOnRemoteCommand,
 					),
 				},
 			},

--- a/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/restart.go
+++ b/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/restart.go
@@ -3,47 +3,25 @@
 package containerdapplypatchesandrestart
 
 import (
-	"bytes"
 	_ "embed"
-	"fmt"
-	"text/template"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 )
 
 const (
-	tomlMergeImage                              = "ghcr.io/mesosphere/toml-merge:v0.2.0"
-	containerdPatchesDirOnRemote                = "/etc/containerd/cre.d"
-	containerdApplyPatchesScriptOnRemote        = "/etc/containerd/apply-patches.sh"
-	containerdApplyPatchesScriptOnRemoteCommand = "/bin/bash " + containerdApplyPatchesScriptOnRemote
+	ContainerdRestartScriptOnRemote        = "/etc/containerd/restart.sh"
+	ContainerdRestartScriptOnRemoteCommand = "/bin/bash " + ContainerdRestartScriptOnRemote
 )
 
-//go:embed templates/containerd-apply-patches.sh.gotmpl
-var containerdApplyConfigPatchesScript []byte
+//go:embed templates/containerd-restart.sh
+var containerdRestartScript []byte
 
-func generateContainerdApplyPatchesScript() (bootstrapv1.File, string, error) {
-	t, err := template.New("").Parse(string(containerdApplyConfigPatchesScript))
-	if err != nil {
-		return bootstrapv1.File{}, "", fmt.Errorf("failed to parse go template: %w", err)
-	}
-
-	templateInput := struct {
-		TOMLMergeImage string
-		PatchDir       string
-	}{
-		TOMLMergeImage: tomlMergeImage,
-		PatchDir:       containerdPatchesDirOnRemote,
-	}
-
-	var b bytes.Buffer
-	err = t.Execute(&b, templateInput)
-	if err != nil {
-		return bootstrapv1.File{}, "", fmt.Errorf("failed executing template: %w", err)
-	}
-
+//nolint:gocritic // no need for named return values
+func generateContainerdRestartScript() (bootstrapv1.File, string) {
 	return bootstrapv1.File{
-		Path:        containerdApplyPatchesScriptOnRemote,
-		Content:     b.String(),
-		Permissions: "0700",
-	}, containerdApplyPatchesScriptOnRemoteCommand, nil
+			Path:        ContainerdRestartScriptOnRemote,
+			Content:     string(containerdRestartScript),
+			Permissions: "0700",
+		},
+		ContainerdRestartScriptOnRemoteCommand
 }

--- a/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/restart.go
+++ b/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/restart.go
@@ -6,11 +6,13 @@ import (
 	_ "embed"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/common"
 )
 
-const (
-	ContainerdRestartScriptOnRemote        = "/etc/containerd/restart.sh"
-	ContainerdRestartScriptOnRemoteCommand = "/bin/bash " + ContainerdRestartScriptOnRemote
+var (
+	containerdRestartScriptOnRemote        = common.ContainerdScriptPathOnRemote("restart.sh")
+	containerdRestartScriptOnRemoteCommand = "/bin/bash " + containerdRestartScriptOnRemote
 )
 
 //go:embed templates/containerd-restart.sh
@@ -19,9 +21,9 @@ var containerdRestartScript []byte
 //nolint:gocritic // no need for named return values
 func generateContainerdRestartScript() (bootstrapv1.File, string) {
 	return bootstrapv1.File{
-			Path:        ContainerdRestartScriptOnRemote,
+			Path:        containerdRestartScriptOnRemote,
 			Content:     string(containerdRestartScript),
 			Permissions: "0700",
 		},
-		ContainerdRestartScriptOnRemoteCommand
+		containerdRestartScriptOnRemoteCommand
 }

--- a/pkg/handlers/generic/mutation/containerdmetrics/metrics.go
+++ b/pkg/handlers/generic/mutation/containerdmetrics/metrics.go
@@ -4,23 +4,16 @@ package containerdmetrics
 
 import (
 	_ "embed"
-	"path"
 
 	cabpkv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
-)
 
-const (
-	// TODO Factor out this constant to a common package.
-	containerdPatchesDirOnRemote = "/etc/caren/containerd"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/common"
 )
 
 var (
 	//go:embed files/metrics-config.toml
 	metricsConfigDropIn             []byte
-	metricsConfigDropInFileOnRemote = path.Join(
-		containerdPatchesDirOnRemote,
-		"metrics-config.toml",
-	)
+	metricsConfigDropInFileOnRemote = common.ContainerdPatchPathOnRemote("metrics-config.toml")
 )
 
 func generateMetricsConfigDropIn() cabpkv1.File {

--- a/pkg/handlers/generic/mutation/containerdmetrics/metrics.go
+++ b/pkg/handlers/generic/mutation/containerdmetrics/metrics.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// TODO Factor out this constant to a common package.
-	containerdPatchesDirOnRemote = "/etc/containerd/cre.d"
+	containerdPatchesDirOnRemote = "/etc/caren/containerd"
 )
 
 var (

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_install_files.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_install_files.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	//nolint:gosec // Does not contain hard coded credentials.
-	installKubeletCredentialProvidersScriptOnRemote = "/etc/cre/install-kubelet-credential-providers.sh"
+	installKubeletCredentialProvidersScriptOnRemote = "/etc/caren/install-kubelet-credential-providers.sh"
 
 	installKubeletCredentialProvidersScriptOnRemoteCommand = "/bin/bash " + installKubeletCredentialProvidersScriptOnRemote
 

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_install_files.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_install_files.go
@@ -10,14 +10,18 @@ import (
 	"text/template"
 
 	cabpkv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/common"
+)
+
+var (
+	installKubeletCredentialProvidersScriptOnRemote = common.ConfigFilePathOnRemote(
+		"install-kubelet-credential-providers.sh")
+
+	installKubeletCredentialProvidersScriptOnRemoteCommand = "/bin/bash " + installKubeletCredentialProvidersScriptOnRemote
 )
 
 const (
-	//nolint:gosec // Does not contain hard coded credentials.
-	installKubeletCredentialProvidersScriptOnRemote = "/etc/caren/install-kubelet-credential-providers.sh"
-
-	installKubeletCredentialProvidersScriptOnRemoteCommand = "/bin/bash " + installKubeletCredentialProvidersScriptOnRemote
-
 	//nolint:gosec // Does not contain hard coded credentials.
 	dynamicCredentialProviderImage = "ghcr.io/mesosphere/dynamic-credential-provider:v0.5.0"
 

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Generate Image registry patches", func() {
 					Path:      "/spec/template/spec/kubeadmConfigSpec/files",
 					ValueMatcher: gomega.ContainElements(
 						gomega.HaveKeyWithValue(
-							"path", "/etc/cre/install-kubelet-credential-providers.sh",
+							"path", "/etc/caren/install-kubelet-credential-providers.sh",
 						),
 						gomega.HaveKeyWithValue(
 							"path", "/etc/kubernetes/image-credential-provider-config.yaml",
@@ -175,7 +175,7 @@ var _ = Describe("Generate Image registry patches", func() {
 					Operation: "add",
 					Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
 					ValueMatcher: gomega.ContainElement(
-						"/bin/bash /etc/cre/install-kubelet-credential-providers.sh",
+						"/bin/bash /etc/caren/install-kubelet-credential-providers.sh",
 					),
 				},
 				{
@@ -222,7 +222,7 @@ var _ = Describe("Generate Image registry patches", func() {
 					Path:      "/spec/template/spec/kubeadmConfigSpec/files",
 					ValueMatcher: gomega.ContainElements(
 						gomega.HaveKeyWithValue(
-							"path", "/etc/cre/install-kubelet-credential-providers.sh",
+							"path", "/etc/caren/install-kubelet-credential-providers.sh",
 						),
 						gomega.HaveKeyWithValue(
 							"path", "/etc/kubernetes/image-credential-provider-config.yaml",
@@ -239,7 +239,7 @@ var _ = Describe("Generate Image registry patches", func() {
 					Operation: "add",
 					Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
 					ValueMatcher: gomega.ContainElement(
-						"/bin/bash /etc/cre/install-kubelet-credential-providers.sh",
+						"/bin/bash /etc/caren/install-kubelet-credential-providers.sh",
 					),
 				},
 				{
@@ -286,7 +286,7 @@ var _ = Describe("Generate Image registry patches", func() {
 					Path:      "/spec/template/spec/files",
 					ValueMatcher: gomega.ContainElements(
 						gomega.HaveKeyWithValue(
-							"path", "/etc/cre/install-kubelet-credential-providers.sh",
+							"path", "/etc/caren/install-kubelet-credential-providers.sh",
 						),
 						gomega.HaveKeyWithValue(
 							"path", "/etc/kubernetes/image-credential-provider-config.yaml",
@@ -300,7 +300,7 @@ var _ = Describe("Generate Image registry patches", func() {
 					Operation: "add",
 					Path:      "/spec/template/spec/preKubeadmCommands",
 					ValueMatcher: gomega.ContainElement(
-						"/bin/bash /etc/cre/install-kubelet-credential-providers.sh",
+						"/bin/bash /etc/caren/install-kubelet-credential-providers.sh",
 					),
 				},
 				{
@@ -344,7 +344,7 @@ var _ = Describe("Generate Image registry patches", func() {
 					Path:      "/spec/template/spec/files",
 					ValueMatcher: gomega.ContainElements(
 						gomega.HaveKeyWithValue(
-							"path", "/etc/cre/install-kubelet-credential-providers.sh",
+							"path", "/etc/caren/install-kubelet-credential-providers.sh",
 						),
 						gomega.HaveKeyWithValue(
 							"path", "/etc/kubernetes/image-credential-provider-config.yaml",
@@ -361,7 +361,7 @@ var _ = Describe("Generate Image registry patches", func() {
 					Operation: "add",
 					Path:      "/spec/template/spec/preKubeadmCommands",
 					ValueMatcher: gomega.ContainElement(
-						"/bin/bash /etc/cre/install-kubelet-credential-providers.sh",
+						"/bin/bash /etc/caren/install-kubelet-credential-providers.sh",
 					),
 				},
 				{

--- a/pkg/handlers/generic/mutation/mirrors/inject_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/inject_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Generate Global mirror patches", func() {
 							"path", "/etc/containerd/certs.d/_default/hosts.toml",
 						),
 						gomega.HaveKeyWithValue(
-							"path", "/etc/containerd/cre.d/registry-config.toml",
+							"path", "/etc/caren/containerd/patches/registry-config.toml",
 						),
 					),
 				},
@@ -105,7 +105,7 @@ var _ = Describe("Generate Global mirror patches", func() {
 							"path", "/etc/certs/mirror.pem",
 						),
 						gomega.HaveKeyWithValue(
-							"path", "/etc/containerd/cre.d/registry-config.toml",
+							"path", "/etc/caren/containerd/patches/registry-config.toml",
 						),
 					),
 				},
@@ -140,7 +140,7 @@ var _ = Describe("Generate Global mirror patches", func() {
 							"path", "/etc/containerd/certs.d/_default/hosts.toml",
 						),
 						gomega.HaveKeyWithValue(
-							"path", "/etc/containerd/cre.d/registry-config.toml",
+							"path", "/etc/caren/containerd/patches/registry-config.toml",
 						),
 					),
 				},
@@ -183,7 +183,7 @@ var _ = Describe("Generate Global mirror patches", func() {
 							"path", "/etc/certs/mirror.pem",
 						),
 						gomega.HaveKeyWithValue(
-							"path", "/etc/containerd/cre.d/registry-config.toml",
+							"path", "/etc/caren/containerd/patches/registry-config.toml",
 						),
 					),
 				},

--- a/pkg/handlers/generic/mutation/mirrors/mirror.go
+++ b/pkg/handlers/generic/mutation/mirrors/mirror.go
@@ -17,14 +17,13 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/containerdapplypatchesandrestart"
 )
 
 const (
 	mirrorCACertPathOnRemote                = "/etc/certs/mirror.pem"
 	defaultRegistryMirrorConfigPathOnRemote = "/etc/containerd/certs.d/_default/hosts.toml"
 	secretKeyForMirrorCACert                = "ca.crt"
-
-	containerdPatchesDirOnRemote = "/etc/containerd/cre.d"
 )
 
 var (
@@ -38,7 +37,7 @@ var (
 	//go:embed templates/containerd-registry-config-drop-in.toml
 	containerdRegistryConfigDropIn             []byte
 	containerdRegistryConfigDropInFileOnRemote = path.Join(
-		containerdPatchesDirOnRemote,
+		containerdapplypatchesandrestart.ContainerdPatchesDirOnRemote,
 		"registry-config.toml",
 	)
 )

--- a/pkg/handlers/generic/mutation/mirrors/mirror.go
+++ b/pkg/handlers/generic/mutation/mirrors/mirror.go
@@ -17,7 +17,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
-	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/containerdapplypatchesandrestart"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/common"
 )
 
 const (
@@ -36,8 +36,7 @@ var (
 
 	//go:embed templates/containerd-registry-config-drop-in.toml
 	containerdRegistryConfigDropIn             []byte
-	containerdRegistryConfigDropInFileOnRemote = path.Join(
-		containerdapplypatchesandrestart.ContainerdPatchesDirOnRemote,
+	containerdRegistryConfigDropInFileOnRemote = common.ContainerdPatchPathOnRemote(
 		"registry-config.toml",
 	)
 )

--- a/pkg/handlers/generic/mutation/mirrors/mirror_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/mirror_test.go
@@ -161,7 +161,7 @@ func Test_generateMirrorCACertFile(t *testing.T) {
 func Test_generateContainerdRegistryConfigDropInFile(t *testing.T) {
 	want := []cabpkv1.File{
 		{
-			Path:        "/etc/containerd/cre.d/registry-config.toml",
+			Path:        "/etc/caren/containerd/patches/registry-config.toml",
 			Owner:       "",
 			Permissions: "0600",
 			Encoding:    "",


### PR DESCRIPTION
**What problem does this PR solve?**:
Previously, we wrote some configuration to /etc/cre. Now that the project name is CAREN, we should use /etc/caren.

We also wrote containerd configuration to /etc/containerd/cre.d, but this configuration is not read by containerd directly. Instead, it is read by a script that merges it to the primary containerd configuration. For that reason, this configuration belongs under /etc/caren.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
