### PR TITLE
build: Fix an incorrect make variable passed to goreleaser

### DIFF
--- a/make/goreleaser.mk
+++ b/make/goreleaser.mk
@@ -11,7 +11,7 @@ endif
 .PHONY: build-snapshot
 build-snapshot: ## Builds a snapshot with goreleaser
 build-snapshot: go-generate ; $(info $(M) building snapshot $*)
-	goreleaser --verbose=$(GORELEASER_VERBOSE) \
+	goreleaser --verbose=$(GORELEASER_DEBUG) \
 		build \
 		--snapshot \
 		--clean \

--- a/make/goreleaser.mk
+++ b/make/goreleaser.mk
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 GORELEASER_PARALLELISM ?= $(shell nproc --ignore=1)
-GORELEASER_DEBUG ?= false
+GORELEASER_VERBOSE ?= false
 
 ifndef GORELEASER_CURRENT_TAG
 export GORELEASER_CURRENT_TAG=$(GIT_TAG)
@@ -11,7 +11,7 @@ endif
 .PHONY: build-snapshot
 build-snapshot: ## Builds a snapshot with goreleaser
 build-snapshot: go-generate ; $(info $(M) building snapshot $*)
-	goreleaser --verbose=$(GORELEASER_DEBUG) \
+	goreleaser --verbose=$(GORELEASER_VERBOSE) \
 		build \
 		--snapshot \
 		--clean \
@@ -21,7 +21,7 @@ build-snapshot: go-generate ; $(info $(M) building snapshot $*)
 .PHONY: release
 release: ## Builds a release with goreleaser
 release: go-generate ; $(info $(M) building release $*)
-	goreleaser --verbose=$(GORELEASER_DEBUG) \
+	goreleaser --verbose=$(GORELEASER_VERBOSE) \
 		release \
 		--clean \
 		--parallelism=$(GORELEASER_PARALLELISM) \
@@ -31,7 +31,7 @@ release: go-generate ; $(info $(M) building release $*)
 .PHONY: release-snapshot
 release-snapshot: ## Builds a snapshot release with goreleaser
 release-snapshot: go-generate ; $(info $(M) building snapshot release $*)
-	goreleaser --verbose=$(GORELEASER_DEBUG) \
+	goreleaser --verbose=$(GORELEASER_VERBOSE) \
 		release \
 		--snapshot \
 		--clean \


### PR DESCRIPTION
**What problem does this PR solve?**:
The make variable reference was replaced recently in https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/704/files#diff-fa98b7f1d4a049ad777fb9453f6657c512c8b715a9f8bc47dfd57f1143bbb930L14.

The new reference is to `GORELEASE_VERBOSE`, which is unset, and goreleaser fails:

```shell
> make build-snapshot
▶ running go generate
make[1]: Entering directory '/home/dlipovetsky/nutanix/capi-runtime-extensions'
▶ configuring supported csi providers
make[1]: Leaving directory '/home/dlipovetsky/nutanix/capi-runtime-extensions'
▶ building snapshot
  ⨯ command failed                                   error=invalid argument "" for "--verbose" flag: strconv.ParseBool: parsing "": invalid syntax
```

Not sure how CI passed for #704, because this issue affects main.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
