### PR TITLE
build: Add 'chart-docs' make target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,12 @@ repos:
     language: system
     files: "(.*\\.go|go.mod|go.sum|go.mk)$"
     pass_filenames: false
+  - id: chart-docs
+    name: chart-docs
+    entry: make chart-docs
+    language: system
+    files: "^charts/"
+    pass_filenames: false
   - id: hugo-mod-tidy
     name: hugo-mod-tidy
     entry: bash -c "cd docs && hugo mod tidy"
@@ -145,11 +151,3 @@ repos:
       - --comment-style
       - <!--|| -->
       - --allow-past-years
-- repo: https://github.com/norwoodj/helm-docs
-  rev: v1.13.1
-  hooks:
-  - id: helm-docs
-    stages: [commit]
-    args:
-      # Make the tool search for charts only under the `example-charts` directory
-      - --chart-search-root=charts

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -1,6 +1,11 @@
 # Copyright 2023 Nutanix. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+.PHONY: chart-docs
+chart-docs: ## Update helm chart docs
+chart-docs:
+	helm-docs --chart-search-root=charts
+
 .PHONY: lint-chart
 lint-chart: ## Lints helm chart
 lint-chart:


### PR DESCRIPTION
**What problem does this PR solve?**:
Previously, the chart docs could only be updated by running pre-commit. Now they can be updated by running `make chart-docs`. (Pre-commit now uses this make target as well).

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
