### PR TITLE
fix: Remove resource name stutter in default ClusterClasses

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/aws-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/aws-cluster-class.yaml
@@ -14,7 +14,7 @@ spec:
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
-      name: aws-quick-start-control-plane
+      name: aws-quick-start
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
@@ -51,12 +51,12 @@ spec:
           ref:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
             kind: KubeadmConfigTemplate
-            name: aws-quick-start-worker-bootstraptemplate
+            name: aws-quick-start-worker
         infrastructure:
           ref:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
             kind: AWSMachineTemplate
-            name: aws-quick-start-worker-machinetemplate
+            name: aws-quick-start-worker
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterTemplate
@@ -73,7 +73,7 @@ kind: KubeadmControlPlaneTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: aws
-  name: aws-quick-start-control-plane
+  name: aws-quick-start
 spec:
   template:
     spec:
@@ -113,7 +113,7 @@ kind: AWSMachineTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: aws
-  name: aws-quick-start-worker-machinetemplate
+  name: aws-quick-start-worker
 spec:
   template:
     spec:
@@ -125,7 +125,7 @@ kind: KubeadmConfigTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: aws
-  name: aws-quick-start-worker-bootstraptemplate
+  name: aws-quick-start-worker
 spec:
   template:
     spec:

--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml
@@ -19,7 +19,7 @@ spec:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DockerClusterTemplate
-      name: docker-quick-start-cluster
+      name: docker-quick-start
   patches:
   - external:
       discoverVariablesExtension: dockerclusterconfigvars.cluster-api-runtime-extensions-nutanix
@@ -37,19 +37,19 @@ spec:
           ref:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
             kind: KubeadmConfigTemplate
-            name: docker-quick-start-default-worker-bootstraptemplate
+            name: docker-quick-start-default-worker
         infrastructure:
           ref:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: DockerMachineTemplate
-            name: docker-quick-start-default-worker-machinetemplate
+            name: docker-quick-start-default-worker
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: docker
-  name: docker-quick-start-cluster
+  name: docker-quick-start
 spec:
   template:
     spec: {}
@@ -59,7 +59,7 @@ kind: KubeadmControlPlaneTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: docker
-  name: docker-quick-start-control-plane
+  name: docker-quick-start
 spec:
   template:
     spec:
@@ -88,7 +88,7 @@ kind: DockerMachineTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: docker
-  name: docker-quick-start-default-worker-machinetemplate
+  name: docker-quick-start-default-worker
 spec:
   template:
     spec:
@@ -101,7 +101,7 @@ kind: KubeadmConfigTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: docker
-  name: docker-quick-start-default-worker-bootstraptemplate
+  name: docker-quick-start-default-worker
 spec:
   template:
     spec:

--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
@@ -3,7 +3,7 @@ kind: KubeadmConfigTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: nutanix
-  name: nutanix-quick-start-kcfg-0
+  name: nutanix-quick-start
 spec:
   template:
     spec:
@@ -54,16 +54,16 @@ spec:
       ref:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: NutanixMachineTemplate
-        name: nutanix-quick-start-cp-nmt
+        name: nutanix-quick-start-control-plane
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
-      name: nutanix-quick-start-kcpt
+      name: nutanix-quick-start
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: NutanixClusterTemplate
-      name: nutanix-quick-start-nct
+      name: nutanix-quick-start
   patches:
   - external:
       discoverVariablesExtension: nutanixclusterconfigvars.cluster-api-runtime-extensions-nutanix
@@ -103,19 +103,19 @@ spec:
           ref:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
             kind: KubeadmConfigTemplate
-            name: nutanix-quick-start-kcfg-0
+            name: nutanix-quick-start-worker
         infrastructure:
           ref:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: NutanixMachineTemplate
-            name: nutanix-quick-start-md-nmt
+            name: nutanix-quick-start-worker
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlaneTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: nutanix
-  name: nutanix-quick-start-kcpt
+  name: nutanix-quick-start
 spec:
   template:
     spec:
@@ -163,7 +163,7 @@ kind: NutanixClusterTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: nutanix
-  name: nutanix-quick-start-nct
+  name: nutanix-quick-start
 spec:
   template:
     spec:
@@ -184,7 +184,7 @@ kind: NutanixMachineTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: nutanix
-  name: nutanix-quick-start-cp-nmt
+  name: nutanix-quick-start-control-plane
 spec:
   template:
     spec:
@@ -209,7 +209,7 @@ kind: NutanixMachineTemplate
 metadata:
   labels:
     cluster.x-k8s.io/provider: nutanix
-  name: nutanix-quick-start-md-nmt
+  name: nutanix-quick-start-control-plane
 spec:
   template:
     spec:


### PR DESCRIPTION
**What problem does this PR solve?**:
1. Removes sutter from resource names. The KubeadmControlPlaneTemplate for the aws-quick-start ClusterClass  is renamed from `aws-quick-start-control-plane` to `aws-quick-start`, because its Kind already makes it clear that it's for the control plane, and only one such resource exists.
2. Follows one convention for resource names in all default ClusterClasses. For example, the workers' NutanixMachineTemplate for the nutanix-quick-start ClusterClass is renamed from `nutanix-quick-start-md-nmt` to `nutanix-quick-start-workers`, because its `nmt` repeats the information in the Kind, and `-workers` clearly communicates that the resource is for workers, whereas `-md` does not.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
