### PR TITLE
build: Make CAREN mindthegap reg multiarch

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -195,6 +195,12 @@ jobs:
           fi
 
       - if: steps.list-changed.outputs.changed == 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - if: steps.list-changed.outputs.changed == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - if: steps.list-changed.outputs.changed == 'true'
         name: Run chart-testing (lint)
         run: |
           devbox run -- \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,10 @@ jobs:
           echo "After removing files:"
           df -h
 
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
       - name: Run e2e tests
         run: devbox run -- make e2e-test E2E_LABEL='provider:${{ inputs.provider }}' E2E_SKIP='${{ inputs.skip }}' E2E_FOCUS='${{ inputs.focus }}'
         env:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -27,6 +27,10 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,13 +96,54 @@ archives:
       - cluster-api-runtime-extensions-nutanix
 
 dockers:
-  - id: helm-registry-container
+  - image_templates:
+      # Specify the image tag including `-amd64` suffix if the build is not a snapshot build or is not being built on
+      # amd64 machine. This allows for using the snapshot image build without the architecture specific suffix
+      # consistently on local machines, i.e. can always use `ghcr.io/nutanix-cloud-native/caren-helm-reg:v<VERSION>` on the machine the snapshot
+      # is built on.
+      #
+      # For a release build the `-amd64` suffix will always be included and the `docker_manifests` specification below
+      # will create the final multiplatform manifest to be pushed to the registry.
+      - 'ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}{{ if or (not .IsSnapshot) (not (eq .Runtime.Goarch "amd64")) }}-amd64{{ end }}'
     use: buildx
     dockerfile: ./hack/addons/mindthegap-helm-registry/Dockerfile
     extra_files:
       - hack/addons/mindthegap-helm-registry/repos.yaml
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.CommitDate}}"
+      - "--label=org.opencontainers.image.title=caren-helm-reg"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - '--label=org.opencontainers.image.version=v{{ trimprefix .Version "v" }}'
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - image_templates:
+      # Specify the image tag including `-arm64` suffix if the build is not a snapshot build or is not being built on
+      # arm64 machine. This allows for using the snapshot image build without the architecture specific suffix
+      # consistently on local machines, i.e. can always use `ghcr.io/nutanix-cloud-native/caren-helm-reg:v<VERSION>` on the machine the snapshot
+      # is built on.
+      #
+      # For a release build the `-arm64` suffix will always be included and the `docker_manifests` specification below
+      # will create the final multiplatform manifest to be pushed to the registry.
+      - 'ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}{{ if or (not .IsSnapshot) (not (eq .Runtime.Goarch "arm64")) }}-arm64{{ end }}'
+    use: buildx
+    dockerfile: ./hack/addons/mindthegap-helm-registry/Dockerfile
+    extra_files:
+      - hack/addons/mindthegap-helm-registry/repos.yaml
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.CommitDate}}"
+      - "--label=org.opencontainers.image.title=caren-helm-reg"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - '--label=org.opencontainers.image.version=v{{ trimprefix .Version "v" }}'
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
+docker_manifests:
+  - name_template: ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}
     image_templates:
-      -  'ghcr.io/nutanix-cloud-native/caren-helm-reg:{{ .Version }}'
+      - ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}-amd64
+      - ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}-arm64
 
 kos:
   - id: cluster-api-runtime-extensions-nutanix
@@ -121,7 +162,7 @@ kos:
       org.opencontainers.image.created: "{{ .CommitDate }}"
       org.opencontainers.image.title: "{{ .ProjectName }}"
       org.opencontainers.image.revision: "{{ .FullCommit }}"
-      org.opencontainers.image.version: v{{ .Version }}
+      org.opencontainers.image.version: v{{ trimprefix .Version "v" }}
       org.opencontainers.image.source: "{{ .GitURL }}"
     platforms:
       - linux/amd64

--- a/hack/addons/mindthegap-helm-registry/Dockerfile
+++ b/hack/addons/mindthegap-helm-registry/Dockerfile
@@ -1,5 +1,5 @@
-FROM ghcr.io/mesosphere/mindthegap:v1.13.4
+FROM ghcr.io/mesosphere/mindthegap:v1.14.3
 # this gets called by goreleaser so the copy source has to be the path relative to the repo root.
-RUN --mount=source=./hack/addons/mindthegap-helm-registry/repos.yaml,target=/repos.yaml ["/ko-app/mindthegap", "create", "helm-bundle", "--helm-charts-file=/repos.yaml", "--output-file=/tmp/helm-charts.tar"]
+RUN --mount=source=./hack/addons/mindthegap-helm-registry/repos.yaml,target=/repos.yaml ["/ko-app/mindthegap", "create", "bundle", "--helm-charts-file=/repos.yaml", "--output-file=/tmp/helm-charts.tar"]
 VOLUME /certs
 CMD ["serve", "bundle", "--bundle=/tmp/helm-charts.tar", "--listen-port=5000", "--listen-address=0.0.0.0", "--tls-private-key-file=/certs/tls.key", "--tls-cert-file=/certs/tls.crt"]


### PR DESCRIPTION
This commit makes the CAREN mindthegap registry image a multiarch
image by building both amd64 and arm64 variants and pushing a
docker multiarch image manifest to the target registry.
