### PR TITLE
build: Tidy up goreleaser config

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -223,7 +223,7 @@ jobs:
             kind load docker-image \
               --name chart-testing \
               "ko.local/cluster-api-runtime-extensions-nutanix:$(devbox run -- gojq -r .version dist/metadata.json)" \
-              "ghcr.io/nutanix-cloud-native/caren-helm-reg:$(devbox run -- gojq -r .version dist/metadata.json)"
+              "ghcr.io/nutanix-cloud-native/caren-helm-reg:$(devbox run -- gojq -r .version dist/metadata.json)-$(devbox run -- go env GOARCH)"
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Setup Cluster API and cert-manager

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,18 +41,17 @@ before:
         name: caren-system
       $(helm template {{ .ProjectName }} ./charts/{{ .ProjectName }} \
         --namespace caren-system \
-        --set-string image.tag=v{{ trimprefix .Version "v" }} \
-        --set-string helmRepositoryImage.tag=v{{ trimprefix .Version "v" }} \
-        {{ if .IsSnapshot }}--set-string image.repository=ko.local/{{ .ProjectName }}{{ end }} \
+        --set-string image.tag={{ .Version }} \
+        --set-string helmRepositoryImage.tag={{ .Version }}{{ if .IsSnapshot }}-{{ .Env.GOARCH }} \
+        --set-string image.repository=ko.local/{{ .ProjectName }}{{ end }} \
       )
       EOF'
-    - sed -i -e 's/\${/$${/g' -e 's/v0.0.0-dev/v{{ trimprefix .Version "v" }}/g' runtime-extension-components.yaml
+    - sed -i -e 's/\${/$${/g' -e 's/v0.0.0-dev/{{ .Version }}/g' runtime-extension-components.yaml
     - |
       sh -ec 'gojq --yaml-input --yaml-output \
         ".releaseSeries |= (. + [{contract: \"v1beta1\", major: {{ .Major }}, minor: {{ .Minor }}}] | unique)" \
         metadata.yaml >release-metadata.yaml'
     - make template-helm-repository
-
 
 builds:
   - id: cluster-api-runtime-extensions-nutanix
@@ -67,7 +66,7 @@ builds:
       - -X 'k8s.io/component-base/version.buildDate={{ .CommitDate }}'
       - -X 'k8s.io/component-base/version.gitCommit={{ .FullCommit }}'
       - -X 'k8s.io/component-base/version.gitTreeState={{ .Env.GIT_TREE_STATE }}'
-      - -X 'k8s.io/component-base/version.gitVersion=v{{ trimprefix .Version "v" }}'
+      - -X 'k8s.io/component-base/version.gitVersion={{ .Version }}'
       - -X 'k8s.io/component-base/version.major={{ .Major }}'
       - -X 'k8s.io/component-base/version.minor={{ .Minor }}'
       - -X 'k8s.io/component-base/version/verflag.programName={{ .ProjectName }}'
@@ -86,66 +85,52 @@ builds:
                 KO_DOCKER_REPO=ko.local/{{ .ProjectName }} \
                 ko build \
                   --bare \
-                  -t v{{ trimprefix .Version "v" }} \
+                  -t {{ .Version }} \
                   ./cmd
           fi'
 
 archives:
-  - name_template: '{{ .ProjectName }}_v{{ trimprefix .Version "v" }}_{{ .Os }}_{{ .Arch }}'
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     builds:
       - cluster-api-runtime-extensions-nutanix
 
 dockers:
   - image_templates:
-      # Specify the image tag including `-amd64` suffix if the build is not a snapshot build or is not being built on
-      # amd64 machine. This allows for using the snapshot image build without the architecture specific suffix
-      # consistently on local machines, i.e. can always use `ghcr.io/nutanix-cloud-native/caren-helm-reg:v<VERSION>` on the machine the snapshot
-      # is built on.
-      #
-      # For a release build the `-amd64` suffix will always be included and the `docker_manifests` specification below
-      # will create the final multiplatform manifest to be pushed to the registry.
-      - 'ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}{{ if or (not .IsSnapshot) (not (eq .Runtime.Goarch "amd64")) }}-amd64{{ end }}'
+      - 'ghcr.io/nutanix-cloud-native/caren-helm-reg:{{ .Version }}-amd64'
     use: buildx
     dockerfile: ./hack/addons/mindthegap-helm-registry/Dockerfile
     extra_files:
       - hack/addons/mindthegap-helm-registry/repos.yaml
     build_flag_templates:
       - "--platform=linux/amd64"
