### PR TITLE
fix: Post-process clusterconfig CRDs for supported CSI providers

### DIFF
--- a/api/v1alpha1/crds/caren.nutanix.com_awsclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_awsclusterconfigs.yaml
@@ -16,409 +16,349 @@ spec:
     singular: awsclusterconfig
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: AWSClusterConfig is the Schema for the awsclusterconfigs API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AWSClusterConfigSpec defines the desired state of ClusterConfig.
-            properties:
-              addons:
-                properties:
-                  ccm:
-                    description: CCM tells us to enable or disable the cloud provider
-                      interface.
-                    properties:
-                      credentials:
-                        description: A reference to the Secret for credential information
-                          for the target Prism Central instance
-                        properties:
-                          secretRef:
-                            description: A reference to the Secret containing the
-                              credentials used by the CCM provider.
-                            properties:
-                              name:
-                                description: |-
-                                  Name of the referent.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                minLength: 1
-                                type: string
-                            required:
-                            - name
-                            type: object
-                        required:
-                        - secretRef
-                        type: object
-                    type: object
-                  clusterAutoscaler:
-                    description: ClusterAutoscaler tells us to enable or disable the
-                      cluster-autoscaler addon.
-                    properties:
-                      strategy:
-                        description: |-
-                          Addon strategy used to deploy cluster-autoscaler to the management cluster
-                          targeting the workload cluster.
-                        enum:
-                        - ClusterResourceSet
-                        - HelmAddon
-                        type: string
-                    required:
-                    - strategy
-                    type: object
-                  cni:
-                    description: CNI required for providing CNI configuration.
-                    properties:
-                      provider:
-                        description: CNI provider to deploy.
-                        enum:
-                        - Calico
-                        - Cilium
-                        type: string
-                      strategy:
-                        description: Addon strategy used to deploy the CNI provider
-                          to the workload cluster.
-                        enum:
-                        - ClusterResourceSet
-                        - HelmAddon
-                        type: string
-                    required:
-                    - provider
-                    - strategy
-                    type: object
-                  csi:
-                    properties:
-                      defaultStorage:
-                        properties:
-                          providerName:
-                            description: Name of the CSI Provider for the default
-                              storage class.
-                            enum:
-                            - aws-ebs
-                            - nutanix
-                            - local-path
-                            type: string
-                          storageClassConfigName:
-                            description: Name of storage class config in any of the
-                              provider objects.
-                            minLength: 1
-                            type: string
-                        required:
-                        - providerName
-                        - storageClassConfigName
-                        type: object
-                      providers:
-                        items:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: AWSClusterConfig is the Schema for the awsclusterconfigs API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AWSClusterConfigSpec defines the desired state of ClusterConfig.
+              properties:
+                addons:
+                  properties:
+                    ccm:
+                      description: CCM tells us to enable or disable the cloud provider interface.
+                      properties:
+                        credentials:
+                          description: A reference to the Secret for credential information for the target Prism Central instance
                           properties:
-                            credentials:
-                              description: The reference to any secret used by the
-                                CSI Provider.
+                            secretRef:
+                              description: A reference to the Secret containing the credentials used by the CCM provider.
                               properties:
-                                secretRef:
-                                  description: A reference to the Secret containing
-                                    the credentials used by the CSI provider.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  minLength: 1
+                                  type: string
                               required:
-                              - secretRef
-                              type: object
-                            name:
-                              description: Name of the CSI Provider.
-                              enum:
-                              - aws-ebs
-                              - nutanix
-                              - local-path
-                              type: string
-                            storageClassConfig:
-                              description: StorageClassConfig is a list of storage
-                                class configurations for this CSI provider.
-                              items:
-                                properties:
-                                  allowExpansion:
-                                    default: false
-                                    description: If the storage class should allow
-                                      volume expanding
-                                    type: boolean
-                                  name:
-                                    description: Name of storage class config.
-                                    minLength: 1
-                                    type: string
-                                  parameters:
-                                    additionalProperties:
-                                      type: string
-                                    description: Parameters passed into the storage
-                                      class object.
-                                    type: object
-                                  reclaimPolicy:
-                                    default: Delete
-                                    description: PersistentVolumeReclaimPolicy describes
-                                      a policy for end-of-life maintenance of persistent
-                                      volumes.
-                                    enum:
-                                    - Delete
-                                    - Retain
-                                    - Recycle
-                                    type: string
-                                  volumeBindingMode:
-                                    default: WaitForFirstConsumer
-                                    description: VolumeBindingMode indicates how PersistentVolumeClaims
-                                      should be bound.
-                                    enum:
-                                    - Immediate
-                                    - WaitForFirstConsumer
-                                    type: string
-                                required:
                                 - name
-                                type: object
-                              type: array
-                            strategy:
-                              description: Addon strategy used to deploy the CSI provider
-                                to the workload cluster.
-                              enum:
-                              - ClusterResourceSet
-                              - HelmAddon
-                              type: string
+                              type: object
                           required:
-                          - name
-                          - strategy
+                            - secretRef
                           type: object
-                        minItems: 1
-                        type: array
-                    required:
-                    - defaultStorage
-                    - providers
-                    type: object
-                  nfd:
-                    description: NFD tells us to enable or disable the node feature
-                      discovery addon.
-                    properties:
-                      strategy:
-                        description: Addon strategy used to deploy Node Feature Discovery
-                          (NFD) to the workload cluster.
-                        enum:
-                        - ClusterResourceSet
-                        - HelmAddon
-                        type: string
-                    required:
-                    - strategy
-                    type: object
-                  serviceLoadBalancer:
-                    properties:
-                      provider:
-                        description: |-
-                          The LoadBalancer-type Service provider to deploy. Not required in infrastructures where
-                          the CCM acts as the provider.
-                        enum:
-                        - MetalLB
-                        type: string
-                    required:
-                    - provider
-                    type: object
-                type: object
-              aws:
-                description: AWS cluster configuration.
-                properties:
-                  controlPlaneLoadBalancer:
-                    description: AWSLoadBalancerSpec configures an AWS control-plane
-                      LoadBalancer.
-                    properties:
-                      scheme:
-                        default: internet-facing
-                        description: Scheme sets the scheme of the load balancer.
-                        enum:
-                        - internet-facing
-                        - internal
-                        type: string
-                    type: object
-                  network:
-                    description: AWS network configuration.
-                    properties:
-                      subnets:
-                        description: AWS Subnet configuration.
-                        items:
-                          description: SubnetSpec configures an AWS Subnet.
+                      type: object
+                    clusterAutoscaler:
+                      description: ClusterAutoscaler tells us to enable or disable the cluster-autoscaler addon.
+                      properties:
+                        strategy:
+                          description: |-
+                            Addon strategy used to deploy cluster-autoscaler to the management cluster
+                            targeting the workload cluster.
+                          enum:
+                            - ClusterResourceSet
+                            - HelmAddon
+                          type: string
+                      required:
+                        - strategy
+                      type: object
+                    cni:
+                      description: CNI required for providing CNI configuration.
+                      properties:
+                        provider:
+                          description: CNI provider to deploy.
+                          enum:
+                            - Calico
+                            - Cilium
+                          type: string
+                        strategy:
+                          description: Addon strategy used to deploy the CNI provider to the workload cluster.
+                          enum:
+                            - ClusterResourceSet
+                            - HelmAddon
+                          type: string
+                      required:
+                        - provider
+                        - strategy
+                      type: object
+                    csi:
+                      properties:
+                        defaultStorage:
                           properties:
-                            id:
-                              description: Existing Subnet ID to use for the cluster.
+                            providerName:
+                              description: Name of the CSI Provider for the default storage class.
+                              enum:
+                                - aws-ebs
+                              type: string
+                            storageClassConfigName:
+                              description: Name of storage class config in any of the provider objects.
                               minLength: 1
                               type: string
                           required:
-                          - id
+                            - providerName
+                            - storageClassConfigName
                           type: object
