### PR TITLE
feat: Pull calico images from quay.io instead of docker hub

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/aws/crs-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/aws/crs-installation.yaml
@@ -32,5 +32,6 @@ data:
         bgp: Enabled
       nodeMetricsPort: 9091
       typhaMetricsPort: 9093
+      registry: quay.io/
 {{- end -}}
 {{- end -}}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/aws/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/aws/helm-addon-installation.yaml
@@ -20,4 +20,5 @@ data:
           nodeSelector: all(){{ printf "{{ end }}" }}
       nodeMetricsPort: 9091
       typhaMetricsPort: 9093
+      registry: quay.io/
 {{- end -}}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/docker/crs-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/docker/crs-installation.yaml
@@ -31,5 +31,6 @@ data:
           nodeSelector: all()
       nodeMetricsPort: 9091
       typhaMetricsPort: 9093
+      registry: quay.io/
 {{- end -}}
 {{- end -}}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/docker/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/docker/helm-addon-installation.yaml
@@ -19,4 +19,5 @@ data:
           nodeSelector: all(){{ printf "{{ end }}" }}
       nodeMetricsPort: 9091
       typhaMetricsPort: 9093
+      registry: quay.io/
 {{- end -}}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/nutanix/crs-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/nutanix/crs-installation.yaml
@@ -32,5 +32,6 @@ data:
         bgp: Enabled
       nodeMetricsPort: 9091
       typhaMetricsPort: 9093
+      registry: quay.io/
 {{- end -}}
 {{- end -}}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/nutanix/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cni/calico/manifests/nutanix/helm-addon-installation.yaml
@@ -20,4 +20,5 @@ data:
           nodeSelector: all(){{ printf "{{ end }}" }}
       nodeMetricsPort: 9091
       typhaMetricsPort: 9093
+      registry: quay.io/
 {{- end -}}


### PR DESCRIPTION
This reduces need for Docker Hub credentials by pulling images from
another registry that has Calico images pushed to on new Calico
releases.
