### PR TITLE
fix: Add strategy to Nutanix CCM addon in examples

### DIFF
--- a/examples/capi-quick-start/nutanix-cluster-calico-crs.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-calico-crs.yaml
@@ -67,6 +67,7 @@ spec:
             credentials:
               secretRef:
                 name: ${CLUSTER_NAME}-pc-creds
+            strategy: HelmAddon
           clusterAutoscaler:
             strategy: ClusterResourceSet
           cni:

--- a/examples/capi-quick-start/nutanix-cluster-calico-helm-addon.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-calico-helm-addon.yaml
@@ -67,6 +67,7 @@ spec:
             credentials:
               secretRef:
                 name: ${CLUSTER_NAME}-pc-creds
+            strategy: HelmAddon
           clusterAutoscaler:
             strategy: HelmAddon
           cni:

--- a/examples/capi-quick-start/nutanix-cluster-cilium-crs.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-cilium-crs.yaml
@@ -67,6 +67,7 @@ spec:
             credentials:
               secretRef:
                 name: ${CLUSTER_NAME}-pc-creds
+            strategy: HelmAddon
           clusterAutoscaler:
             strategy: ClusterResourceSet
           cni:

--- a/examples/capi-quick-start/nutanix-cluster-cilium-helm-addon.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-cilium-helm-addon.yaml
@@ -67,6 +67,7 @@ spec:
             credentials:
               secretRef:
                 name: ${CLUSTER_NAME}-pc-creds
+            strategy: HelmAddon
           clusterAutoscaler:
             strategy: HelmAddon
           cni:

--- a/hack/addons/kustomize/nutanix-ccm/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/nutanix-ccm/kustomization.yaml.tmpl
@@ -13,6 +13,5 @@ helmCharts:
   repo: https://nutanix.github.io/helm/
   releaseName: nutanix-ccm
   version: ${NUTANIX_CCM_CHART_VERSION}
-  valuesFile: helm-values.yaml
   includeCRDs: true
   skipTests: true

--- a/hack/examples/patches/nutanix/ccm.yaml
+++ b/hack/examples/patches/nutanix/ccm.yaml
@@ -7,3 +7,4 @@
     credentials:
       secretRef:
         name: ${CLUSTER_NAME}-pc-creds
+    strategy: HelmAddon


### PR DESCRIPTION
Missed in previous PR when this ws refactored for AWS CCM. This
was not found in the PR checks because we still do not have CI
running on Nutanix infrastructure - but that is coming soon!

I have tested this manually by running e2e against sherlock dev.