-                        type: array
-                      vpc:
-                        properties:
-                          id:
-                            description: Existing VPC ID to use for the cluster.
-                            minLength: 1
-                            type: string
-                        required:
-                        - id
-                        type: object
-                    type: object
-                  region:
-                    description: AWS region to create cluster in.
-                    type: string
-                type: object
-              controlPlane:
-                description: |-
-                  AWSControlPlaneConfigSpec defines the desired state of AWSNodeConfig.
-                  Place any configuration that can be applied to individual Nodes here.
-                  Otherwise, it should go into the ClusterConfigSpec.
-                properties:
-                  aws:
-                    properties:
-                      additionalSecurityGroups:
-                        items:
+                        providers:
+                          items:
+                            properties:
+                              credentials:
+                                description: The reference to any secret used by the CSI Provider.
+                                properties:
+                                  secretRef:
+                                    description: A reference to the Secret containing the credentials used by the CSI provider.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - secretRef
+                                type: object
+                              name:
+                                description: Name of the CSI Provider.
+                                enum:
+                                  - aws-ebs
+                                type: string
+                              storageClassConfig:
+                                description: StorageClassConfig is a list of storage class configurations for this CSI provider.
+                                items:
+                                  properties:
+                                    allowExpansion:
+                                      default: false
+                                      description: If the storage class should allow volume expanding
+                                      type: boolean
+                                    name:
+                                      description: Name of storage class config.
+                                      minLength: 1
+                                      type: string
+                                    parameters:
+                                      additionalProperties:
+                                        type: string
+                                      description: Parameters passed into the storage class object.
+                                      type: object
+                                    reclaimPolicy:
+                                      default: Delete
+                                      description: PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes.
+                                      enum:
+                                        - Delete
+                                        - Retain
+                                        - Recycle
+                                      type: string
+                                    volumeBindingMode:
+                                      default: WaitForFirstConsumer
+                                      description: VolumeBindingMode indicates how PersistentVolumeClaims should be bound.
+                                      enum:
+                                        - Immediate
+                                        - WaitForFirstConsumer
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                              strategy:
+                                description: Addon strategy used to deploy the CSI provider to the workload cluster.
+                                enum:
+                                  - ClusterResourceSet
+                                  - HelmAddon
+                                type: string
+                            required:
+                              - name
+                              - strategy
+                            type: object
+                          minItems: 1
+                          type: array
+                      required:
+                        - defaultStorage
+                        - providers
+                      type: object
+                    nfd:
+                      description: NFD tells us to enable or disable the node feature discovery addon.
+                      properties:
+                        strategy:
+                          description: Addon strategy used to deploy Node Feature Discovery (NFD) to the workload cluster.
+                          enum:
+                            - ClusterResourceSet
+                            - HelmAddon
+                          type: string
+                      required:
+                        - strategy
+                      type: object
+                    serviceLoadBalancer:
+                      properties:
+                        provider:
+                          description: |-
+                            The LoadBalancer-type Service provider to deploy. Not required in infrastructures where
+                            the CCM acts as the provider.
+                          enum:
+                            - MetalLB
+                          type: string
+                      required:
+                        - provider
+                      type: object
+                  type: object
+                aws:
+                  description: AWS cluster configuration.
+                  properties:
+                    controlPlaneLoadBalancer:
+                      description: AWSLoadBalancerSpec configures an AWS control-plane LoadBalancer.
+                      properties:
+                        scheme:
+                          default: internet-facing
+                          description: Scheme sets the scheme of the load balancer.
+                          enum:
+                            - internet-facing
+                            - internal
+                          type: string
+                      type: object
+                    network:
+                      description: AWS network configuration.
+                      properties:
+                        subnets:
+                          description: AWS Subnet configuration.
+                          items:
+                            description: SubnetSpec configures an AWS Subnet.
+                            properties:
+                              id:
+                                description: Existing Subnet ID to use for the cluster.
+                                minLength: 1
+                                type: string
+                            required:
+                              - id
+                            type: object
+                          type: array
+                        vpc:
                           properties:
                             id:
-                              description: ID is the id of the security group
+                              description: Existing VPC ID to use for the cluster.
+                              minLength: 1
                               type: string
-                          type: object
-                        type: array
-                      ami:
-                        description: |-
-                          AMI or AMI Lookup arguments for machine image of a AWS machine.
-                          If both AMI ID and AMI lookup arguments are provided then AMI ID takes precedence
-                        properties:
-                          id:
-                            description: AMI ID is the reference to the AMI from which
-                              to create the machine instance.
-                            type: string
-                          lookup:
-                            description: Lookup is the lookup arguments for the AMI.
-                            properties:
-                              baseOS:
-                                description: The name of the base os for image lookup
-                                type: string
-                              format:
-                                description: |-
-                                  AMI naming format. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the
-                                  base OS and kubernetes version.
-                                example: capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
-                                type: string
-                              org:
-                                description: The AWS Organization ID to use for image
-                                  lookup.
-                                type: string
-                            type: object
-                        type: object
-                      iamInstanceProfile:
-                        default: control-plane.cluster-api-provider-aws.sigs.k8s.io
-                        description: The IAM instance profile to use for the cluster
-                          Machines.
-                        type: string
-                      instanceType:
-                        default: m5.xlarge
-                        type: string
-                    type: object
-                type: object
-              encryptionAtRest:
-                description: |-
-                  EncryptionAtRest defines the configuration to enable encryption at REST
-                  This configuration is used by API server to encrypt data before storing it in ETCD.
-                  Currently the encryption only enabled for secrets and configmaps.
-                properties:
-                  providers:
-                    default:
-                    - aescbc: {}
-                    description: Encryption providers
-                    items:
-                      properties:
-                        aescbc:
-                          type: object
-                        secretbox:
+                          required:
+                            - id
                           type: object
                       type: object
-                    maxItems: 1
-                    type: array
-                type: object
-              etcd:
-                properties:
-                  image:
-                    description: Image required for overriding etcd image details.
-                    properties:
-                      repository:
-                        description: Repository is used to override the image repository
-                          to pull from.
-                        pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
-                        type: string
-                      tag:
-                        description: Tag is used to override the default image tag.
-                        pattern: ^[\w][\w.-]{0,127}$
-                        type: string
-                    type: object
-                type: object
-              extraAPIServerCertSANs:
-                description: Extra Subject Alternative Names for the API Server signing
-                  cert.
-                items:
-                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                  type: string
-                type: array
-                uniqueItems: true
-              globalImageRegistryMirror:
-                description: GlobalImageRegistryMirror sets default mirror configuration
-                  for all the image registries.
-                properties:
-                  credentials:
-                    description: Credentials and CA certificate for the image registry
-                      mirror
-                    properties:
-                      secretRef:
-                        description: |-
-                          A reference to the Secret containing the registry credentials and optional CA certificate
-                          using the keys `username`, `password` and `ca.crt`.
-                          This credentials Secret is not required for some registries, e.g. ECR.
+                    region:
+                      description: AWS region to create cluster in.
+                      type: string
+                  type: object
+                controlPlane:
+                  description: |-
+                    AWSControlPlaneConfigSpec defines the desired state of AWSNodeConfig.
+                    Place any configuration that can be applied to individual Nodes here.
+                    Otherwise, it should go into the ClusterConfigSpec.
+                  properties:
+                    aws:
+                      properties:
+                        additionalSecurityGroups:
+                          items:
+                            properties:
+                              id:
+                                description: ID is the id of the security group
+                                type: string
+                            type: object
+                          type: array
+                        ami:
+                          description: |-
+                            AMI or AMI Lookup arguments for machine image of a AWS machine.
+                            If both AMI ID and AMI lookup arguments are provided then AMI ID takes precedence
+                          properties:
+                            id:
+                              description: AMI ID is the reference to the AMI from which to create the machine instance.
+                              type: string
+                            lookup:
+                              description: Lookup is the lookup arguments for the AMI.
+                              properties:
+                                baseOS:
+                                  description: The name of the base os for image lookup
+                                  type: string
+                                format:
+                                  description: |-
+                                    AMI naming format. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the
+                                    base OS and kubernetes version.
+                                  example: capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-*
+                                  type: string
+                                org:
+                                  description: The AWS Organization ID to use for image lookup.
+                                  type: string
+                              type: object
+                          type: object
+                        iamInstanceProfile:
+                          default: control-plane.cluster-api-provider-aws.sigs.k8s.io
+                          description: The IAM instance profile to use for the cluster Machines.
+                          type: string
+                        instanceType:
+                          default: m5.xlarge
+                          type: string
+                      type: object
+                  type: object
+                encryptionAtRest:
+                  description: |-
+                    EncryptionAtRest defines the configuration to enable encryption at REST
+                    This configuration is used by API server to encrypt data before storing it in ETCD.
+                    Currently the encryption only enabled for secrets and configmaps.
+                  properties:
+                    providers:
+                      default:
+                        - aescbc: {}
+                      description: Encryption providers
+                      items:
                         properties:
-                          name:
-                            description: |-
-                              Name of the referent.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            minLength: 1
-                            type: string
-                        required:
-                        - name
+                          aescbc:
+                            type: object
+                          secretbox:
+                            type: object
                         type: object
-                    type: object
-                  url:
-                    description: Registry mirror URL.
-                    format: uri
-                    pattern: ^https?://
+                      maxItems: 1
+                      type: array
+                  type: object
+                etcd:
+                  properties:
+                    image:
+                      description: Image required for overriding etcd image details.
+                      properties:
+                        repository:
+                          description: Repository is used to override the image repository to pull from.
+                          pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
+                          type: string
+                        tag:
+                          description: Tag is used to override the default image tag.
+                          pattern: ^[\w][\w.-]{0,127}$
+                          type: string
+                      type: object
+                  type: object
+                extraAPIServerCertSANs:
+                  description: Extra Subject Alternative Names for the API Server signing cert.
+                  items:
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
-                required:
-                - url
-                type: object
-              imageRegistries:
-                items:
+                  type: array
+                  uniqueItems: true
+                globalImageRegistryMirror:
+                  description: GlobalImageRegistryMirror sets default mirror configuration for all the image registries.
                   properties:
                     credentials:
