### PR TITLE
refactor: kube-vip commands

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
@@ -153,7 +153,6 @@ spec:
         - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
         - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
         - echo "127.0.0.1   localhost" >>/etc/hosts
-        - echo "127.0.0.1   kubernetes" >>/etc/hosts
         - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >> /etc/hosts
         useExperimentalRetryJoin: true
         verbosity: 10

--- a/hack/examples/bases/nutanix/clusterclass/kustomization.yaml.tmpl
+++ b/hack/examples/bases/nutanix/clusterclass/kustomization.yaml.tmpl
@@ -63,8 +63,12 @@ patches:
 - target:
     kind: KubeadmControlPlaneTemplate
   patch: |-
+    # deletes 'echo "127.0.0.1   kubernetes" >>/etc/hosts'
     - op: "remove"
-      path: "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/6"
+      path: "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/4"
+    # deletes 'sed -i 's#path: /etc/kubernetes/admin.conf#path: ...'
+    - op: "remove"
+      path: "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/5"
     - op: "remove"
       path: "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/1"
 

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/inject.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/inject.go
@@ -134,12 +134,14 @@ func (h *ControlPlaneVirtualIP) Mutate(
 		selectors.ControlPlane(),
 		log,
 		func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
-			virtualIPProviderFile, getFileErr := virtualIPProvider.GetFile(
-				ctx,
-				controlPlaneEndpointVar,
-			)
-			if getFileErr != nil {
-				return getFileErr
+			virtualIPProviderFiles, preKubeadmCommands, postKubeadmCommands, generateErr :=
+				virtualIPProvider.GenerateFilesAndCommands(
+					ctx,
+					controlPlaneEndpointVar,
+					cluster,
+				)
+			if generateErr != nil {
+				return generateErr
 			}
 
 			log.WithValues(
@@ -151,15 +153,8 @@ func (h *ControlPlaneVirtualIP) Mutate(
 			))
 			obj.Spec.Template.Spec.KubeadmConfigSpec.Files = append(
 				obj.Spec.Template.Spec.KubeadmConfigSpec.Files,
-				*virtualIPProviderFile,
+				virtualIPProviderFiles...,
 			)
-
-			preKubeadmCommands, postKubeadmCommands, getCommandsErr := virtualIPProvider.GetCommands(
-				cluster,
-			)
-			if getCommandsErr != nil {
-				return getCommandsErr
-			}
 
 			if len(preKubeadmCommands) > 0 {
 				log.WithValues(

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/inject.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/inject.go
@@ -134,12 +134,11 @@ func (h *ControlPlaneVirtualIP) Mutate(
 		selectors.ControlPlane(),
 		log,
 		func(obj *controlplanev1.KubeadmControlPlaneTemplate) error {
-			virtualIPProviderFiles, preKubeadmCommands, postKubeadmCommands, generateErr :=
-				virtualIPProvider.GenerateFilesAndCommands(
-					ctx,
-					controlPlaneEndpointVar,
-					cluster,
-				)
+			files, preKubeadmCommands, postKubeadmCommands, generateErr := virtualIPProvider.GenerateFilesAndCommands(
+				ctx,
+				controlPlaneEndpointVar,
+				cluster,
+			)
 			if generateErr != nil {
 				return generateErr
 			}
@@ -153,7 +152,7 @@ func (h *ControlPlaneVirtualIP) Mutate(
 			))
 			obj.Spec.Template.Spec.KubeadmConfigSpec.Files = append(
 				obj.Spec.Template.Spec.KubeadmConfigSpec.Files,
-				virtualIPProviderFiles...,
+				files...,
 			)
 
 			if len(preKubeadmCommands) > 0 {

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/inject_test.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/inject_test.go
@@ -82,8 +82,7 @@ var _ = Describe("Generate ControlPlane virtual IP patches", func() {
 						Operation: "add",
 						Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
 						ValueMatcher: gomega.ContainElements(
-							"/bin/bash /etc/caren/configure-for-kube-vip.sh set-host-aliases",
-							"/bin/bash /etc/caren/configure-for-kube-vip.sh use-super-admin.conf",
+							"/bin/bash /etc/caren/configure-for-kube-vip.sh set-host-aliases use-super-admin.conf",
 						),
 					},
 					{
@@ -162,8 +161,7 @@ var _ = Describe("Generate ControlPlane virtual IP patches", func() {
 						Operation: "add",
 						Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
 						ValueMatcher: gomega.ContainElements(
-							"/bin/bash /etc/caren/configure-for-kube-vip.sh set-host-aliases",
-							"/bin/bash /etc/caren/configure-for-kube-vip.sh use-super-admin.conf",
+							"/bin/bash /etc/caren/configure-for-kube-vip.sh set-host-aliases use-super-admin.conf",
 						),
 					},
 					{

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/inject_test.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/inject_test.go
@@ -82,14 +82,15 @@ var _ = Describe("Generate ControlPlane virtual IP patches", func() {
 						Operation: "add",
 						Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
 						ValueMatcher: gomega.ContainElements(
-							"/bin/bash /etc/caren/configure-kube-vip.sh use-super-admin.conf",
+							"/bin/bash /etc/caren/configure-for-kube-vip.sh set-host-aliases",
+							"/bin/bash /etc/caren/configure-for-kube-vip.sh use-super-admin.conf",
 						),
 					},
 					{
 						Operation: "add",
 						Path:      "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands",
 						ValueMatcher: gomega.ContainElements(
-							"/bin/bash /etc/caren/configure-kube-vip.sh use-admin.conf",
+							"/bin/bash /etc/caren/configure-for-kube-vip.sh use-admin.conf",
 						),
 					},
 				},
@@ -151,7 +152,7 @@ var _ = Describe("Generate ControlPlane virtual IP patches", func() {
 								gomega.HaveKey("content"),
 								gomega.HaveKeyWithValue(
 									"path",
-									gomega.ContainSubstring("configure-kube-vip.sh"),
+									gomega.ContainSubstring("configure-for-kube-vip.sh"),
 								),
 								gomega.HaveKey("permissions"),
 							),
@@ -161,14 +162,15 @@ var _ = Describe("Generate ControlPlane virtual IP patches", func() {
 						Operation: "add",
 						Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
 						ValueMatcher: gomega.ContainElements(
-							"/bin/bash /etc/caren/configure-kube-vip.sh use-super-admin.conf",
+							"/bin/bash /etc/caren/configure-for-kube-vip.sh set-host-aliases",
+							"/bin/bash /etc/caren/configure-for-kube-vip.sh use-super-admin.conf",
 						),
 					},
 					{
 						Operation: "add",
 						Path:      "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands",
 						ValueMatcher: gomega.ContainElements(
-							"/bin/bash /etc/caren/configure-kube-vip.sh use-admin.conf",
+							"/bin/bash /etc/caren/configure-for-kube-vip.sh use-admin.conf",
 						),
 					},
 				},

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/inject_test.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/inject_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
-	virtuialipproviders "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/controlplanevirtualip/providers"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/options"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/test/helpers"
 )
@@ -83,14 +82,14 @@ var _ = Describe("Generate ControlPlane virtual IP patches", func() {
 						Operation: "add",
 						Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
 						ValueMatcher: gomega.ContainElements(
-							virtuialipproviders.KubeVIPPreKubeadmCommands,
+							"/bin/bash /etc/caren/configure-kube-vip.sh use-super-admin.conf",
 						),
 					},
 					{
 						Operation: "add",
 						Path:      "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands",
 						ValueMatcher: gomega.ContainElements(
-							virtuialipproviders.KubeVIPPostKubeadmCommands,
+							"/bin/bash /etc/caren/configure-kube-vip.sh use-admin.conf",
 						),
 					},
 				},
@@ -148,20 +147,28 @@ var _ = Describe("Generate ControlPlane virtual IP patches", func() {
 								),
 								gomega.HaveKey("permissions"),
 							),
+							gomega.SatisfyAll(
+								gomega.HaveKey("content"),
+								gomega.HaveKeyWithValue(
+									"path",
+									gomega.ContainSubstring("configure-kube-vip.sh"),
+								),
+								gomega.HaveKey("permissions"),
+							),
 						),
 					},
 					{
 						Operation: "add",
 						Path:      "/spec/template/spec/kubeadmConfigSpec/preKubeadmCommands",
 						ValueMatcher: gomega.ContainElements(
-							virtuialipproviders.KubeVIPPreKubeadmCommands,
+							"/bin/bash /etc/caren/configure-kube-vip.sh use-super-admin.conf",
 						),
 					},
 					{
 						Operation: "add",
 						Path:      "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands",
 						ValueMatcher: gomega.ContainElements(
-							virtuialipproviders.KubeVIPPostKubeadmCommands,
+							"/bin/bash /etc/caren/configure-kube-vip.sh use-admin.conf",
 						),
 					},
 				},

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip.go
@@ -31,11 +31,9 @@ var (
 		"configure-for-kube-vip.sh")
 
 	configureForKubeVIPScriptOnRemotePreKubeadmCommand = "/bin/bash " +
-		configureForKubeVIPScriptOnRemote + " use-super-admin.conf"
+		configureForKubeVIPScriptOnRemote + " set-host-aliases use-super-admin.conf"
 	configureForKubeVIPScriptOnRemotePostKubeadmCommand = "/bin/bash " +
 		configureForKubeVIPScriptOnRemote + " use-admin.conf"
-
-	setHostAliasesScriptOnRemoteCommand = "/bin/bash " + configureForKubeVIPScriptOnRemote + " set-host-aliases"
 )
 
 //go:embed templates/configure-for-kube-vip.sh
@@ -132,10 +130,7 @@ func (p *kubeVIPFromConfigMapProvider) GenerateFilesAndCommands(
 		},
 	)
 
-	preKubeadmCommands = []string{
-		setHostAliasesScriptOnRemoteCommand,
-		configureForKubeVIPScriptOnRemotePreKubeadmCommand,
-	}
+	preKubeadmCommands = []string{configureForKubeVIPScriptOnRemotePreKubeadmCommand}
 	postKubeadmCommands = []string{configureForKubeVIPScriptOnRemotePostKubeadmCommand}
 
 	return files, preKubeadmCommands, postKubeadmCommands, nil

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip_test.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip_test.go
@@ -118,12 +118,11 @@ func Test_GenerateFilesAndCommands(t *testing.T) {
 				configMapKey: client.ObjectKeyFromObject(tt.configMap),
 			}
 
-			files, preKubeadmCommands, postKubeadmCommands, err :=
-				provider.GenerateFilesAndCommands(
-					context.TODO(),
-					tt.controlPlaneEndpointSpec,
-					tt.cluster,
-				)
+			files, preKubeadmCommands, postKubeadmCommands, err := provider.GenerateFilesAndCommands(
+				context.TODO(),
+				tt.controlPlaneEndpointSpec,
+				tt.cluster,
+			)
 			require.Equal(t, tt.expectedErr, err)
 			assert.Equal(t, tt.expectedFiles, files)
 			assert.Equal(t, tt.expectedPreKubeadmCommands, preKubeadmCommands)

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip_test.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip_test.go
@@ -68,7 +68,7 @@ func Test_GenerateFilesAndCommands(t *testing.T) {
 				},
 			},
 			expectedPreKubeadmCommands: []string{
-				setHostAliasesScriptOnRemoteCommand, configureForKubeVIPScriptOnRemotePreKubeadmCommand,
+				configureForKubeVIPScriptOnRemotePreKubeadmCommand,
 			},
 			expectedPostKubeadmCommands: []string{
 				configureForKubeVIPScriptOnRemotePostKubeadmCommand,

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip_test.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip_test.go
@@ -11,22 +11,69 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 )
 
-func Test_GetFile(t *testing.T) {
+func Test_GenerateFilesAndCommands(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                     string
-		controlPlaneEndpointSpec v1alpha1.ControlPlaneEndpointSpec
-		configMap                *corev1.ConfigMap
-		expectedContent          string
-		expectedErr              error
+		name                        string
+		controlPlaneEndpointSpec    v1alpha1.ControlPlaneEndpointSpec
+		cluster                     *clusterv1.Cluster
+		configMap                   *corev1.ConfigMap
+		expectedFiles               []bootstrapv1.File
+		expectedPreKubeadmCommands  []string
+		expectedPostKubeadmCommands []string
+		expectedErr                 error
 	}{
+		{
+			name: "should return templated data with both host and port and pre/post kubeadm hack commands",
+			controlPlaneEndpointSpec: v1alpha1.ControlPlaneEndpointSpec{
+				Host: "10.20.100.10",
+				Port: 6443,
+			},
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-kube-vip-template",
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					"data": validKubeVIPTemplate,
+				},
+			},
+			cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Version: "v1.29.0",
+					},
+				},
+			},
+			expectedFiles: []bootstrapv1.File{
+				{
+					Content:     expectedKubeVIPPod,
+					Owner:       kubeVIPFileOwner,
+					Path:        kubeVIPFilePath,
+					Permissions: kubeVIPFilePermissions,
+				},
+				{
+					Content:     string(configureKubeVIPScript),
+					Path:        configureKubeVIPScriptOnRemote,
+					Permissions: configureKubeVIPScriptPermissions,
+				},
+			},
+			expectedPreKubeadmCommands: []string{
+				configureKubeVIPScriptOnRemotePreKubeadmCommand,
+			},
+			expectedPostKubeadmCommands: []string{
+				configureKubeVIPScriptOnRemotePostKubeadmCommand,
+			},
+		},
 		{
 			name: "should return templated data with both host and port",
 			controlPlaneEndpointSpec: v1alpha1.ControlPlaneEndpointSpec{
@@ -42,7 +89,21 @@ func Test_GetFile(t *testing.T) {
 					"data": validKubeVIPTemplate,
 				},
 			},
-			expectedContent: expectedKubeVIPPod,
+			cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Version: "v1.28.0",
+					},
+				},
+			},
+			expectedFiles: []bootstrapv1.File{
+				{
+					Content:     expectedKubeVIPPod,
+					Owner:       kubeVIPFileOwner,
+					Path:        kubeVIPFilePath,
+					Permissions: kubeVIPFilePermissions,
+				},
+			},
 		},
 	}
 
