### PR TITLE
test(e2e): Correct default helm release names for AWS CCM and EBS CSI

### DIFF
--- a/test/e2e/ccm_helpers.go
+++ b/test/e2e/ccm_helpers.go
@@ -62,10 +62,6 @@ func WaitForCCMToBeReadyInWorkloadCluster(
 	}
 }
 
-const (
-	awsCCMPrefix = "aws-ccm-"
-)
-
 func WaitForAWSCCMToBeReadyInWorkloadCluster(
 	ctx context.Context,
 	workloadClusterClient client.Client,
@@ -77,7 +73,7 @@ func WaitForAWSCCMToBeReadyInWorkloadCluster(
 		Expect(input.ClusterProxy.GetClient().Get(
 			ctx,
 			types.NamespacedName{
-				Name:      awsCCMPrefix + input.WorkloadCluster.Name,
+				Name:      "aws-ccm-" + input.WorkloadCluster.Name,
 				Namespace: input.WorkloadCluster.Namespace,
 			},
 			crs,
@@ -98,7 +94,7 @@ func WaitForAWSCCMToBeReadyInWorkloadCluster(
 			WaitForHelmReleaseProxyReadyForClusterInput{
 				GetLister:          input.ClusterProxy.GetClient(),
 				Cluster:            input.WorkloadCluster,
-				HelmChartProxyName: awsCCMPrefix + input.WorkloadCluster.Name,
+				HelmChartProxyName: "aws-cloud-controller-manager-" + input.WorkloadCluster.Name,
 			},
 			input.HelmReleaseIntervals...,
 		)

--- a/test/e2e/csi_helpers.go
+++ b/test/e2e/csi_helpers.go
@@ -238,7 +238,7 @@ func waitForAWSEBSCSIToBeReadyInWorkloadCluster(
 			WaitForHelmReleaseProxyReadyForClusterInput{
 				GetLister:          input.clusterProxy.GetClient(),
 				Cluster:            input.workloadCluster,
-				HelmChartProxyName: "aws-ebs-csi-" + input.workloadCluster.Name,
+				HelmChartProxyName: "aws-ebs-csi-driver-" + input.workloadCluster.Name,
 			},
 			input.helmReleaseIntervals...,
 		)


### PR DESCRIPTION
This was missed in previous PR, but discovered by manually running
AWS e2e test suite.