-                      description: Credentials and CA certificate for the image registry
+                      description: Credentials and CA certificate for the image registry mirror
                       properties:
                         secretRef:
                           description: |-
@@ -433,74 +373,104 @@ spec:
                               minLength: 1
                               type: string
                           required:
-                          - name
+                            - name
                           type: object
                       type: object
                     url:
-                      description: Registry URL.
+                      description: Registry mirror URL.
                       format: uri
                       pattern: ^https?://
                       type: string
                   required:
-                  - url
+                    - url
                   type: object
-                type: array
-              kubernetesImageRepository:
-                description: Sets the Kubernetes image repository used for the KubeadmControlPlane.
-                pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
-                type: string
-              proxy:
-                description: HTTPProxy required for providing proxy configuration.
-                properties:
-                  additionalNo:
-                    description: |-
-                      AdditionalNo Proxy list that will be added to the automatically calculated
-                      values that will apply no_proxy configuration for cluster internal network.
-                      Default values: localhost,127.0.0.1,<POD_NETWORK>,<SERVICE_NETWORK>,kubernetes
-                        ,kubernetes.default,.svc,.svc.<SERVICE_DOMAIN>
-                    items:
-                      type: string
-                    type: array
-                  http:
-                    description: HTTP proxy value.
-                    type: string
-                  https:
-                    description: HTTPS proxy value.
-                    type: string
-                type: object
-              users:
-                items:
-                  description: User defines the input for a generated user in cloud-init.
+                imageRegistries:
+                  items:
+                    properties:
+                      credentials:
+                        description: Credentials and CA certificate for the image registry
+                        properties:
+                          secretRef:
+                            description: |-
+                              A reference to the Secret containing the registry credentials and optional CA certificate
+                              using the keys `username`, `password` and `ca.crt`.
+                              This credentials Secret is not required for some registries, e.g. ECR.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                minLength: 1
+                                type: string
+                            required:
+                              - name
+                            type: object
+                        type: object
+                      url:
+                        description: Registry URL.
+                        format: uri
+                        pattern: ^https?://
+                        type: string
+                    required:
+                      - url
+                    type: object
+                  type: array
+                kubernetesImageRepository:
+                  description: Sets the Kubernetes image repository used for the KubeadmControlPlane.
+                  pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
+                  type: string
+                proxy:
+                  description: HTTPProxy required for providing proxy configuration.
                   properties:
-                    hashedPassword:
+                    additionalNo:
                       description: |-
-                        HashedPassword is a hashed password for the user, formatted as described
-                        by the crypt(5) man page. See your distribution's documentation for
-                        instructions to create a hashed password.
-                        An empty string is not marshalled, because it is not a valid value.
-                      type: string
-                    name:
-                      description: Name specifies the user name.
-                      type: string
-                    sshAuthorizedKeys:
-                      description: |-
-                        SSHAuthorizedKeys is a list of public SSH keys to write to the
-                        machine. Use the corresponding private SSH keys to authenticate. See SSH
-                        documentation for instructions to create a key pair.
+                        AdditionalNo Proxy list that will be added to the automatically calculated
+                        values that will apply no_proxy configuration for cluster internal network.
+                        Default values: localhost,127.0.0.1,<POD_NETWORK>,<SERVICE_NETWORK>,kubernetes
+                          ,kubernetes.default,.svc,.svc.<SERVICE_DOMAIN>
                       items:
                         type: string
                       type: array
-                    sudo:
-                      description: |-
-                        Sudo is a sudo user specification, formatted as described in the sudo
-                        documentation.
-                        An empty string is not marshalled, because it is not a valid value.
+                    http:
+                      description: HTTP proxy value.
                       type: string
-                  required:
-                  - name
+                    https:
+                      description: HTTPS proxy value.
+                      type: string
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
+                users:
+                  items:
+                    description: User defines the input for a generated user in cloud-init.
+                    properties:
+                      hashedPassword:
+                        description: |-
+                          HashedPassword is a hashed password for the user, formatted as described
+                          by the crypt(5) man page. See your distribution's documentation for
+                          instructions to create a hashed password.
+                          An empty string is not marshalled, because it is not a valid value.
+                        type: string
+                      name:
+                        description: Name specifies the user name.
+                        type: string
+                      sshAuthorizedKeys:
+                        description: |-
+                          SSHAuthorizedKeys is a list of public SSH keys to write to the
+                          machine. Use the corresponding private SSH keys to authenticate. See SSH
+                          documentation for instructions to create a key pair.
+                        items:
+                          type: string
+                        type: array
+                      sudo:
+                        description: |-
+                          Sudo is a sudo user specification, formatted as described in the sudo
+                          documentation.
+                          An empty string is not marshalled, because it is not a valid value.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/api/v1alpha1/crds/caren.nutanix.com_dockerclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_dockerclusterconfigs.yaml
@@ -16,331 +16,274 @@ spec:
     singular: dockerclusterconfig
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: DockerClusterConfig is the Schema for the dockerclusterconfigs
-          API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: DockerClusterConfigSpec defines the desired state of DockerClusterConfig.
-            properties:
-              addons:
-                properties:
-                  ccm:
-                    description: CCM tells us to enable or disable the cloud provider
-                      interface.
-                    properties:
-                      credentials:
-                        description: A reference to the Secret for credential information
-                          for the target Prism Central instance
-                        properties:
-                          secretRef:
-                            description: A reference to the Secret containing the
-                              credentials used by the CCM provider.
-                            properties:
-                              name:
-                                description: |-
-                                  Name of the referent.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                minLength: 1
-                                type: string
-                            required:
-                            - name
-                            type: object
-                        required:
-                        - secretRef
-                        type: object
-                    type: object
-                  clusterAutoscaler:
-                    description: ClusterAutoscaler tells us to enable or disable the
-                      cluster-autoscaler addon.
-                    properties:
-                      strategy:
-                        description: |-
-                          Addon strategy used to deploy cluster-autoscaler to the management cluster
-                          targeting the workload cluster.
-                        enum:
-                        - ClusterResourceSet
-                        - HelmAddon
-                        type: string
-                    required:
-                    - strategy
-                    type: object
-                  cni:
-                    description: CNI required for providing CNI configuration.
-                    properties:
-                      provider:
-                        description: CNI provider to deploy.
-                        enum:
-                        - Calico
-                        - Cilium
-                        type: string
-                      strategy:
-                        description: Addon strategy used to deploy the CNI provider
-                          to the workload cluster.
-                        enum:
-                        - ClusterResourceSet
-                        - HelmAddon
-                        type: string
-                    required:
-                    - provider
-                    - strategy
-                    type: object
-                  csi:
-                    properties:
-                      defaultStorage:
-                        properties:
-                          providerName:
-                            description: Name of the CSI Provider for the default
-                              storage class.
-                            enum:
-                            - aws-ebs
-                            - nutanix
-                            - local-path
-                            type: string
-                          storageClassConfigName:
-                            description: Name of storage class config in any of the
-                              provider objects.
-                            minLength: 1
-                            type: string
-                        required:
-                        - providerName
-                        - storageClassConfigName
-                        type: object
-                      providers:
-                        items:
-                          properties:
-                            credentials:
-                              description: The reference to any secret used by the
-                                CSI Provider.
-                              properties:
-                                secretRef:
-                                  description: A reference to the Secret containing
-                                    the credentials used by the CSI provider.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                              required:
-                              - secretRef
-                              type: object
-                            name:
-                              description: Name of the CSI Provider.
-                              enum:
-                              - aws-ebs
-                              - nutanix
-                              - local-path
-                              type: string
-                            storageClassConfig:
-                              description: StorageClassConfig is a list of storage
-                                class configurations for this CSI provider.
-                              items:
-                                properties:
-                                  allowExpansion:
-                                    default: false
-                                    description: If the storage class should allow
-                                      volume expanding
-                                    type: boolean
-                                  name:
-                                    description: Name of storage class config.
-                                    minLength: 1
-                                    type: string
-                                  parameters:
-                                    additionalProperties:
-                                      type: string
-                                    description: Parameters passed into the storage
-                                      class object.
-                                    type: object
-                                  reclaimPolicy:
-                                    default: Delete
-                                    description: PersistentVolumeReclaimPolicy describes
-                                      a policy for end-of-life maintenance of persistent
-                                      volumes.
-                                    enum:
-                                    - Delete
-                                    - Retain
-                                    - Recycle
-                                    type: string
-                                  volumeBindingMode:
-                                    default: WaitForFirstConsumer
-                                    description: VolumeBindingMode indicates how PersistentVolumeClaims
-                                      should be bound.
-                                    enum:
-                                    - Immediate
-                                    - WaitForFirstConsumer
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              type: array
-                            strategy:
-                              description: Addon strategy used to deploy the CSI provider
-                                to the workload cluster.
-                              enum:
-                              - ClusterResourceSet
-                              - HelmAddon
-                              type: string
-                          required:
-                          - name
-                          - strategy
-                          type: object
-                        minItems: 1
-                        type: array
-                    required:
-                    - defaultStorage
-                    - providers
-                    type: object
-                  nfd:
-                    description: NFD tells us to enable or disable the node feature
-                      discovery addon.
-                    properties:
-                      strategy:
-                        description: Addon strategy used to deploy Node Feature Discovery
-                          (NFD) to the workload cluster.
-                        enum:
-                        - ClusterResourceSet
-                        - HelmAddon
-                        type: string
-                    required:
-                    - strategy
-                    type: object
-                  serviceLoadBalancer:
-                    properties:
-                      provider:
-                        description: |-
-                          The LoadBalancer-type Service provider to deploy. Not required in infrastructures where
-                          the CCM acts as the provider.
-                        enum:
-                        - MetalLB
-                        type: string
-                    required:
-                    - provider
-                    type: object
-                type: object
-              controlPlane:
-                description: DockerNodeConfigSpec defines the desired state of DockerNodeSpec.
-                properties:
-                  docker:
-                    properties:
-                      customImage:
-                        description: Custom OCI image for control plane and worker
-                          Nodes.
-                        pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*(:[\w][\w.-]{0,127})?(@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9A-Fa-f]{32,})?$
-                        type: string
-                    type: object
-                type: object
-              docker:
-                type: object
-              encryptionAtRest:
-                description: |-
-                  EncryptionAtRest defines the configuration to enable encryption at REST
-                  This configuration is used by API server to encrypt data before storing it in ETCD.
-                  Currently the encryption only enabled for secrets and configmaps.
-                properties:
-                  providers:
-                    default:
-                    - aescbc: {}
-                    description: Encryption providers
-                    items:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DockerClusterConfig is the Schema for the dockerclusterconfigs API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DockerClusterConfigSpec defines the desired state of DockerClusterConfig.
+              properties:
+                addons:
+                  properties:
+                    ccm:
+                      description: CCM tells us to enable or disable the cloud provider interface.
                       properties:
