### PR TITLE
fix: Add namespace get/list/watch perms for namespacesync controller

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/role.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/role.yaml
@@ -21,6 +21,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get

--- a/pkg/controllers/namespacesync/doc.go
+++ b/pkg/controllers/namespacesync/doc.go
@@ -1,7 +1,7 @@
 // Copyright 2024 Nutanix. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package syncclusterclass provides a controller that copies ClusterClasses and their referenced
+// Package namespacesync provides a controller that copies ClusterClasses and their referenced
 // Templates from a source namespace to target namespaces.
 //
 // For every ClusterClass in the source namespace, the controller creates a copy of it, and all its
@@ -12,4 +12,5 @@
 //
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io;controlplane.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusterclasses,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 package namespacesync


### PR DESCRIPTION
This was missing in previous PR and without an e2e test this error was hidden.
