### PR TITLE
feat: Configure namespace sync in helm chart

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -32,10 +32,4 @@ const (
 	GlobalMirrorVariableName = "globalImageRegistryMirror"
 	// ImageRegistriesVariableName is the image registries patch variable name.
 	ImageRegistriesVariableName = "imageRegistries"
-
-	// NamespaceSyncLabelKey is a label that can be applied to a namespace.
-	//
-	// When a namespace has a label with this key, ClusterClasses and their Templates are
-	// copied to the namespace from a source namespace. The copies are not updated or deleted.
-	NamespaceSyncLabelKey = "caren.nutanix.com/namespace-sync"
 )

--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -73,6 +73,9 @@ A Helm chart for cluster-api-runtime-extensions-nutanix
 | image.repository | string | `"ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the container image |
+| namespaceSync.enabled | bool | `true` |  |
+| namespaceSync.sourceNamespace | string | `""` |  |
+| namespaceSync.targetNamespaceLabelKey | string | `"caren.nutanix.com/namespace-sync"` |  |
 | nodeSelector | object | `{}` |  |
 | priorityClassName | string | `"system-cluster-critical"` | Priority class to be used for the pod. |
 | resources.limits.cpu | string | `"100m"` |  |

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         args:
         - --webhook-cert-dir=/runtimehooks-certs/
         - --defaults-namespace=$(POD_NAMESPACE)
+        - --namespacesync-enabled={{ .Values.namespaceSync.enabled }}
+        - --namespacesync-source-namespace={{ .Values.namespaceSync.sourceNamespace | default .Release.Namespace }}
+        - --namespacesync-target-namespace-label-key={{ .Values.namespaceSync.targetNamespaceLabelKey }}
         - --helm-addons-configmap={{ .Values.helmAddonsConfigMap }}
         - --cni.cilium.helm-addon.default-values-template-configmap-name={{ .Values.hooks.cni.cilium.helmAddonStrategy.defaultValueTemplateConfigMap.name }}
         - --nfd.helm-addon.default-values-template-configmap-name={{ .Values.hooks.nfd.helmAddonStrategy.defaultValueTemplateConfigMap.name }}

--- a/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
@@ -401,6 +401,20 @@
         "imagePullSecrets": {
             "type": "array"
         },
+        "namespaceSync": {
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "sourceNamespace": {
+                    "type": "string"
+                },
+                "targetNamespaceLabelKey": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "nodeSelector": {
             "properties": {},
             "type": "object"

--- a/charts/cluster-api-runtime-extensions-nutanix/values.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.yaml
@@ -89,6 +89,16 @@ selfHostedRegistry: true
 
 deployDefaultClusterClasses: true
 
+# The ClusterClass and the Templates it references must be in the same namespace
+# as the Cluster. To enable cluster creation in user-defined namespaces, CAREN
+# will copy all ClusterClasses and Templates from the source namespace to every
+# target namespace, i.e., every namespace that has a label with a matching key.
+namespaceSync:
+  enabled: true
+  targetNamespaceLabelKey: caren.nutanix.com/namespace-sync
+  # By default, sourceNamespace is the helm release namespace.
+  sourceNamespace: ""
+
 deployment:
   replicas: 1
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -179,7 +179,12 @@ func main() {
 			mgr,
 			controller.Options{MaxConcurrentReconciles: namespacesyncOptions.Concurrency},
 		); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "namespacesync.Reconciler")
+			setupLog.Error(
+				err,
+				"unable to create controller",
+				"controller",
+				"namespacesync.Reconciler",
+			)
 			os.Exit(1)
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	caaphv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
-	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/server"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/controllers/namespacesync"
@@ -164,7 +163,7 @@ func main() {
 		Client:                      mgr.GetClient(),
 		UnstructuredCachingClient:   unstructuredCachingClient,
 		SourceClusterClassNamespace: namespacesyncOptions.SourceNamespace,
-		TargetNamespaceFilter:       namespacesync.NamespaceHasLabelKey(v1alpha1.NamespaceSyncLabelKey),
+		TargetNamespaceFilter:       namespacesync.NamespaceHasLabelKey(namespacesyncOptions.TargetNamespaceLabelKey),
 	}).SetupWithManager(
 		signalCtx,
 		mgr,

--- a/pkg/controllers/namespacesync/flags.go
+++ b/pkg/controllers/namespacesync/flags.go
@@ -32,7 +32,7 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	pflag.CommandLine.StringVar(
 		&o.SourceNamespace,
 		"namespacesync-source-namespace",
-		corev1.NamespaceDefault,
+		"",
 		"Namespace from which ClusterClasses and Templates are copied.",
 	)
 

--- a/pkg/controllers/namespacesync/flags.go
+++ b/pkg/controllers/namespacesync/flags.go
@@ -9,8 +9,9 @@ import (
 )
 
 type Options struct {
-	Concurrency     int
-	SourceNamespace string
+	Concurrency             int
+	SourceNamespace         string
+	TargetNamespaceLabelKey string
 }
 
 func (o *Options) AddFlags(flags *pflag.FlagSet) {
@@ -24,6 +25,14 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	pflag.CommandLine.StringVar(
 		&o.SourceNamespace,
 		"namespacesync-source-namespace",
-		corev1.NamespaceDefault, "Namespace from which ClusterClasses and Templates are copied.",
+		corev1.NamespaceDefault,
+		"Namespace from which ClusterClasses and Templates are copied.",
+	)
+
+	pflag.CommandLine.StringVar(
+		&o.TargetNamespaceLabelKey,
+		"namespacesync-target-namespace-label-key",
+		"",
+		"Label key to determine if a namespace is a target. If a namespace has a label with this key, copy ClusterClasses and Templates to it from the source namespace.", //nolint:lll // Output will be wrapped.
 	)
 }

--- a/pkg/controllers/namespacesync/flags.go
+++ b/pkg/controllers/namespacesync/flags.go
@@ -5,16 +5,23 @@ package namespacesync
 
 import (
 	"github.com/spf13/pflag"
-	corev1 "k8s.io/api/core/v1"
 )
 
 type Options struct {
+	Enabled                 bool
 	Concurrency             int
 	SourceNamespace         string
 	TargetNamespaceLabelKey string
 }
 
 func (o *Options) AddFlags(flags *pflag.FlagSet) {
+	pflag.CommandLine.BoolVar(
+		&o.Enabled,
+		"namespacesync-enabled",
+		false,
+		"Enable copying of ClusterClasses and Templates from a source namespace to one or more target namespaces.",
+	)
+
 	pflag.CommandLine.IntVar(
 		&o.Concurrency,
 		"namespacesync-concurrency",


### PR DESCRIPTION
**What problem does this PR solve?**:
- Allows user to configure target namespace label key using flag. Sets the default label key as an empty string. Labels cannot have an empty key, which means that, by default, no namespaces are target namespaces.
- Adds configuration fields to helm values, and passes them to manager as flags. Defines `caren.nutanix.com/namespace-sync` as the default target namespace label key.
- Documents configuration fields and their default values.

#725 fixes behavior when the source namespace and/or target namespace label key are empty strings.
  
**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
I think this behavior deserves to be documented, but right now the only place where we talk about configuration of CAREN itself is in the Chart README. Should I add something there, or under `docs/`?