-                        aescbc:
-                          type: object
-                        secretbox:
+                        credentials:
+                          description: A reference to the Secret for credential information for the target Prism Central instance
+                          properties:
+                            secretRef:
+                              description: A reference to the Secret containing the credentials used by the CCM provider.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - secretRef
                           type: object
                       type: object
-                    maxItems: 1
-                    type: array
-                type: object
-              etcd:
-                properties:
-                  image:
-                    description: Image required for overriding etcd image details.
-                    properties:
-                      repository:
-                        description: Repository is used to override the image repository
-                          to pull from.
-                        pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
-                        type: string
-                      tag:
-                        description: Tag is used to override the default image tag.
-                        pattern: ^[\w][\w.-]{0,127}$
-                        type: string
-                    type: object
-                type: object
-              extraAPIServerCertSANs:
-                description: |-
-                  Extra Subject Alternative Names for the API Server signing cert.
-                  For the Docker provider, the following default SANs will always be added:
-                  - localhost
-                  - 127.0.0.1
-                  - 0.0.0.0
-                  - host.docker.internal
-                items:
-                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                  type: string
-                type: array
-                uniqueItems: true
-              globalImageRegistryMirror:
-                description: GlobalImageRegistryMirror sets default mirror configuration
-                  for all the image registries.
-                properties:
-                  credentials:
-                    description: Credentials and CA certificate for the image registry
-                      mirror
-                    properties:
-                      secretRef:
-                        description: |-
-                          A reference to the Secret containing the registry credentials and optional CA certificate
-                          using the keys `username`, `password` and `ca.crt`.
-                          This credentials Secret is not required for some registries, e.g. ECR.
+                    clusterAutoscaler:
+                      description: ClusterAutoscaler tells us to enable or disable the cluster-autoscaler addon.
+                      properties:
+                        strategy:
+                          description: |-
+                            Addon strategy used to deploy cluster-autoscaler to the management cluster
+                            targeting the workload cluster.
+                          enum:
+                            - ClusterResourceSet
+                            - HelmAddon
+                          type: string
+                      required:
+                        - strategy
+                      type: object
+                    cni:
+                      description: CNI required for providing CNI configuration.
+                      properties:
+                        provider:
+                          description: CNI provider to deploy.
+                          enum:
+                            - Calico
+                            - Cilium
+                          type: string
+                        strategy:
+                          description: Addon strategy used to deploy the CNI provider to the workload cluster.
+                          enum:
+                            - ClusterResourceSet
+                            - HelmAddon
+                          type: string
+                      required:
+                        - provider
+                        - strategy
+                      type: object
+                    csi:
+                      properties:
+                        defaultStorage:
+                          properties:
+                            providerName:
+                              description: Name of the CSI Provider for the default storage class.
+                              enum:
+                                - local-path
+                              type: string
+                            storageClassConfigName:
+                              description: Name of storage class config in any of the provider objects.
+                              minLength: 1
+                              type: string
+                          required:
+                            - providerName
+                            - storageClassConfigName
+                          type: object
+                        providers:
+                          items:
+                            properties:
+                              credentials:
+                                description: The reference to any secret used by the CSI Provider.
+                                properties:
+                                  secretRef:
+                                    description: A reference to the Secret containing the credentials used by the CSI provider.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - secretRef
+                                type: object
+                              name:
+                                description: Name of the CSI Provider.
+                                enum:
+                                  - local-path
+                                type: string
+                              storageClassConfig:
+                                description: StorageClassConfig is a list of storage class configurations for this CSI provider.
+                                items:
+                                  properties:
+                                    allowExpansion:
+                                      default: false
+                                      description: If the storage class should allow volume expanding
+                                      type: boolean
+                                    name:
+                                      description: Name of storage class config.
+                                      minLength: 1
+                                      type: string
+                                    parameters:
+                                      additionalProperties:
+                                        type: string
+                                      description: Parameters passed into the storage class object.
+                                      type: object
+                                    reclaimPolicy:
+                                      default: Delete
+                                      description: PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes.
+                                      enum:
+                                        - Delete
+                                        - Retain
+                                        - Recycle
+                                      type: string
+                                    volumeBindingMode:
+                                      default: WaitForFirstConsumer
+                                      description: VolumeBindingMode indicates how PersistentVolumeClaims should be bound.
+                                      enum:
+                                        - Immediate
+                                        - WaitForFirstConsumer
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                              strategy:
+                                description: Addon strategy used to deploy the CSI provider to the workload cluster.
+                                enum:
+                                  - ClusterResourceSet
+                                  - HelmAddon
+                                type: string
+                            required:
+                              - name
+                              - strategy
+                            type: object
+                          minItems: 1
+                          type: array
+                      required:
+                        - defaultStorage
+                        - providers
+                      type: object
+                    nfd:
+                      description: NFD tells us to enable or disable the node feature discovery addon.
+                      properties:
+                        strategy:
+                          description: Addon strategy used to deploy Node Feature Discovery (NFD) to the workload cluster.
+                          enum:
+                            - ClusterResourceSet
+                            - HelmAddon
+                          type: string
+                      required:
+                        - strategy
+                      type: object
+                    serviceLoadBalancer:
+                      properties:
+                        provider:
+                          description: |-
+                            The LoadBalancer-type Service provider to deploy. Not required in infrastructures where
+                            the CCM acts as the provider.
+                          enum:
+                            - MetalLB
+                          type: string
+                      required:
+                        - provider
+                      type: object
+                  type: object
+                controlPlane:
+                  description: DockerNodeConfigSpec defines the desired state of DockerNodeSpec.
+                  properties:
+                    docker:
+                      properties:
+                        customImage:
+                          description: Custom OCI image for control plane and worker Nodes.
+                          pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*(:[\w][\w.-]{0,127})?(@[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9A-Fa-f]{32,})?$
+                          type: string
+                      type: object
+                  type: object
+                docker:
+                  type: object
+                encryptionAtRest:
+                  description: |-
+                    EncryptionAtRest defines the configuration to enable encryption at REST
+                    This configuration is used by API server to encrypt data before storing it in ETCD.
+                    Currently the encryption only enabled for secrets and configmaps.
+                  properties:
+                    providers:
+                      default:
+                        - aescbc: {}
+                      description: Encryption providers
+                      items:
                         properties:
-                          name:
-                            description: |-
-                              Name of the referent.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            minLength: 1
-                            type: string
-                        required:
-                        - name
+                          aescbc:
+                            type: object
+                          secretbox:
+                            type: object
                         type: object
-                    type: object
-                  url:
-                    description: Registry mirror URL.
-                    format: uri
-                    pattern: ^https?://
+                      maxItems: 1
+                      type: array
+                  type: object
+                etcd:
+                  properties:
+                    image:
+                      description: Image required for overriding etcd image details.
+                      properties:
+                        repository:
+                          description: Repository is used to override the image repository to pull from.
+                          pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
+                          type: string
+                        tag:
+                          description: Tag is used to override the default image tag.
+                          pattern: ^[\w][\w.-]{0,127}$
+                          type: string
+                      type: object
+                  type: object
+                extraAPIServerCertSANs:
+                  description: |-
+                    Extra Subject Alternative Names for the API Server signing cert.
+                    For the Docker provider, the following default SANs will always be added:
+                    - localhost
+                    - 127.0.0.1
+                    - 0.0.0.0
+                    - host.docker.internal
+                  items:
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
-                required:
-                - url
-                type: object
-              imageRegistries:
-                items:
+                  type: array
+                  uniqueItems: true
+                globalImageRegistryMirror:
+                  description: GlobalImageRegistryMirror sets default mirror configuration for all the image registries.
                   properties:
                     credentials:
