### PR TITLE
e2e: use all CPUs running ginkgo tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,3 +71,10 @@ jobs:
           check_name: 'e2e test report'
           detailed_summary: true
           require_passed_tests: true
+
+      - if: success() || failure() # always run even if the previous step fails
+        name: 'Archive ${{ inputs.focus }} e2e artifacts'
+        uses: actions/upload-artifact@v4
+        with:
+          name: '${{ inputs.provider }} ${{ inputs.focus }} e2e artifacts'
+          path: '_artifacts/'

--- a/make/go.mk
+++ b/make/go.mk
@@ -76,7 +76,7 @@ bench.%: ; $(info $(M) running benchmarks$(if $(GOTEST_RUN), matching "$(GOTEST_
 
 E2E_DRYRUN ?= false
 E2E_VERBOSE ?= $(filter $(E2E_DRYRUN)$(CI),true) # If dry-run or CI, enable verbosity
-E2E_PARALLEL_NODES ?= $(if $(filter $(E2E_DRYRUN),true),1,$(shell nproc --ignore=1)) # Ginkgo cannot dry-run in parallel
+E2E_PARALLEL_NODES ?= $(if $(filter $(E2E_DRYRUN),true),1,$(shell nproc)) # Ginkgo cannot dry-run in parallel
 E2E_FLAKE_ATTEMPTS ?= 1
 E2E_CONF_FILE ?= $(REPO_ROOT)/test/e2e/config/caren.yaml
 E2E_CONF_FILE_ENVSUBST ?= $(basename $(E2E_CONF_FILE))-envsubst.yaml

--- a/test/e2e/framework/self_hosted.go
+++ b/test/e2e/framework/self_hosted.go
@@ -228,7 +228,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		)
 
 		By("Initializing the workload cluster")
-		// watchesCtx is used in log streaming to be able to get canceld via cancelWatches after ending the test suite.
+		// watchesCtx is used in log streaming to be able to get cancelled via cancelWatches after ending the test suite.
 		watchesCtx, cancelWatches := context.WithCancel(ctx)
 		defer cancelWatches()
 		clusterctl.InitManagementClusterAndWatchControllerLogs(

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/variables"
 )
 
-var _ = Describe("Quick start", Serial, func() {
+var _ = Describe("Quick start", func() {
 	for _, provider := range []string{"Docker", "AWS", "Nutanix"} {
 		lowercaseProvider := strings.ToLower(provider)
 		for _, cniProvider := range []string{"Cilium", "Calico"} {


### PR DESCRIPTION
**What problem does this PR solve?**:
There are 4 e2e tests running in 3 tests in parallel, effectively doubling the time to run e2e tests. Testing here to use all CPUs in the runners.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