-      - "--builder=caren"
       - "--pull"
       - "--label=org.opencontainers.image.created={{.CommitDate}}"
       - "--label=org.opencontainers.image.title=caren-helm-reg"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - '--label=org.opencontainers.image.version=v{{ trimprefix .Version "v" }}'
+      - '--label=org.opencontainers.image.version={{ .Version }}'
       - "--label=org.opencontainers.image.source={{.GitURL}}"
+    goarch: amd64
   - image_templates:
-      # Specify the image tag including `-arm64` suffix if the build is not a snapshot build or is not being built on
-      # arm64 machine. This allows for using the snapshot image build without the architecture specific suffix
-      # consistently on local machines, i.e. can always use `ghcr.io/nutanix-cloud-native/caren-helm-reg:v<VERSION>` on the machine the snapshot
-      # is built on.
-      #
-      # For a release build the `-arm64` suffix will always be included and the `docker_manifests` specification below
-      # will create the final multiplatform manifest to be pushed to the registry.
-      - 'ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}{{ if or (not .IsSnapshot) (not (eq .Runtime.Goarch "arm64")) }}-arm64{{ end }}'
+      - 'ghcr.io/nutanix-cloud-native/caren-helm-reg:{{ .Version }}-arm64'
     use: buildx
     dockerfile: ./hack/addons/mindthegap-helm-registry/Dockerfile
     extra_files:
       - hack/addons/mindthegap-helm-registry/repos.yaml
     build_flag_templates:
       - "--platform=linux/arm64"
-      - "--builder=caren"
       - "--pull"
       - "--label=org.opencontainers.image.created={{.CommitDate}}"
       - "--label=org.opencontainers.image.title=caren-helm-reg"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - '--label=org.opencontainers.image.version=v{{ trimprefix .Version "v" }}'
+      - '--label=org.opencontainers.image.version={{ .Version }}'
       - "--label=org.opencontainers.image.source={{.GitURL}}"
+    goarch: arm64
 
 docker_manifests:
-  - name_template: ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}
+  - name_template: ghcr.io/nutanix-cloud-native/caren-helm-reg:{{ .Version }}
     image_templates:
-      - ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}-amd64
-      - ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}-arm64
+      - ghcr.io/nutanix-cloud-native/caren-helm-reg:{{ .Version }}-amd64
+      - ghcr.io/nutanix-cloud-native/caren-helm-reg:{{ .Version }}-arm64
 
 kos:
   - id: cluster-api-runtime-extensions-nutanix
@@ -156,7 +141,7 @@ kos:
       - -X 'k8s.io/component-base/version.buildDate={{ .CommitDate }}'
       - -X 'k8s.io/component-base/version.gitCommit={{ .FullCommit }}'
       - -X 'k8s.io/component-base/version.gitTreeState={{ .Env.GIT_TREE_STATE }}'
-      - -X 'k8s.io/component-base/version.gitVersion=v{{ trimprefix .Version "v" }}'
+      - -X 'k8s.io/component-base/version.gitVersion={{ .Version }}'
       - -X 'k8s.io/component-base/version.major={{ .Major }}'
       - -X 'k8s.io/component-base/version.minor={{ .Minor }}'
       - -X 'k8s.io/component-base/version/verflag.programName={{ .ProjectName }}'
@@ -164,7 +149,7 @@ kos:
       org.opencontainers.image.created: "{{ .CommitDate }}"
       org.opencontainers.image.title: "{{ .ProjectName }}"
       org.opencontainers.image.revision: "{{ .FullCommit }}"
-      org.opencontainers.image.version: v{{ trimprefix .Version "v" }}
+      org.opencontainers.image.version: "{{ .Version }}"
       org.opencontainers.image.source: "{{ .GitURL }}"
     platforms:
       - linux/amd64
@@ -172,7 +157,7 @@ kos:
     repository: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix
     bare: true
     tags:
-      - v{{ trimprefix .Version "v" }}
+      - "{{ .Version }}"
 
 checksum:
   name_template: 'checksums.txt'

