### PR TITLE
refactor: rename credential provider response secret

### DIFF
--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credentials_secret.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credentials_secret.go
@@ -114,5 +114,5 @@ func kubeletStaticCredentialProviderSecretContents(configs []providerConfig) (st
 }
 
 func credentialSecretName(clusterName string) string {
-	return fmt.Sprintf("%s-registry-creds", clusterName)
+	return fmt.Sprintf("%s-credential-provider-response", clusterName)
 }

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 const (
-	validSecretName                       = "myregistry-credentials"
-	registryStaticCredentialsSecretSuffix = "registry-creds"
+	validSecretName = "myregistry-credentials"
 )
 
 func Test_needImageRegistryCredentialsConfiguration(t *testing.T) {


### PR DESCRIPTION
**What problem does this PR solve?**:
Wanted to avoid "creds" abbreviation.
Also, the Konvoy secret names are `<cluster-name>-image-registry-credentials` and `<cluster-name>-image-registry-mirror-credentials` so it was pretty confusing also having a `<cluster-name>-registry-creds`. Wanted to make it a little more descriptive. (Suggestions welcome!)
Here is what that Secret looks like:
```
{
  "kind":"CredentialProviderResponse",
  "apiVersion":"credentialprovider.kubelet.k8s.io/v1",
  "cacheKeyType":"Image",
  "cacheDuration":"0s",
  "auth":{
    "docker.io": {"username": "<>", "password": "<>"}
  }
}
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