-                      description: Credentials and CA certificate for the image registry
+                      description: Credentials and CA certificate for the image registry mirror
                       properties:
                         secretRef:
                           description: |-
@@ -355,74 +298,104 @@ spec:
                               minLength: 1
                               type: string
                           required:
-                          - name
+                            - name
                           type: object
                       type: object
                     url:
-                      description: Registry URL.
+                      description: Registry mirror URL.
                       format: uri
                       pattern: ^https?://
                       type: string
                   required:
-                  - url
+                    - url
                   type: object
-                type: array
-              kubernetesImageRepository:
-                description: Sets the Kubernetes image repository used for the KubeadmControlPlane.
-                pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
-                type: string
-              proxy:
-                description: HTTPProxy required for providing proxy configuration.
-                properties:
-                  additionalNo:
-                    description: |-
-                      AdditionalNo Proxy list that will be added to the automatically calculated
-                      values that will apply no_proxy configuration for cluster internal network.
-                      Default values: localhost,127.0.0.1,<POD_NETWORK>,<SERVICE_NETWORK>,kubernetes
-                        ,kubernetes.default,.svc,.svc.<SERVICE_DOMAIN>
-                    items:
-                      type: string
-                    type: array
-                  http:
-                    description: HTTP proxy value.
-                    type: string
-                  https:
-                    description: HTTPS proxy value.
-                    type: string
-                type: object
-              users:
-                items:
-                  description: User defines the input for a generated user in cloud-init.
+                imageRegistries:
+                  items:
+                    properties:
+                      credentials:
+                        description: Credentials and CA certificate for the image registry
+                        properties:
+                          secretRef:
+                            description: |-
+                              A reference to the Secret containing the registry credentials and optional CA certificate
+                              using the keys `username`, `password` and `ca.crt`.
+                              This credentials Secret is not required for some registries, e.g. ECR.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                minLength: 1
+                                type: string
+                            required:
+                              - name
+                            type: object
+                        type: object
+                      url:
+                        description: Registry URL.
+                        format: uri
+                        pattern: ^https?://
+                        type: string
+                    required:
+                      - url
+                    type: object
+                  type: array
+                kubernetesImageRepository:
+                  description: Sets the Kubernetes image repository used for the KubeadmControlPlane.
+                  pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
+                  type: string
+                proxy:
+                  description: HTTPProxy required for providing proxy configuration.
                   properties:
-                    hashedPassword:
+                    additionalNo:
                       description: |-
-                        HashedPassword is a hashed password for the user, formatted as described
-                        by the crypt(5) man page. See your distribution's documentation for
-                        instructions to create a hashed password.
-                        An empty string is not marshalled, because it is not a valid value.
-                      type: string
-                    name:
-                      description: Name specifies the user name.
-                      type: string
-                    sshAuthorizedKeys:
-                      description: |-
-                        SSHAuthorizedKeys is a list of public SSH keys to write to the
-                        machine. Use the corresponding private SSH keys to authenticate. See SSH
-                        documentation for instructions to create a key pair.
+                        AdditionalNo Proxy list that will be added to the automatically calculated
+                        values that will apply no_proxy configuration for cluster internal network.
+                        Default values: localhost,127.0.0.1,<POD_NETWORK>,<SERVICE_NETWORK>,kubernetes
+                          ,kubernetes.default,.svc,.svc.<SERVICE_DOMAIN>
                       items:
                         type: string
                       type: array
-                    sudo:
-                      description: |-
-                        Sudo is a sudo user specification, formatted as described in the sudo
-                        documentation.
-                        An empty string is not marshalled, because it is not a valid value.
+                    http:
+                      description: HTTP proxy value.
                       type: string
-                  required:
-                  - name
+                    https:
+                      description: HTTPS proxy value.
+                      type: string
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
+                users:
+                  items:
+                    description: User defines the input for a generated user in cloud-init.
+                    properties:
+                      hashedPassword:
+                        description: |-
+                          HashedPassword is a hashed password for the user, formatted as described
+                          by the crypt(5) man page. See your distribution's documentation for
+                          instructions to create a hashed password.
+                          An empty string is not marshalled, because it is not a valid value.
+                        type: string
+                      name:
+                        description: Name specifies the user name.
+                        type: string
+                      sshAuthorizedKeys:
+                        description: |-
+                          SSHAuthorizedKeys is a list of public SSH keys to write to the
+                          machine. Use the corresponding private SSH keys to authenticate. See SSH
+                          documentation for instructions to create a key pair.
+                        items:
+                          type: string
+                        type: array
+                      sudo:
+                        description: |-
+                          Sudo is a sudo user specification, formatted as described in the sudo
+                          documentation.
+                          An empty string is not marshalled, because it is not a valid value.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
@@ -16,501 +16,428 @@ spec:
     singular: nutanixclusterconfig
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: NutanixClusterConfig is the Schema for the nutanixclusterconfigs
-          API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: NutanixClusterConfigSpec defines the desired state of NutanixClusterConfig.
-            properties:
-              addons:
-                properties:
-                  ccm:
-                    description: CCM tells us to enable or disable the cloud provider
-                      interface.
-                    properties:
-                      credentials:
-                        description: A reference to the Secret for credential information
-                          for the target Prism Central instance
-                        properties:
-                          secretRef:
-                            description: A reference to the Secret containing the
-                              credentials used by the CCM provider.
-                            properties:
-                              name:
-                                description: |-
-                                  Name of the referent.
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                minLength: 1
-                                type: string
-                            required:
-                            - name
-                            type: object
-                        required:
-                        - secretRef
-                        type: object
-                    type: object
-                  clusterAutoscaler:
-                    description: ClusterAutoscaler tells us to enable or disable the
-                      cluster-autoscaler addon.
-                    properties:
-                      strategy:
-                        description: |-
-                          Addon strategy used to deploy cluster-autoscaler to the management cluster
-                          targeting the workload cluster.
-                        enum:
-                        - ClusterResourceSet
-                        - HelmAddon
-                        type: string
-                    required:
-                    - strategy
-                    type: object
-                  cni:
-                    description: CNI required for providing CNI configuration.
-                    properties:
-                      provider:
-                        description: CNI provider to deploy.
-                        enum:
-                        - Calico
-                        - Cilium
-                        type: string
-                      strategy:
-                        description: Addon strategy used to deploy the CNI provider
-                          to the workload cluster.
-                        enum:
-                        - ClusterResourceSet
-                        - HelmAddon
-                        type: string
-                    required:
-                    - provider
-                    - strategy
-                    type: object
-                  csi:
-                    properties:
-                      defaultStorage:
-                        properties:
-                          providerName:
-                            description: Name of the CSI Provider for the default
-                              storage class.
-                            enum:
-                            - aws-ebs
-                            - nutanix
-                            - local-path
-                            type: string
-                          storageClassConfigName:
-                            description: Name of storage class config in any of the
-                              provider objects.
-                            minLength: 1
-                            type: string
-                        required:
-                        - providerName
-                        - storageClassConfigName
-                        type: object
-                      providers:
-                        items:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: NutanixClusterConfig is the Schema for the nutanixclusterconfigs API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NutanixClusterConfigSpec defines the desired state of NutanixClusterConfig.
+              properties:
+                addons:
+                  properties:
+                    ccm:
+                      description: CCM tells us to enable or disable the cloud provider interface.
+                      properties:
+                        credentials:
+                          description: A reference to the Secret for credential information for the target Prism Central instance
                           properties:
-                            credentials:
-                              description: The reference to any secret used by the
-                                CSI Provider.
+                            secretRef:
+                              description: A reference to the Secret containing the credentials used by the CCM provider.
                               properties:
-                                secretRef:
-                                  description: A reference to the Secret containing
-                                    the credentials used by the CSI provider.
-                                  properties:
-                                    name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  minLength: 1
+                                  type: string
                               required:
-                              - secretRef
-                              type: object
-                            name:
-                              description: Name of the CSI Provider.
-                              enum:
-                              - aws-ebs
-                              - nutanix
-                              - local-path
-                              type: string
-                            storageClassConfig:
-                              description: StorageClassConfig is a list of storage
-                                class configurations for this CSI provider.
-                              items:
-                                properties:
-                                  allowExpansion:
-                                    default: false
-                                    description: If the storage class should allow
-                                      volume expanding
-                                    type: boolean
-                                  name:
-                                    description: Name of storage class config.
-                                    minLength: 1
-                                    type: string
-                                  parameters:
-                                    additionalProperties:
-                                      type: string
-                                    description: Parameters passed into the storage
-                                      class object.
-                                    type: object
-                                  reclaimPolicy:
-                                    default: Delete
-                                    description: PersistentVolumeReclaimPolicy describes
-                                      a policy for end-of-life maintenance of persistent
-                                      volumes.
-                                    enum:
-                                    - Delete
-                                    - Retain
-                                    - Recycle
-                                    type: string
-                                  volumeBindingMode:
-                                    default: WaitForFirstConsumer
-                                    description: VolumeBindingMode indicates how PersistentVolumeClaims
-                                      should be bound.
-                                    enum:
-                                    - Immediate
-                                    - WaitForFirstConsumer
-                                    type: string
-                                required:
                                 - name
