### PR TITLE
test: Remove hard-coded text focus and label for e2e tests

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -77,8 +77,6 @@ func TestE2E(t *testing.T) {
 	ctrl.SetLogger(klog.Background())
 	RegisterFailHandler(Fail)
 	suiteConfig, reporterConfig := GinkgoConfiguration()
-	suiteConfig.LabelFilter = "provider:Docker && cni:Cilium && addonStrategy:ClusterResourceSet"
-	suiteConfig.FocusStrings = []string{"Quick start"}
 	RunSpecs(t, "caren-e2e", suiteConfig, reporterConfig)
 }
 


### PR DESCRIPTION
**What problem does this PR solve?**:
Removes hard-coded text focus and label for e2e tests.

This code took precedent over any configuration provided to ginkgo at
runtime, so only single e2e test matching both focus and labels could
run.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
I used dry-run (added in #666) to confirm that the removed code was the root cause.