### PR TITLE
fix: Namespace Sync controller should list no resources when source namespace is empty string

### DIFF
--- a/pkg/controllers/namespacesync/controller.go
+++ b/pkg/controllers/namespacesync/controller.go
@@ -150,6 +150,12 @@ func (r *Reconciler) listSourceClusterClasses(
 	[]clusterv1.ClusterClass,
 	error,
 ) {
+	// Handle the empty string explicitly, because listing resources with an empty
+	// string namespace returns resources in all namespaces.
+	if r.SourceClusterClassNamespace == "" {
+		return nil, nil
+	}
+
 	ccl := &clusterv1.ClusterClassList{}
 	err := r.Client.List(ctx, ccl, client.InNamespace(r.SourceClusterClassNamespace))
 	if err != nil {

--- a/pkg/controllers/namespacesync/controller.go
+++ b/pkg/controllers/namespacesync/controller.go
@@ -32,13 +32,6 @@ type Reconciler struct {
 	TargetNamespaceFilter func(ns *corev1.Namespace) bool
 }
 
-var NamespaceHasLabelKey = func(key string) func(ns *corev1.Namespace) bool {
-	return func(ns *corev1.Namespace) bool {
-		_, ok := ns.GetLabels()[key]
-		return ok
-	}
-}
-
 func (r *Reconciler) SetupWithManager(
 	ctx context.Context,
 	mgr ctrl.Manager,

--- a/pkg/controllers/namespacesync/controller_test.go
+++ b/pkg/controllers/namespacesync/controller_test.go
@@ -73,6 +73,29 @@ func TestReconcileNewClusterClass(t *testing.T) {
 	}
 }
 
+func TestSourceClusterClassNamespaceEmpty(t *testing.T) {
+	g := NewWithT(t)
+
+	_, cleanup, err := createUniqueClusterClassAndTemplates(
+		sourceClusterClassNamespace,
+	)
+	g.Expect(err).ToNot(HaveOccurred())
+	defer func() {
+		g.Expect(cleanup()).To(Succeed())
+	}()
+
+	// This test initializes its own reconciler, instead of using the one created
+	// in suite_test.go, in order to configure the source namespace.
+	r := Reconciler{
+		Client:                      env.Client,
+		SourceClusterClassNamespace: "",
+	}
+
+	ns, err := r.listSourceClusterClasses(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ns).To(BeEmpty())
+}
+
 func verifyClusterClassAndTemplates(
 	cli client.Reader,
 	name,

--- a/pkg/controllers/namespacesync/label.go
+++ b/pkg/controllers/namespacesync/label.go
@@ -1,3 +1,5 @@
+// Copyright 2024 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 package namespacesync
 
 import corev1 "k8s.io/api/core/v1"

--- a/pkg/controllers/namespacesync/label.go
+++ b/pkg/controllers/namespacesync/label.go
@@ -1,0 +1,10 @@
+package namespacesync
+
+import corev1 "k8s.io/api/core/v1"
+
+var NamespaceHasLabelKey = func(key string) func(ns *corev1.Namespace) bool {
+	return func(ns *corev1.Namespace) bool {
+		_, ok := ns.GetLabels()[key]
+		return ok
+	}
+}

--- a/pkg/controllers/namespacesync/label_test.go
+++ b/pkg/controllers/namespacesync/label_test.go
@@ -1,3 +1,5 @@
+// Copyright 2024 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
 package namespacesync
 
 import (

--- a/pkg/controllers/namespacesync/label_test.go
+++ b/pkg/controllers/namespacesync/label_test.go
@@ -1,0 +1,59 @@
+package namespacesync
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNamespaceHasLabelKey(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		ns   *corev1.Namespace
+		want bool
+	}{
+		{
+			name: "match a labeled namespace",
+			key:  "testkey",
+			ns: &corev1.Namespace{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"testkey": "",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "do not match if label key is not found",
+			key:  "testkey",
+			ns: &corev1.Namespace{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "do not match if label key is empty string",
+			key:  "",
+			ns: &corev1.Namespace{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := NamespaceHasLabelKey(tt.key)
+			if got := fn(tt.ns); got != tt.want {
+				t.Fatalf("got %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What problem does this PR solve?**:
Previously, the controller listed resources in all namespaces when the source namespace was an empty string. Now, it lists no resources.

The PR adds a test verifying the above. It also adds a test that verifies that an the controller will not match any namespaces when the target namespace label key is an empty string. 

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
