### PR TITLE
fix: use minimal image when deploying nfd chart

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/helm-addon-installation.yaml
@@ -8,6 +8,8 @@ metadata:
   name: '{{ .Values.hooks.nfd.helmAddonStrategy.defaultValueTemplateConfigMap.name }}'
 data:
   values.yaml: |-
+    image:
+      tag: v0.15.2-minimal
     master:
       extraLabelNs:
         - nvidia.com


### PR DESCRIPTION
**What problem does this PR solve?**:
When deploying with the helm addon strategy i noticed that we did not deploy the minimal image. 

I'm going to follow this up with a PR that automates syncing the values in the templates and `hack/addons/kustomize/**/helm-values.yaml` 

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
