### PR TITLE
fix: CredentialProviderConfig matchImages to support registries with port

### DIFF
--- a/pkg/handlers/generic/mutation/imageregistries/credentials/templates/kubelet-image-credential-provider-config.yaml.gotmpl
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/templates/kubelet-image-credential-provider-config.yaml.gotmpl
@@ -9,6 +9,14 @@ providers:
   {{- end }}
   {{- end }}
   matchImages:
+  {{- range .RegistryHosts}}
+  {{- with . }}
+  - {{ printf "%q" . }}
+  {{- if eq . "registry-1.docker.io" }}
+  - "docker.io"
+  {{- end }}
+  {{- end }}
+  {{- end }}
   - "*"
   - "*.*"
   - "*.*.*"


### PR DESCRIPTION
**What problem does this PR solve?**:
While debugging another issue where I launched a local registry in a container at `https://172.18.0.10:5000`, I noticed that Deployments with an image in that registry failed:
```
  Warning  Failed     7m14s (x4 over 8m47s)   kubelet            Failed to pull image "172.18.0.10:5000/library/nginx:latest": failed to pull and unpack image "172.18.0.10:5000/library/nginx:latest": failed to resolve reference "172.18.0.10:5000/library/nginx:latest": pull access denied, repository does not exist or may require authorization: authorization failed: no basic auth credentials
```

This is because of a bug in how `matchImages` in `CredentialProviderConfig` was generated, the globs don't match images with a port or a path. This PR fixes that by explicitly including the user provided registries in `matchImages`.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
* Updated unit tests

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
