### PR TITLE
fix: adds a docker buildx step before release-snapshot

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -195,12 +195,6 @@ jobs:
           fi
 
       - if: steps.list-changed.outputs.changed == 'true'
-        uses: docker/setup-qemu-action@v3
-
-      - if: steps.list-changed.outputs.changed == 'true'
-        uses: docker/setup-buildx-action@v3
-
-      - if: steps.list-changed.outputs.changed == 'true'
         name: Run chart-testing (lint)
         run: |
           devbox run -- \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,10 +55,6 @@ jobs:
           echo "After removing files:"
           df -h
 
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
       - name: Run e2e tests
         run: devbox run -- make e2e-test E2E_LABEL='provider:${{ inputs.provider }}' E2E_SKIP='${{ inputs.skip }}' E2E_FOCUS='${{ inputs.focus }}'
         env:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -27,10 +27,6 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -111,6 +111,7 @@ dockers:
       - hack/addons/mindthegap-helm-registry/repos.yaml
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--builder=caren"
       - "--pull"
       - "--label=org.opencontainers.image.created={{.CommitDate}}"
       - "--label=org.opencontainers.image.title=caren-helm-reg"
@@ -132,6 +133,7 @@ dockers:
       - hack/addons/mindthegap-helm-registry/repos.yaml
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--builder=caren"
       - "--pull"
       - "--label=org.opencontainers.image.created={{.CommitDate}}"
       - "--label=org.opencontainers.image.title=caren-helm-reg"

--- a/make/goreleaser.mk
+++ b/make/goreleaser.mk
@@ -9,7 +9,7 @@ export GORELEASER_CURRENT_TAG=$(GIT_TAG)
 endif
 
 .PHONY: docker-buildx
-docker-buildx:
+docker-buildx: ## Creates buildx builder container that supports multiple platforms.
 docker-buildx:
 	 docker buildx create --use --name=caren --platform=linux/arm64,linux/amd64 || true
 

--- a/make/goreleaser.mk
+++ b/make/goreleaser.mk
@@ -8,6 +8,11 @@ ifndef GORELEASER_CURRENT_TAG
 export GORELEASER_CURRENT_TAG=$(GIT_TAG)
 endif
 
+.PHONY: docker-buildx
+docker-buildx:
+docker-buildx:
+	 docker buildx create --use --name=caren --platform=linux/arm64,linux/amd64 || true
+
 .PHONY: build-snapshot
 build-snapshot: ## Builds a snapshot with goreleaser
 build-snapshot: go-generate ; $(info $(M) building snapshot $*)
@@ -30,7 +35,7 @@ release: go-generate ; $(info $(M) building release $*)
 
 .PHONY: release-snapshot
 release-snapshot: ## Builds a snapshot release with goreleaser
-release-snapshot: go-generate ; $(info $(M) building snapshot release $*)
+release-snapshot: docker-buildx go-generate ; $(info $(M) building snapshot release $*)
 	goreleaser --verbose=$(GORELEASER_VERBOSE) \
 		release \
 		--snapshot \

--- a/make/goreleaser.mk
+++ b/make/goreleaser.mk
@@ -25,7 +25,7 @@ build-snapshot: go-generate ; $(info $(M) building snapshot $*)
 
 .PHONY: release
 release: ## Builds a release with goreleaser
-release: go-generate ; $(info $(M) building release $*)
+release: docker-buildx go-generate ; $(info $(M) building release $*)
 	goreleaser --verbose=$(GORELEASER_VERBOSE) \
 		release \
 		--clean \

--- a/make/goreleaser.mk
+++ b/make/goreleaser.mk
@@ -11,7 +11,7 @@ endif
 .PHONY: docker-buildx
 docker-buildx: ## Creates buildx builder container that supports multiple platforms.
 docker-buildx:
-	 docker buildx create --use --name=caren --platform=linux/arm64,linux/amd64 || true
+	 docker buildx create --name=caren --platform=linux/arm64,linux/amd64 || true
 
 .PHONY: build-snapshot
 build-snapshot: ## Builds a snapshot with goreleaser


### PR DESCRIPTION
**What problem does this PR solve?**:

This should fix the local development flow for `make release-snapshot`.
Tested on amd64 and arm64.

We also remove unnecessary use of third-party github actions for docker

We now have a make target that creates a dockerx builder container
with multiarch support. Both the release and release-snapshot make
targets depend on this make target.

The two github actions are no longer necessary, and are removed.


**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