--- a/hack/addons/mindthegap-helm-registry/Dockerfile
+++ b/hack/addons/mindthegap-helm-registry/Dockerfile
@@ -1,5 +1,16 @@
-FROM ghcr.io/mesosphere/mindthegap:v1.14.3
+ARG MINDTHEGAP_VERSION=v1.14.3
+
+FROM --platform=${BUILDPLATFORM} ghcr.io/mesosphere/mindthegap:${MINDTHEGAP_VERSION} as bundle_builder
 # this gets called by goreleaser so the copy source has to be the path relative to the repo root.
-RUN --mount=source=./hack/addons/mindthegap-helm-registry/repos.yaml,target=/repos.yaml ["/ko-app/mindthegap", "create", "bundle", "--helm-charts-file=/repos.yaml", "--output-file=/tmp/helm-charts.tar"]
+RUN --mount=source=./hack/addons/mindthegap-helm-registry/repos.yaml,target=/repos.yaml \
+    ["/ko-app/mindthegap", "create", "bundle", "--helm-charts-file=/repos.yaml", "--output-file=/tmp/helm-charts.tar"]
+
+FROM --platform=${TARGETPLATFORM} ghcr.io/mesosphere/mindthegap:${MINDTHEGAP_VERSION}
+COPY --from=bundle_builder /tmp/helm-charts.tar /tmp/helm-charts.tar
 VOLUME /certs
-CMD ["serve", "bundle", "--bundle=/tmp/helm-charts.tar", "--listen-port=5000", "--listen-address=0.0.0.0", "--tls-private-key-file=/certs/tls.key", "--tls-cert-file=/certs/tls.crt"]
+CMD [ "serve", "bundle", \
+      "--bundle=/tmp/helm-charts.tar", \
+      "--listen-port=5000", \
+      "--listen-address=0.0.0.0", \
+      "--tls-private-key-file=/certs/tls.key", \
+      "--tls-cert-file=/certs/tls.crt" ]

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -5,32 +5,32 @@
 dev.run-on-kind: export KUBECONFIG := $(KIND_KUBECONFIG)
 dev.run-on-kind: kind.create clusterctl.init
 ifndef SKIP_BUILD
-	$(MAKE) release-snapshot
+dev.run-on-kind: release-snapshot
 endif
+dev.run-on-kind:
 	kind load docker-image --name $(KIND_CLUSTER_NAME) \
-		ko.local/cluster-api-runtime-extensions-nutanix:$$(gojq -r .version dist/metadata.json)
-	kind load docker-image --name $(KIND_CLUSTER_NAME) \
-		ghcr.io/nutanix-cloud-native/caren-helm-reg:$$(gojq -r .version dist/metadata.json)
+		ko.local/cluster-api-runtime-extensions-nutanix:$$(gojq -r .version dist/metadata.json) \
+		ghcr.io/nutanix-cloud-native/caren-helm-reg:$$(gojq -r .version dist/metadata.json)-$(GOARCH)
 	helm upgrade --install cluster-api-runtime-extensions-nutanix ./charts/cluster-api-runtime-extensions-nutanix \
 		--set-string image.repository=ko.local/cluster-api-runtime-extensions-nutanix \
 		--set-string image.tag=$$(gojq -r .version dist/metadata.json) \
-		--set-string helmRepositoryImage.tag=$$(gojq -r .version dist/metadata.json) \
+		--set-string helmRepositoryImage.tag=$$(gojq -r .version dist/metadata.json)-$(GOARCH) \
 		--wait --wait-for-jobs
 	kubectl rollout restart deployment cluster-api-runtime-extensions-nutanix
 	kubectl rollout status deployment cluster-api-runtime-extensions-nutanix
 
 .PHONY: dev.update-webhook-image-on-kind
 dev.update-webhook-image-on-kind: export KUBECONFIG := $(KIND_KUBECONFIG)
-dev.update-webhook-image-on-kind:
 ifndef SKIP_BUILD
-	$(MAKE) release-snapshot
+dev.update-webhook-image-on-kind: release-snapshot
 endif
+dev.update-webhook-image-on-kind:
 	kind load docker-image --name $(KIND_CLUSTER_NAME) \