-                                type: object
-                              type: array
-                            strategy:
-                              description: Addon strategy used to deploy the CSI provider
-                                to the workload cluster.
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                      type: object
+                    clusterAutoscaler:
+                      description: ClusterAutoscaler tells us to enable or disable the cluster-autoscaler addon.
+                      properties:
+                        strategy:
+                          description: |-
+                            Addon strategy used to deploy cluster-autoscaler to the management cluster
+                            targeting the workload cluster.
+                          enum:
+                            - ClusterResourceSet
+                            - HelmAddon
+                          type: string
+                      required:
+                        - strategy
+                      type: object
+                    cni:
+                      description: CNI required for providing CNI configuration.
+                      properties:
+                        provider:
+                          description: CNI provider to deploy.
+                          enum:
+                            - Calico
+                            - Cilium
+                          type: string
+                        strategy:
+                          description: Addon strategy used to deploy the CNI provider to the workload cluster.
+                          enum:
+                            - ClusterResourceSet
+                            - HelmAddon
+                          type: string
+                      required:
+                        - provider
+                        - strategy
+                      type: object
+                    csi:
+                      properties:
+                        defaultStorage:
+                          properties:
+                            providerName:
+                              description: Name of the CSI Provider for the default storage class.
                               enum:
-                              - ClusterResourceSet
-                              - HelmAddon
+                                - nutanix
+                              type: string
+                            storageClassConfigName:
+                              description: Name of storage class config in any of the provider objects.
+                              minLength: 1
                               type: string
                           required:
-                          - name
-                          - strategy
+                            - providerName
+                            - storageClassConfigName
                           type: object
-                        minItems: 1
-                        type: array
-                    required:
-                    - defaultStorage
-                    - providers
-                    type: object
-                  nfd:
-                    description: NFD tells us to enable or disable the node feature
-                      discovery addon.
-                    properties:
-                      strategy:
-                        description: Addon strategy used to deploy Node Feature Discovery
-                          (NFD) to the workload cluster.
-                        enum:
-                        - ClusterResourceSet
-                        - HelmAddon
-                        type: string
-                    required:
-                    - strategy
-                    type: object
-                  serviceLoadBalancer:
-                    properties:
-                      provider:
-                        description: |-
-                          The LoadBalancer-type Service provider to deploy. Not required in infrastructures where
-                          the CCM acts as the provider.
-                        enum:
-                        - MetalLB
-                        type: string
-                    required:
-                    - provider
-                    type: object
-                type: object
-              controlPlane:
-                description: NutanixNodeSpec defines the desired state of NutanixNodeSpec.
-                properties:
-                  nutanix:
-                    properties:
-                      machineDetails:
-                        properties:
-                          additionalCategories:
-                            description: |-
-                              List of categories that need to be added to the machines. Categories must already
-                              exist in Prism Central. One category key can have more than one value.
-                            items:
-                              properties:
-                                key:
-                                  description: key is the Key of category in PC.
-                                  type: string
-                                value:
-                                  description: value is the category value linked
-                                    to the category key in PC
-                                  type: string
-                              type: object
-                            type: array
-                          bootType:
-                            description: Defines the boot type of the virtual machine.
-                              Only supports UEFI and Legacy
-                            enum:
-                            - legacy
-                            - uefi
-                            type: string
-                          cluster:
-                            description: |-
-                              cluster identifies the Prism Element in which the machine will be created.
-                              The identifier (uuid or name) can be obtained from the console or API.
+                        providers:
+                          items:
                             properties:
+                              credentials:
+                                description: The reference to any secret used by the CSI Provider.
+                                properties:
+                                  secretRef:
+                                    description: A reference to the Secret containing the credentials used by the CSI provider.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - secretRef
+                                type: object
                               name:
-                                description: name is the resource name in the PC
-                                type: string
-                              type:
-                                description: Type is the identifier type to use for
-                                  this resource.
+                                description: Name of the CSI Provider.
                                 enum:
-                                - uuid
-                                - name
+                                  - nutanix
                                 type: string
-                              uuid:
-                                description: uuid is the UUID of the resource in the
-                                  PC.
+                              storageClassConfig:
+                                description: StorageClassConfig is a list of storage class configurations for this CSI provider.
+                                items:
+                                  properties:
+                                    allowExpansion:
+                                      default: false
+                                      description: If the storage class should allow volume expanding
+                                      type: boolean
+                                    name:
+                                      description: Name of storage class config.
+                                      minLength: 1
+                                      type: string
+                                    parameters:
+                                      additionalProperties:
+                                        type: string
+                                      description: Parameters passed into the storage class object.
+                                      type: object
+                                    reclaimPolicy:
+                                      default: Delete
+                                      description: PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes.
+                                      enum:
+                                        - Delete
+                                        - Retain
+                                        - Recycle
+                                      type: string
+                                    volumeBindingMode:
+                                      default: WaitForFirstConsumer
+                                      description: VolumeBindingMode indicates how PersistentVolumeClaims should be bound.
+                                      enum:
+                                        - Immediate
+                                        - WaitForFirstConsumer
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                              strategy:
+                                description: Addon strategy used to deploy the CSI provider to the workload cluster.
+                                enum:
+                                  - ClusterResourceSet
+                                  - HelmAddon
                                 type: string
                             required:
-                            - type
+                              - name
+                              - strategy
                             type: object
-                          gpus:
-                            description: List of GPU devices that need to be added
-                              to the machines.
-                            items:
-                              properties:
-                                deviceID:
-                                  description: deviceID is the id of the GPU entity.
-                                  format: int64
-                                  type: integer
-                                name:
-                                  description: name is the GPU name
-                                  type: string
-                                type:
-                                  description: Type is the identifier type to use
-                                    for this resource.
-                                  enum:
-                                  - deviceID
-                                  - name
-                                  type: string
-                              required:
-                              - type
-                              type: object
-                            type: array
-                          image:
-                            description: |-
-                              image identifies the image uploaded to Prism Central (PC). The identifier
-                              (uuid or name) can be obtained from the console or API.
-                            properties:
-                              name:
-                                description: name is the resource name in the PC
-                                type: string
-                              type:
-                                description: Type is the identifier type to use for
-                                  this resource.
-                                enum:
-                                - uuid
-                                - name
-                                type: string
-                              uuid:
-                                description: uuid is the UUID of the resource in the
-                                  PC.
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          memorySize:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: memorySize is the memory size (in Quantity
-                              format) of the VM
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          project:
-                            description: |-
-                              add the virtual machines to the project defined in Prism Central.
-                              The project must already be present in the Prism Central.
-                            properties:
-                              name:
-                                description: name is the resource name in the PC
-                                type: string
-                              type:
-                                description: Type is the identifier type to use for
-                                  this resource.
-                                enum:
-                                - uuid
-                                - name
-                                type: string
-                              uuid:
-                                description: uuid is the UUID of the resource in the
-                                  PC.
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          subnets:
-                            description: |-
-                              subnet identifies the network subnet to use for the machine.
-                              The identifier (uuid or name) can be obtained from the console or API.
-                            items:
-                              description: NutanixResourceIdentifier holds the identity
-                                of a Nutanix PC resource (cluster, image, subnet,
-                                etc.)
+                          minItems: 1
+                          type: array
+                      required:
+                        - defaultStorage
+                        - providers
+                      type: object
+                    nfd:
+                      description: NFD tells us to enable or disable the node feature discovery addon.
+                      properties:
+                        strategy:
+                          description: Addon strategy used to deploy Node Feature Discovery (NFD) to the workload cluster.
+                          enum:
+                            - ClusterResourceSet
+                            - HelmAddon
+                          type: string
+                      required:
+                        - strategy
+                      type: object
+                    serviceLoadBalancer:
+                      properties:
+                        provider:
+                          description: |-
+                            The LoadBalancer-type Service provider to deploy. Not required in infrastructures where
+                            the CCM acts as the provider.
+                          enum:
+                            - MetalLB
+                          type: string
+                      required:
+                        - provider
+                      type: object
+                  type: object
+                controlPlane:
+                  description: NutanixNodeSpec defines the desired state of NutanixNodeSpec.
+                  properties:
+                    nutanix:
+                      properties:
+                        machineDetails:
+                          properties:
+                            additionalCategories:
+                              description: |-
+                                List of categories that need to be added to the machines. Categories must already
+                                exist in Prism Central. One category key can have more than one value.
+                              items:
+                                properties:
+                                  key:
+                                    description: key is the Key of category in PC.
+                                    type: string
+                                  value:
+                                    description: value is the category value linked to the category key in PC
+                                    type: string
+                                type: object
+                              type: array
+                            bootType:
+                              description: Defines the boot type of the virtual machine. Only supports UEFI and Legacy
+                              enum:
+                                - legacy
+                                - uefi
+                              type: string
+                            cluster:
+                              description: |-
+                                cluster identifies the Prism Element in which the machine will be created.
+                                The identifier (uuid or name) can be obtained from the console or API.
                               properties:
                                 name:
                                   description: name is the resource name in the PC
                                   type: string
                                 type:
