### PR TITLE
ci: Use coreutils shuf instead of devbox shuf

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           CONTROL_PLANE_ENDPOINT_RANGE_START="${{ vars.NUTANIX_CONTROL_PLANE_ENDPOINT_RANGE_START }}"
           CONTROL_PLANE_ENDPOINT_RANGE_END="${{ vars.NUTANIX_CONTROL_PLANE_ENDPOINT_RANGE_END }}"
-          control_plane_endpoint_ip="$(devbox run -- fping -g -u "${CONTROL_PLANE_ENDPOINT_RANGE_START}" "${CONTROL_PLANE_ENDPOINT_RANGE_END}" | devbox run -- shuf --head-count=1)"
+          control_plane_endpoint_ip="$(devbox run -- fping -g -u "${CONTROL_PLANE_ENDPOINT_RANGE_START}" "${CONTROL_PLANE_ENDPOINT_RANGE_END}" | shuf --head-count=1)"
           echo "control_plane_endpoint_ip=${control_plane_endpoint_ip}" >> "${GITHUB_OUTPUT}"
 
       - name: Check Control Plane endpoint IP


### PR DESCRIPTION
This will hopefully reduce the following errors coming out of devbox

/usr/bin/sh: 1: /home/runner/_work/cluster-api-runtime-extensions-nutanix/cluster-api-runtime-extensions-nutanix/.devbox/gen/scripts/.cmd.sh: Text file busy
Error: error running script "shuf" in Devbox: exit status 126
Error: error running script "fping" in Devbox: exit status 141