### PR TITLE
fix: Upgrade dynamic-credential-provider to v0.5.3

### DIFF
--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files_test.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files_test.go
@@ -267,7 +267,7 @@ credentialProviders:
 kind: DynamicCredentialProviderConfig
 mirror:
   endpoint: 98765432.dkr.ecr.us-east-1.amazonaws.com
-  credentialsStrategy: MirrorCredentialsOnly
+  credentialsStrategy: MirrorCredentialsFirst
 credentialProviderPluginBinDir: /etc/kubernetes/image-credential-provider/
 credentialProviders:
   apiVersion: kubelet.config.k8s.io/v1
@@ -315,7 +315,7 @@ credentialProviders:
 kind: DynamicCredentialProviderConfig
 mirror:
   endpoint: mymirror.com
-  credentialsStrategy: MirrorCredentialsOnly
+  credentialsStrategy: MirrorCredentialsFirst
 credentialProviderPluginBinDir: /etc/kubernetes/image-credential-provider/
 credentialProviders:
   apiVersion: kubelet.config.k8s.io/v1

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_install_files.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_install_files.go
@@ -23,7 +23,7 @@ var (
 
 const (
 	//nolint:gosec // Does not contain hard coded credentials.
-	dynamicCredentialProviderImage = "ghcr.io/mesosphere/dynamic-credential-provider:v0.5.0"
+	dynamicCredentialProviderImage = "ghcr.io/mesosphere/dynamic-credential-provider:v0.5.3"
 
 	//nolint:gosec // Does not contain hard coded credentials.
 	credentialProviderTargetDir = "/etc/kubernetes/image-credential-provider/"

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/templates/dynamic-credential-provider-config.yaml.gotmpl
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/templates/dynamic-credential-provider-config.yaml.gotmpl
@@ -4,7 +4,7 @@ kind: DynamicCredentialProviderConfig
 {{- if .Mirror }}
 mirror:
   endpoint: {{ .RegistryHost }}
-  credentialsStrategy: MirrorCredentialsOnly
+  credentialsStrategy: MirrorCredentialsFirst
 {{- break }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes falling back to origin registry if mirror does not contain
requested image.
