### PR TITLE
fix: Allow Nutanix CSI snapshot controller & webhook to run on CP nodes

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/nutanix/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/nutanix/manifests/helm-addon-installation.yaml
@@ -11,4 +11,17 @@ data:
     # The Secret containing the credentials will be created by the handler.
     createPrismCentralSecret: false
     pcSecretName: nutanix-csi-credentials
+
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 300
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
 {{- end -}}


### PR DESCRIPTION
**What problem does this PR solve?**:
With this change, all Nutanix CSI components can run on a single node cluster.

**Which issue(s) this PR fixes**:
Fixes #https://jira.nutanix.com/browse/NCN-100706

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