-                                  description: Type is the identifier type to use
-                                    for this resource.
+                                  description: Type is the identifier type to use for this resource.
                                   enum:
-                                  - uuid
-                                  - name
+                                    - uuid
+                                    - name
                                   type: string
                                 uuid:
-                                  description: uuid is the UUID of the resource in
-                                    the PC.
+                                  description: uuid is the UUID of the resource in the PC.
                                   type: string
                               required:
-                              - type
+                                - type
                               type: object
-                            type: array
-                          systemDiskSize:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: |-
-                              systemDiskSize is size (in Quantity format) of the system disk of the VM
-                              The minimum systemDiskSize is 20Gi bytes
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          vcpuSockets:
-                            description: vcpuSockets is the number of vCPU sockets
-                              of the VM
-                            format: int32
-                            type: integer
-                          vcpusPerSocket:
-                            description: vcpusPerSocket is the number of vCPUs per
-                              socket of the VM
-                            format: int32
-                            type: integer
-                        required:
-                        - cluster
-                        - image
-                        - memorySize
-                        - subnets
-                        - systemDiskSize
-                        - vcpuSockets
-                        - vcpusPerSocket
-                        type: object
-                    required:
-                    - machineDetails
-                    type: object
-                type: object
-              encryptionAtRest:
-                description: |-
-                  EncryptionAtRest defines the configuration to enable encryption at REST
-                  This configuration is used by API server to encrypt data before storing it in ETCD.
-                  Currently the encryption only enabled for secrets and configmaps.
-                properties:
-                  providers:
-                    default:
-                    - aescbc: {}
-                    description: Encryption providers
-                    items:
-                      properties:
-                        aescbc:
+                            gpus:
+                              description: List of GPU devices that need to be added to the machines.
+                              items:
+                                properties:
+                                  deviceID:
+                                    description: deviceID is the id of the GPU entity.
+                                    format: int64
+                                    type: integer
+                                  name:
+                                    description: name is the GPU name
+                                    type: string
+                                  type:
+                                    description: Type is the identifier type to use for this resource.
+                                    enum:
+                                      - deviceID
+                                      - name
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                              type: array
+                            image:
+                              description: |-
+                                image identifies the image uploaded to Prism Central (PC). The identifier
+                                (uuid or name) can be obtained from the console or API.
+                              properties:
+                                name:
+                                  description: name is the resource name in the PC
+                                  type: string
+                                type:
+                                  description: Type is the identifier type to use for this resource.
+                                  enum:
+                                    - uuid
+                                    - name
+                                  type: string
+                                uuid:
+                                  description: uuid is the UUID of the resource in the PC.
+                                  type: string
+                              required:
+                                - type
+                              type: object
+                            memorySize:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: memorySize is the memory size (in Quantity format) of the VM
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            project:
+                              description: |-
+                                add the virtual machines to the project defined in Prism Central.
+                                The project must already be present in the Prism Central.
+                              properties:
+                                name:
+                                  description: name is the resource name in the PC
+                                  type: string
+                                type:
+                                  description: Type is the identifier type to use for this resource.
+                                  enum:
+                                    - uuid
+                                    - name
+                                  type: string
+                                uuid:
+                                  description: uuid is the UUID of the resource in the PC.
+                                  type: string
+                              required:
+                                - type
+                              type: object
+                            subnets:
+                              description: |-
+                                subnet identifies the network subnet to use for the machine.
+                                The identifier (uuid or name) can be obtained from the console or API.
+                              items:
+                                description: NutanixResourceIdentifier holds the identity of a Nutanix PC resource (cluster, image, subnet, etc.)
+                                properties:
+                                  name:
+                                    description: name is the resource name in the PC
+                                    type: string
+                                  type:
+                                    description: Type is the identifier type to use for this resource.
+                                    enum:
+                                      - uuid
+                                      - name
+                                    type: string
+                                  uuid:
+                                    description: uuid is the UUID of the resource in the PC.
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                              type: array
+                            systemDiskSize:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: |-
+                                systemDiskSize is size (in Quantity format) of the system disk of the VM
+                                The minimum systemDiskSize is 20Gi bytes
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            vcpuSockets:
+                              description: vcpuSockets is the number of vCPU sockets of the VM
+                              format: int32
+                              type: integer
+                            vcpusPerSocket:
+                              description: vcpusPerSocket is the number of vCPUs per socket of the VM
+                              format: int32
+                              type: integer
+                          required:
+                            - cluster
+                            - image
+                            - memorySize
+                            - subnets
+                            - systemDiskSize
+                            - vcpuSockets
+                            - vcpusPerSocket
                           type: object
-                        secretbox:
-                          type: object
+                      required:
+                        - machineDetails
                       type: object
-                    maxItems: 1
-                    type: array
-                type: object
-              etcd:
-                properties:
-                  image:
-                    description: Image required for overriding etcd image details.
-                    properties:
-                      repository:
-                        description: Repository is used to override the image repository
-                          to pull from.
-                        pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
-                        type: string
-                      tag:
-                        description: Tag is used to override the default image tag.
-                        pattern: ^[\w][\w.-]{0,127}$
-                        type: string
-                    type: object
-                type: object
-              extraAPIServerCertSANs:
-                description: |-
-                  Subject Alternative Names for the API Server signing cert.
-                  For the Nutanix provider, the following default SANs will always be added:
-                  - localhost
-                  - 127.0.0.1
-                  - 0.0.0.0
-                items:
-                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                  type: string
-                type: array
-                uniqueItems: true
-              globalImageRegistryMirror:
-                description: GlobalImageRegistryMirror sets default mirror configuration
-                  for all the image registries.
-                properties:
-                  credentials:
-                    description: Credentials and CA certificate for the image registry
-                      mirror
-                    properties:
-                      secretRef:
-                        description: |-
-                          A reference to the Secret containing the registry credentials and optional CA certificate
-                          using the keys `username`, `password` and `ca.crt`.
-                          This credentials Secret is not required for some registries, e.g. ECR.
+                  type: object
+                encryptionAtRest:
+                  description: |-
+                    EncryptionAtRest defines the configuration to enable encryption at REST
+                    This configuration is used by API server to encrypt data before storing it in ETCD.
+                    Currently the encryption only enabled for secrets and configmaps.
+                  properties:
+                    providers:
+                      default:
+                        - aescbc: {}
+                      description: Encryption providers
+                      items:
                         properties:
-                          name:
-                            description: |-
-                              Name of the referent.
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            minLength: 1
-                            type: string
-                        required:
-                        - name
+                          aescbc:
+                            type: object
+                          secretbox:
+                            type: object
                         type: object
-                    type: object
-                  url:
-                    description: Registry mirror URL.
-                    format: uri
-                    pattern: ^https?://
+                      maxItems: 1
+                      type: array
+                  type: object
+                etcd:
+                  properties:
+                    image:
+                      description: Image required for overriding etcd image details.
+                      properties:
+                        repository:
+                          description: Repository is used to override the image repository to pull from.
+                          pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
+                          type: string
+                        tag:
+                          description: Tag is used to override the default image tag.
+                          pattern: ^[\w][\w.-]{0,127}$
+                          type: string
+                      type: object
+                  type: object
+                extraAPIServerCertSANs:
+                  description: |-
+                    Subject Alternative Names for the API Server signing cert.
+                    For the Nutanix provider, the following default SANs will always be added:
+                    - localhost
+                    - 127.0.0.1
+                    - 0.0.0.0
+                  items:
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
-                required:
-                - url
-                type: object
-              imageRegistries:
-                items:
+                  type: array
+                  uniqueItems: true
+                globalImageRegistryMirror:
+                  description: GlobalImageRegistryMirror sets default mirror configuration for all the image registries.
                   properties:
                     credentials:
-                      description: Credentials and CA certificate for the image registry
+                      description: Credentials and CA certificate for the image registry mirror
                       properties:
                         secretRef:
                           description: |-
@@ -525,71 +452,28 @@ spec:
                               minLength: 1
                               type: string
                           required:
-                          - name
+                            - name
                           type: object
                       type: object
                     url:
-                      description: Registry URL.
+                      description: Registry mirror URL.
                       format: uri
                       pattern: ^https?://
                       type: string
                   required:
-                  - url
+                    - url
                   type: object
