### PR TITLE
feat: bumps caaph to 0.2.4

### DIFF
--- a/hack/third-party/caaph/go.mod
+++ b/hack/third-party/caaph/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/ex
 
 go 1.21
 
-require sigs.k8s.io/cluster-api-addon-provider-helm v0.2.3
+require sigs.k8s.io/cluster-api-addon-provider-helm v0.2.4
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/hack/third-party/caaph/go.sum
+++ b/hack/third-party/caaph/go.sum
@@ -208,8 +208,8 @@ k8s.io/utils v0.0.0-20240102154912-e7106e64919e h1:eQ/4ljkx21sObifjzXwlPKpdGLrCf
 k8s.io/utils v0.0.0-20240102154912-e7106e64919e/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/cluster-api v1.7.2 h1:bRE8zoao7ajuLC0HijqfZVcubKQCPlZ04HMgcA53FGE=
 sigs.k8s.io/cluster-api v1.7.2/go.mod h1:V9ZhKLvQtsDODwjXOKgbitjyCmC71yMBwDcMyNNIov0=
-sigs.k8s.io/cluster-api-addon-provider-helm v0.2.3 h1:oWSlwY0zfxI8CG0kCi74oFtYxQfAaYda5ra3AwaiGjs=
-sigs.k8s.io/cluster-api-addon-provider-helm v0.2.3/go.mod h1:ELiDb1satBERIsvXWTniyfh3aZt0OLl670C67UqjJQk=
+sigs.k8s.io/cluster-api-addon-provider-helm v0.2.4 h1:QVHsoG65OaPNmmTYyYjkrc9U/pyoF3nANs7XDGfs5Uk=
+sigs.k8s.io/cluster-api-addon-provider-helm v0.2.4/go.mod h1:MyKmUXjxBqNdobwhbdF3BwpKfvlELrHmAKxOdxtzWvI=
 sigs.k8s.io/controller-runtime v0.17.3 h1:65QmN7r3FWgTxDMz9fvGnO1kbf2nu+acg9p2R9oYYYk=
 sigs.k8s.io/controller-runtime v0.17.3/go.mod h1:N0jpP5Lo7lMTF9aL56Z/B2oWBJjey6StQM0jRbKQXtY=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=


### PR DESCRIPTION
**What problem does this PR solve?**:
Upgrade CAAPH to 0.2.4
This release includes fixes needed for supporting CAAPH in airgap environment.

🌱 Use upstream cluster RESTConfig utility by @jimmidyson in https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/pull/248
🐛 Fix OCI client configuration logic by @jimmidyson in https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/pull/252
🐛 pointer checks if user doesn't specify CASecret by @faiq in https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/pull/253
**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
