### PR TITLE
test(e2e): Set empty env vars for Nutanix e2e vars

### DIFF
--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -185,16 +185,18 @@ variables:
   AMI_LOOKUP_BASEOS: "rocky-9.1"
   AMI_LOOKUP_ORG: "999867407951"
   # To run Nutanix provider tests, set following variables here or as an env var
-  # # IP/FQDN of Prism Central.
-  # NUTANIX_ENDPOINT: ""
+  # IP/FQDN of Prism Central.
+  # NOTE: This has to be overridden by specifying the env var NUTANIX_ENDPOINT when running the e2e tests. It is
+  # set as empty here to enable running the e2e tests for non-nutanix providers locally without setting the env var.
+  NUTANIX_ENDPOINT: ""
   # # Port of Prism Central. Default: 9440
   # NUTANIX_PORT: 9440
   # # Disable Prism Central certificate checking. Default: false
   # NUTANIX_INSECURE: false
   # # Prism Central user
-  # NUTANIX_USER: ""
+  NUTANIX_USER: ""
   # # Prism Central password
-  # NUTANIX_PASSWORD: ""
+  NUTANIX_PASSWORD: ""
   # # Host IP to be assigned to the CAPX Kubernetes cluster.
   # CONTROL_PLANE_ENDPOINT_IP: ""
   # # Port of the CAPX Kubernetes cluster. Default: 6443


### PR DESCRIPTION
When running e2e tests for other providers, it is currently necessary
to export empty variables for `NUTANIX_ENDPOINT`, `NUTANIX_PASSWORD`
and `NUTANIX_USER`. This commit sets these to empty values in the
e2e configuration so they are not required for other providers e2e
tests but can still be overridden when running the Nutanix e2e tests.
