### PR TITLE
fix: skip kubeadm CA file when Secret doesn't have a CA 

### DIFF
--- a/pkg/handlers/generic/mutation/mirrors/containerd_files.go
+++ b/pkg/handlers/generic/mutation/mirrors/containerd_files.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	containerdHostsConfigurationOnRemote = "/etc/containerd/certs.d/_default/hosts.toml"
-	secretKeyForMirrorCACert             = "ca.crt"
+	secretKeyForCACert                   = "ca.crt"
 )
 
 var (
@@ -159,7 +159,7 @@ func generateRegistryCACertFiles(
 			ContentFrom: &cabpkv1.FileSource{
 				Secret: cabpkv1.SecretFileSource{
 					Name: config.CASecretName,
-					Key:  secretKeyForMirrorCACert,
+					Key:  secretKeyForCACert,
 				},
 			},
 		})

--- a/pkg/handlers/generic/mutation/mirrors/inject.go
+++ b/pkg/handlers/generic/mutation/mirrors/inject.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -193,9 +194,9 @@ func containerdConfigFromGlobalMirror(
 		)
 	}
 
-	if secret != nil {
+	if secretHasCACert(secret) {
 		configWithOptionalCACert.CASecretName = secret.Name
-		configWithOptionalCACert.CACert = string(secret.Data[secretKeyForMirrorCACert])
+		configWithOptionalCACert.CACert = string(secret.Data[secretKeyForCACert])
 	}
 
 	return configWithOptionalCACert, nil
@@ -225,9 +226,9 @@ func containerdConfigFromImageRegistry(
 		)
 	}
 
-	if secret != nil {
+	if secretHasCACert(secret) {
 		configWithOptionalCACert.CASecretName = secret.Name
-		configWithOptionalCACert.CACert = string(secret.Data[secretKeyForMirrorCACert])
+		configWithOptionalCACert.CACert = string(secret.Data[secretKeyForCACert])
 	}
 
 	return configWithOptionalCACert, nil
@@ -270,4 +271,13 @@ func needContainerdConfiguration(configs []containerdConfig) bool {
 	}
 
 	return false
+}
+
+func secretHasCACert(secret *corev1.Secret) bool {
+	if secret == nil {
+		return false
+	}
+
+	_, ok := secret.Data[secretKeyForCACert]
+	return ok
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
Found a bug when testing with a mirror registry where it doesn't have the CA key set in the Secret.
The handler incorrectly generated a patch to add `/etc/certs/...` file with a Secret source and key `ca.crt`, however its possible that the Secret does not have that key set.
Example of an incorrect file:
```
  - contentFrom:
      secret:
        key: ca.crt
        name: e2e-aws-ag-cc-test-1719374309-image-registry-mirror-credentials
    path: /etc/certs/999867407951.dkr.ecr.us-west-2.amazonaws.com-e2e-aws-ag-cc-test-1719374309.pem
    permissions: "0600"
```
This led to CAPI failing because `ca.crt` did not exist in the Secret.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
The first commit contains a failing unit tests to cover this scenario.

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