@@ -57,12 +118,16 @@ func Test_GetFile(t *testing.T) {
 				configMapKey: client.ObjectKeyFromObject(tt.configMap),
 			}
 
-			file, err := provider.GetFile(context.TODO(), tt.controlPlaneEndpointSpec)
+			files, preKubeadmCommands, postKubeadmCommands, err :=
+				provider.GenerateFilesAndCommands(
+					context.TODO(),
+					tt.controlPlaneEndpointSpec,
+					tt.cluster,
+				)
 			require.Equal(t, tt.expectedErr, err)
-			assert.Equal(t, tt.expectedContent, file.Content)
-			assert.NotEmpty(t, file.Path)
-			assert.NotEmpty(t, file.Owner)
-			assert.NotEmpty(t, file.Permissions)
+			assert.Equal(t, tt.expectedFiles, files)
+			assert.Equal(t, tt.expectedPreKubeadmCommands, preKubeadmCommands)
+			assert.Equal(t, tt.expectedPostKubeadmCommands, postKubeadmCommands)
 		})
 	}
 }

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip_test.go
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/providers/kubevip_test.go
@@ -62,16 +62,16 @@ func Test_GenerateFilesAndCommands(t *testing.T) {
 					Permissions: kubeVIPFilePermissions,
 				},
 				{
-					Content:     string(configureKubeVIPScript),
-					Path:        configureKubeVIPScriptOnRemote,
-					Permissions: configureKubeVIPScriptPermissions,
+					Content:     string(configureForKubeVIPScript),
+					Path:        configureForKubeVIPScriptOnRemote,
+					Permissions: configureForKubeVIPScriptPermissions,
 				},
 			},
 			expectedPreKubeadmCommands: []string{
-				configureKubeVIPScriptOnRemotePreKubeadmCommand,
+				setHostAliasesScriptOnRemoteCommand, configureForKubeVIPScriptOnRemotePreKubeadmCommand,
 			},
 			expectedPostKubeadmCommands: []string{
-				configureKubeVIPScriptOnRemotePostKubeadmCommand,
+				configureForKubeVIPScriptOnRemotePostKubeadmCommand,
 			},
 		},
 		{

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/providers/templates/configure-for-kube-vip.sh
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/providers/templates/configure-for-kube-vip.sh
@@ -22,9 +22,13 @@ function use_admin_conf() {
   fi
 }
 
+function set_host_aliases() {
+  echo "127.0.0.1   kubernetes" >>/etc/hosts
+}
+
 function print_usage {
   cat >&2 <<EOF
-  Usage: ${SCRIPT_NAME} [use-super-admin.conf|use-admin.conf]
+  Usage: ${SCRIPT_NAME} [use-super-admin.conf|use-admin.conf|set-host-aliases]
 EOF
 }
 
@@ -38,6 +42,11 @@ function run_cmd() {
       ;;
     use-admin.conf)
       use_admin_conf
+      shift
+      break
+      ;;
+    set-host-aliases)
+      set_host_aliases
       shift
       break
       ;;

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/providers/templates/configure-for-kube-vip.sh
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/providers/templates/configure-for-kube-vip.sh
@@ -28,27 +28,21 @@ function set_host_aliases() {
 
 function print_usage {
   cat >&2 <<EOF
-  Usage: ${SCRIPT_NAME} [use-super-admin.conf|use-admin.conf|set-host-aliases]
+Usage: ${SCRIPT_NAME} [set-host-aliases|use-super-admin.conf|use-admin.conf]
 EOF
 }
 
 function run_cmd() {
-  while [ -n "$1" ]; do
+  while [ $# -gt 0 ]; do
     case $1 in
     use-super-admin.conf)
       use_super_admin_conf
-      shift
-      break
       ;;
     use-admin.conf)
       use_admin_conf
-      shift
-      break
       ;;
     set-host-aliases)
       set_host_aliases