-		ko.local/cluster-api-runtime-extensions-nutanix:$$(gojq -r .version dist/metadata.json)
-	kubectl set image deployment cluster-api-runtime-extensions-nutanix webhook=ko.local/cluster-api-runtime-extensions-nutanix:$$(gojq -r .version dist/metadata.json)
+	  ko.local/cluster-api-runtime-extensions-nutanix:$$(gojq -r .version dist/metadata.json)
+	kubectl set image deployment \
+	  cluster-api-runtime-extensions-nutanix webhook=ko.local/cluster-api-runtime-extensions-nutanix:$$(gojq -r .version dist/metadata.json)
 	kubectl rollout restart deployment cluster-api-runtime-extensions-nutanix
 	kubectl rollout status deployment cluster-api-runtime-extensions-nutanix
-
 
 .PHONY: dev.update-bootstrap-credentials-aws
 dev.update-bootstrap-credentials-aws: export KUBECONFIG := $(KIND_KUBECONFIG)

--- a/make/go.mk
+++ b/make/go.mk
@@ -52,13 +52,13 @@ test.%: go-generate ; $(info $(M) running tests$(if $(GOTEST_RUN), matching "$(G
 
 .PHONY: integration-test
 integration-test: ## Runs integration tests for all modules in repository
-integration-test:
-	$(MAKE) GOTEST_RUN=Integration test
+integration-test: GOTEST_RUN := Integration
+integration-test: test
 
 .PHONY: integration-test.%
 integration-test.%: ## Runs integration tests for a specific module
-integration-test.%:
-	$(MAKE) GOTEST_RUN=Integration test.$*
+integration-test.%: GOTEST_RUN := Integration
+integration-test.%: test.$*
 
 .PHONY: bench
 bench: ## Runs go benchmarks for all modules in repository

--- a/make/goreleaser.mk
+++ b/make/goreleaser.mk
@@ -8,11 +8,6 @@ ifndef GORELEASER_CURRENT_TAG
 export GORELEASER_CURRENT_TAG=$(GIT_TAG)
 endif
 
-.PHONY: docker-buildx
-docker-buildx: ## Creates buildx builder container that supports multiple platforms.
-docker-buildx:
-	 docker buildx create --name=caren --platform=linux/arm64,linux/amd64 || true
-
 .PHONY: build-snapshot
 build-snapshot: ## Builds a snapshot with goreleaser
 build-snapshot: go-generate ; $(info $(M) building snapshot $*)
@@ -25,7 +20,7 @@ build-snapshot: go-generate ; $(info $(M) building snapshot $*)
 
 .PHONY: release
 release: ## Builds a release with goreleaser
-release: docker-buildx go-generate ; $(info $(M) building release $*)
+release: go-generate ; $(info $(M) building release $*)
 	goreleaser --verbose=$(GORELEASER_VERBOSE) \
 		release \
 		--clean \
@@ -35,7 +30,7 @@ release: docker-buildx go-generate ; $(info $(M) building release $*)
 
 .PHONY: release-snapshot
 release-snapshot: ## Builds a snapshot release with goreleaser
-release-snapshot: docker-buildx go-generate ; $(info $(M) building snapshot release $*)
+release-snapshot: go-generate ; $(info $(M) building snapshot release $*)
 	goreleaser --verbose=$(GORELEASER_VERBOSE) \
 		release \
 		--snapshot \

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -6,7 +6,7 @@ managementClusterName: caren-e2e
 images:
   - name: ko.local/cluster-api-runtime-extensions-nutanix:${E2E_IMAGE_TAG}
     loadBehavior: mustLoad
-  - name: ghcr.io/nutanix-cloud-native/caren-helm-reg:${E2E_IMAGE_TAG}
+  - name: ghcr.io/nutanix-cloud-native/caren-helm-reg:${E2E_IMAGE_TAG}-${GOARCH}
     loadBehavior: mustLoad
 
 providers:


### PR DESCRIPTION
This commit tidies up the goreleaser config that contained some
configuration that is no longer required, e.g. deleting the `v`

prefix handling code; templating the arch specific Docker
image builds (now handled by loading the arch specific
image into KinD and e2e environment); and removing the
caren buildx build container (changing the helm registry
Dockerfile to be a multistage build to only run the
compatible architecture of mindthegap).