-                type: array
-              kubernetesImageRepository:
-                description: Sets the Kubernetes image repository used for the KubeadmControlPlane.
-                pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
-                type: string
-              nutanix:
-                description: NutanixSpec defines the desired state of NutanixCluster.
-                properties:
-                  controlPlaneEndpoint:
-                    description: |-
-                      ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
-                      host can be either DNS name or ip address
+                imageRegistries:
+                  items:
                     properties:
-                      host:
-                        description: The hostname on which the API server is serving.
-                        minLength: 1
-                        type: string
-                      port:
-                        description: The port on which the API server is serving.
-                        format: int32
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                      virtualIP:
-                        description: Configuration for the virtual IP provider.
-                        properties:
-                          provider:
-                            default: KubeVIP
-                            description: Virtual IP provider to deploy.
-                            enum:
-                            - KubeVIP
-                            type: string
-                        type: object
-                    required:
-                    - host
-                    - port
-                    type: object
-                  prismCentralEndpoint:
-                    description: Nutanix Prism Central endpoint configuration.
-                    properties:
-                      additionalTrustBundle:
-                        description: |-
-                          A base64 PEM encoded x509 cert for the RootCA that was used to create
-                          the certificate for a Prism Central that uses certificates that were issued by a non-publicly trusted RootCA.
-                          The trust bundle is added to the cert pool used to authenticate the TLS connection to the Prism Central.
-                        format: byte
-                        type: string
                       credentials:
-                        description: A reference to the Secret for credential information
-                          for the target Prism Central instance.
+                        description: Credentials and CA certificate for the image registry
                         properties:
                           secretRef:
-                            description: A reference to the Secret containing the
-                              Prism Central credentials.
+                            description: |-
+                              A reference to the Secret containing the registry credentials and optional CA certificate
+                              using the keys `username`, `password` and `ca.crt`.
+                              This credentials Secret is not required for some registries, e.g. ECR.
                             properties:
                               name:
                                 description: |-
@@ -598,80 +482,150 @@ spec:
                                 minLength: 1
                                 type: string
                             required:
-                            - name
+                              - name
                             type: object
-                        required:
-                        - secretRef
                         type: object
-                      insecure:
-                        description: use insecure connection to Prism Central endpoint
-                        type: boolean
                       url:
-                        description: The URL of Nutanix Prism Central, can be DNS
-                          name or an IP address.
+                        description: Registry URL.
                         format: uri
-                        pattern: ^https://
+                        pattern: ^https?://
                         type: string
                     required:
-                    - credentials
-                    - url
+                      - url
                     type: object
-                required:
-                - controlPlaneEndpoint
-                - prismCentralEndpoint
-                type: object
-              proxy:
-                description: HTTPProxy required for providing proxy configuration.
-                properties:
-                  additionalNo:
-                    description: |-
-                      AdditionalNo Proxy list that will be added to the automatically calculated
-                      values that will apply no_proxy configuration for cluster internal network.
-                      Default values: localhost,127.0.0.1,<POD_NETWORK>,<SERVICE_NETWORK>,kubernetes
-                        ,kubernetes.default,.svc,.svc.<SERVICE_DOMAIN>
-                    items:
-                      type: string
-                    type: array
-                  http:
-                    description: HTTP proxy value.
-                    type: string
-                  https:
-                    description: HTTPS proxy value.
-                    type: string
-                type: object
-              users:
-                items:
-                  description: User defines the input for a generated user in cloud-init.
+                  type: array
+                kubernetesImageRepository:
+                  description: Sets the Kubernetes image repository used for the KubeadmControlPlane.
+                  pattern: ^((?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*|\[(?:[a-fA-F0-9:]+)\])(:[0-9]+)?/)?[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*(/[a-z0-9]+((?:[._]|__|[-]+)[a-z0-9]+)*)*$
+                  type: string
+                nutanix:
+                  description: NutanixSpec defines the desired state of NutanixCluster.
                   properties:
-                    hashedPassword:
+                    controlPlaneEndpoint:
                       description: |-
-                        HashedPassword is a hashed password for the user, formatted as described
-                        by the crypt(5) man page. See your distribution's documentation for
-                        instructions to create a hashed password.
-                        An empty string is not marshalled, because it is not a valid value.
-                      type: string
-                    name:
-                      description: Name specifies the user name.
-                      type: string
-                    sshAuthorizedKeys:
+                        ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                        host can be either DNS name or ip address
+                      properties:
+                        host:
+                          description: The hostname on which the API server is serving.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: The port on which the API server is serving.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        virtualIP:
+                          description: Configuration for the virtual IP provider.
+                          properties:
+                            provider:
+                              default: KubeVIP
+                              description: Virtual IP provider to deploy.
+                              enum:
+                                - KubeVIP
+                              type: string
+                          type: object
+                      required:
+                        - host
+                        - port
+                      type: object
+                    prismCentralEndpoint:
+                      description: Nutanix Prism Central endpoint configuration.
+                      properties:
+                        additionalTrustBundle:
+                          description: |-
+                            A base64 PEM encoded x509 cert for the RootCA that was used to create
+                            the certificate for a Prism Central that uses certificates that were issued by a non-publicly trusted RootCA.
+                            The trust bundle is added to the cert pool used to authenticate the TLS connection to the Prism Central.
+                          format: byte
+                          type: string
+                        credentials:
+                          description: A reference to the Secret for credential information for the target Prism Central instance.
+                          properties:
+                            secretRef:
+                              description: A reference to the Secret containing the Prism Central credentials.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        insecure:
+                          description: use insecure connection to Prism Central endpoint
+                          type: boolean
+                        url:
+                          description: The URL of Nutanix Prism Central, can be DNS name or an IP address.
+                          format: uri
+                          pattern: ^https://
+                          type: string
+                      required:
+                        - credentials
+                        - url
+                      type: object
+                  required:
+                    - controlPlaneEndpoint
+                    - prismCentralEndpoint
+                  type: object
+                proxy:
+                  description: HTTPProxy required for providing proxy configuration.
+                  properties:
+                    additionalNo:
                       description: |-
-                        SSHAuthorizedKeys is a list of public SSH keys to write to the
-                        machine. Use the corresponding private SSH keys to authenticate. See SSH
-                        documentation for instructions to create a key pair.
+                        AdditionalNo Proxy list that will be added to the automatically calculated
+                        values that will apply no_proxy configuration for cluster internal network.
+                        Default values: localhost,127.0.0.1,<POD_NETWORK>,<SERVICE_NETWORK>,kubernetes
+                          ,kubernetes.default,.svc,.svc.<SERVICE_DOMAIN>
                       items:
                         type: string
                       type: array
-                    sudo:
-                      description: |-
-                        Sudo is a sudo user specification, formatted as described in the sudo
-                        documentation.
-                        An empty string is not marshalled, because it is not a valid value.
+                    http:
+                      description: HTTP proxy value.
                       type: string
-                  required:
-                  - name
+                    https:
+                      description: HTTPS proxy value.
+                      type: string
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
+                users:
+                  items:
+                    description: User defines the input for a generated user in cloud-init.
+                    properties:
+                      hashedPassword:
+                        description: |-
+                          HashedPassword is a hashed password for the user, formatted as described
+                          by the crypt(5) man page. See your distribution's documentation for
+                          instructions to create a hashed password.
+                          An empty string is not marshalled, because it is not a valid value.
+                        type: string
+                      name:
+                        description: Name specifies the user name.
+                        type: string
+                      sshAuthorizedKeys:
+                        description: |-
+                          SSHAuthorizedKeys is a list of public SSH keys to write to the
+                          machine. Use the corresponding private SSH keys to authenticate. See SSH
+                          documentation for instructions to create a key pair.
+                        items:
+                          type: string
+                        type: array
+                      sudo:
+                        description: |-
+                          Sudo is a sudo user specification, formatted as described in the sudo
+                          documentation.
+                          An empty string is not marshalled, because it is not a valid value.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/make/go.mk
+++ b/make/go.mk
@@ -201,6 +201,7 @@ go-generate: ; $(info $(M) running go generate)
 	  object:headerFile="hack/license-header.go.txt" output:object:artifacts:config=/dev/null \
 	  crd:headerFile=hack/license-header.yaml.txt output:crd:artifacts:config=./api/v1alpha1/crds
 	#$(MAKE) go-fix
+	$(MAKE) $(addprefix configure-csi-providers.,aws nutanix docker)
 
 .PHONY: go-mod-upgrade
 go-mod-upgrade: ## Interactive check for direct module dependency upgrades


### PR DESCRIPTION
Only supported CSI providers should be available on each CAPI provider. This
commit enforces that via the API, without changing handler logic to allow
for easier extensibility later, by simply updating the supported CSI provider
names in the API definitions.

This can only happen as CRD post-processing as kubebuilder annotations are
specified on API types in go. To use that approach for CSI providers here
would require changing the whole API structure to provide CAPI provider
specific types with CAPI provider specific annotations, which would be a
maintenance headache.

This issue arose for me when adding the `local-path` CSI provider for Docker
as I did not want this to be available on AWS or Nutanix clusters, as well
as the opposite way round for Docker clusters (no `aws-ebs` or `nutanix`
support).
