### PR TITLE
fix: Temporarily hard-code supported PC version for Nutanix CSI

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/nutanix/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/nutanix/manifests/helm-addon-installation.yaml
@@ -24,4 +24,7 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
         operator: Exists
+
+    # TODO Remove this once the Nutanix 3.0 CSI driver is GA.
+    supportedPCVersions: master,fraser-2024.1-stable-pc-0,fraser-2023.4-stable-pc-0,fraser-2024.1-stable-pc-0.1
 {{- end -}}


### PR DESCRIPTION
Necessary until this is fixed in GA Nutanix CSI 3.0 release.

CSI pods come up testing against Sherlock!

```
ntnx-system              nutanix-csi-controller-574bdd7b96-4v9fs               7/7     Running             0  4m22s
ntnx-system              nutanix-csi-controller-574bdd7b96-nd8r6               7/7     Running             0  4m22s
ntnx-system              nutanix-csi-node-n5sfx                                3/3     Running             0  2m1s
ntnx-system              nutanix-csi-node-plx8l                                3/3     Running             0  3m31s
```