### PR TITLE
build: Fix devbox run errors due to piped commands

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -191,6 +191,8 @@ jobs:
 
   lint-test-helm:
     runs-on: ubuntu-22.04
+    env:
+      KIND_CLUSTER_NAME: chart-testing
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -220,34 +222,26 @@ jobs:
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Create kind cluster
-        run: |
-          devbox run -- \
-            kind create cluster \
-              --image=ghcr.io/mesosphere/kind-node:"$(devbox run -- kubectl version --output=json --client | devbox run -- gojq --raw-output .clientVersion.gitVersion)" \
-              --name=chart-testing
+        run: devbox run -- make kind.create
         env:
           KUBECONFIG: ct-kind-kubeconfig
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Build Docker images
-        run: |
-          devbox run -- \
-            make release-snapshot
+        run: devbox run -- make release-snapshot
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Sideload docker image
         run: |
           devbox run -- \
             kind load docker-image \
-              --name chart-testing \
+              --name "${KIND_CLUSTER_NAME}" \
               "ko.local/cluster-api-runtime-extensions-nutanix:$(devbox run -- gojq -r .version dist/metadata.json)" \
               "ghcr.io/nutanix-cloud-native/caren-helm-reg:$(devbox run -- gojq -r .version dist/metadata.json)-$(devbox run -- go env GOARCH)"
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Setup Cluster API and cert-manager
-        run: |
-          devbox run -- \
-            make clusterctl.init
+        run: devbox run -- make clusterctl.init
         env:
           KIND_KUBECONFIG: ct-kind-kubeconfig
 
@@ -264,8 +258,7 @@ jobs:
       - if: steps.list-changed.outputs.changed == 'true' && always()
         name: Delete chart-testing KinD cluster
         run: |
-          devbox run -- \
-            kind delete cluster --name chart-testing || true
+          devbox run -- make kind.delete
 
   govulncheck:
     runs-on: ubuntu-22.04

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,9 +81,9 @@ jobs:
         id: get-control-plane-endpoint-ip
         if: inputs.provider == 'Nutanix'
         run: |
-          CONTROL_PLANE_ENDPOINT_RANGE_START="${{ vars.NUTANIX_CONTROL_PLANE_ENDPOINT_RANGE_START }}"
-          CONTROL_PLANE_ENDPOINT_RANGE_END="${{ vars.NUTANIX_CONTROL_PLANE_ENDPOINT_RANGE_END }}"
-          control_plane_endpoint_ip="$(devbox run -- fping -g -u "${CONTROL_PLANE_ENDPOINT_RANGE_START}" "${CONTROL_PLANE_ENDPOINT_RANGE_END}" | devbox run -- shuf --head-count=1)"
+          export CONTROL_PLANE_ENDPOINT_RANGE_START="${{ vars.NUTANIX_CONTROL_PLANE_ENDPOINT_RANGE_START }}"
+          export CONTROL_PLANE_ENDPOINT_RANGE_END="${{ vars.NUTANIX_CONTROL_PLANE_ENDPOINT_RANGE_END }}"
+          control_plane_endpoint_ip="$(devbox run -- make nutanix-cp-endpoint-ip)"
           echo "control_plane_endpoint_ip=${control_plane_endpoint_ip}" >> "${GITHUB_OUTPUT}"
 
       - name: Check Control Plane endpoint IP

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mapfile -t releases < <( devbox run -- gh release list --json tagName | devbox run -- gojq -r .[].tagName )
+          mapfile -t releases < <( devbox run -- make list-releases )
           for release in "${releases[@]}"; do
             if devbox run -- gh release download "${release}" \
                 --pattern 'cluster-api-runtime-extensions-nutanix-*.tgz' \

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -55,3 +55,7 @@ endif
 	gojq --yaml-input --raw-output '.variables | to_entries | map("export \(.key)=\(.value|tostring)")|.[]' < test/e2e/config/caren.yaml | envsubst > .envrc.e2e
 	setup-envtest use -p env $(ENVTEST_VERSION) >> .envrc.e2e
 	direnv reload
+
+.PHONY: nutanix-cp-endpoint-ip
+nutanix-cp-endpoint-ip: ## Gets a random IP from the control plane endpoint range.
+	shuf --head-count=1 < <(fping -g -u "$(CONTROL_PLANE_ENDPOINT_RANGE_START)" "$(CONTROL_PLANE_ENDPOINT_RANGE_END)")

--- a/make/goreleaser.mk
+++ b/make/goreleaser.mk
@@ -37,3 +37,7 @@ release-snapshot: go-generate ; $(info $(M) building snapshot release $*)
 		--clean \
 		--parallelism=$(GORELEASER_PARALLELISM) \
 		--timeout=60m
+
+.PHONY: list-releases
+list-releases: ## List releases from GitHub
+	gh release list --json tagName | gojq -r .[].tagName


### PR DESCRIPTION
Piping from and to devbox commands leads to errors like `Text
file busy` or `No file found` as they attempt to write their
respective commands to temporary files. Moving these to devbox
scripts should fix this and bring CI back to stable.
