### PR TITLE
fix: credential provider response secret ownership

### DIFF
--- a/pkg/handlers/generic/mutation/imageregistries/credentials/inject.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/inject.go
@@ -368,15 +368,14 @@ func createSecretIfNeeded(
 		)
 	}
 	if credentialsSecret != nil {
-		if err := client.ServerSideApply(ctx, c, credentialsSecret, client.ForceOwnership); err != nil {
-			return fmt.Errorf("failed to apply Image Registry Credentials Secret: %w", err)
-		}
-
 		if err = controllerutil.SetOwnerReference(cluster, credentialsSecret, c.Scheme()); err != nil {
 			return fmt.Errorf(
 				"failed to set owner reference on Image Registry Credentials Secret: %w",
 				err,
 			)
+		}
+		if err := client.ServerSideApply(ctx, c, credentialsSecret, client.ForceOwnership); err != nil {
+			return fmt.Errorf("failed to apply Image Registry Credentials Secret: %w", err)
 		}
 	}
 


### PR DESCRIPTION
**What problem does this PR solve?**:
Saw that the owner was not getting correctly set on image credential Secret.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
