### PR TITLE
fix: RBAC role for namespace-sync controller to watch,list namespaces

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/role.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/role.yaml
@@ -21,6 +21,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get

--- a/pkg/controllers/namespacesync/doc.go
+++ b/pkg/controllers/namespacesync/doc.go
@@ -12,4 +12,5 @@
 //
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io;controlplane.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusterclasses,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 package namespacesync


### PR DESCRIPTION
**What problem does this PR solve?**:
Noticed an error in the logs:
```
E0620 21:23:28.879891       1 reflector.go:147] k8s.io/client-go@v0.29.6/tools/cache/reflector.go:229: Failed to watch *v1.Namespace: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:default:cluster-api-runtime-extensions-nutanix" cannot list resource "namespaces" in API group "" at the cluster scope
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