-      shift
-      break
       ;;
     -h | --help)
       print_usage
@@ -59,7 +53,6 @@ function run_cmd() {
       exit 1
       ;;
     esac
-    echo "$1"
     shift
   done
 }

--- a/pkg/handlers/generic/mutation/controlplanevirtualip/providers/templates/configure-kube-vip.sh
+++ b/pkg/handlers/generic/mutation/controlplanevirtualip/providers/templates/configure-kube-vip.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_NAME="$(basename "${0}")"
+readonly SCRIPT_NAME
+
+declare -r KUBEADM_INIT_FILE="/run/kubeadm/kubeadm.yaml"
+declare -r KUBE_VIP_MANIFEST_FILE="/etc/kubernetes/manifests/kube-vip.yaml"
+
+function use_super_admin_conf {
+  if [[ -f ${KUBEADM_INIT_FILE} && -f ${KUBE_VIP_MANIFEST_FILE} ]]; then
+    sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+      /etc/kubernetes/manifests/kube-vip.yaml
+  fi
+}
+
+function use_admin_conf() {
+  if [[ -f ${KUBEADM_INIT_FILE} && -f ${KUBE_VIP_MANIFEST_FILE} ]]; then
+    sed -i 's#path: /etc/kubernetes/super-admin.conf#path: /etc/kubernetes/admin.conf#' \
+      /etc/kubernetes/manifests/kube-vip.yaml
+  fi
+}
+
+function print_usage {
+  cat >&2 <<EOF
+  Usage: ${SCRIPT_NAME} [use-super-admin.conf|use-admin.conf]
+EOF
+}
+
+function run_cmd() {
+  while [ -n "$1" ]; do
+    case $1 in
+    use-super-admin.conf)
+      use_super_admin_conf
+      shift
+      break
+      ;;
+    use-admin.conf)
+      use_admin_conf
+      shift
+      break
+      ;;
+    -h | --help)
+      print_usage
+      exit
+      ;;
+    *)
+      echo "invalid argument"
+      exit 1
+      ;;
+    esac
+    echo "$1"
+    shift
+  done
+}
+
+run_cmd "$@"

--- a/pkg/handlers/generic/mutation/encryptionatrest/inject.go
+++ b/pkg/handlers/generic/mutation/encryptionatrest/inject.go
@@ -125,7 +125,7 @@ func (h *encryptionPatchHandler) Mutate(
 				"patchedObjectName", ctrlclient.ObjectKeyFromObject(obj),
 			).Info("adding encryption configuration files and API server extra args in control plane kubeadm config spec")
 
-			// Create kubadm config file for encryption config
+			// Create kubeadm config file for encryption config
 			obj.Spec.Template.Spec.KubeadmConfigSpec.Files = append(
 				obj.Spec.Template.Spec.KubeadmConfigSpec.Files,
 				generateEncryptionCredentialsFile(cluster))


### PR DESCRIPTION
**What problem does this PR solve?**:
This PR refactors the kube-vip handler to:
1. Use a script file when running preKubeadmCommands/postKubeadmCommands. IMO this is simpler to maintain and change in the future instead of looking for complex multi-line strings in the slices.
2. Move `echo "127.0.0.1   kubernetes" >>/etc/hosts` out of the template and into the handler since this command is not unique to Nutanix and would be needed for other infra providers using kube-vip.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
