### PR TITLE
fix: Namespacesync controller should reconcile an updated namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -173,7 +173,7 @@ func main() {
 			Client:                      mgr.GetClient(),
 			UnstructuredCachingClient:   unstructuredCachingClient,
 			SourceClusterClassNamespace: namespacesyncOptions.SourceNamespace,
-			TargetNamespaceFilter:       namespacesync.NamespaceHasLabelKey(namespacesyncOptions.TargetNamespaceLabelKey),
+			IsTargetNamespace:           namespacesync.NamespaceHasLabelKey(namespacesyncOptions.TargetNamespaceLabelKey),
 		}).SetupWithManager(
 			signalCtx,
 			mgr,

--- a/pkg/controllers/namespacesync/controller.go
+++ b/pkg/controllers/namespacesync/controller.go
@@ -66,9 +66,8 @@ func (r *Reconciler) SetupWithManager(
 							return false
 						}
 						// Only reconcile the namespace if the answer to the question "Is this a
-						// target namespace?" has changed. Other changes are not relevant to
-						// this controller.
-						return r.IsTargetNamespace(nsOld) != r.IsTargetNamespace(nsNew)
+						// target namespace?" changed from no to yes.
+						return !r.IsTargetNamespace(nsOld) && r.IsTargetNamespace(nsNew)
 					},
 					DeleteFunc: func(e event.DeleteEvent) bool {
 						// Ignore deletes.

--- a/pkg/controllers/namespacesync/controller.go
+++ b/pkg/controllers/namespacesync/controller.go
@@ -57,7 +57,18 @@ func (r *Reconciler) SetupWithManager(
 					UpdateFunc: func(e event.UpdateEvent) bool {
 						// Called when an object is already in the cache, and it is either updated,
 						// or fetched as part of a re-list (aka re-sync).
-						return false
+						nsOld, ok := e.ObjectOld.(*corev1.Namespace)
+						if !ok {
+							return false
+						}
+						nsNew, ok := e.ObjectNew.(*corev1.Namespace)
+						if !ok {
+							return false
+						}
+						// Only reconcile the namespace if the answer to the question "Is this a
+						// target namespace?" has changed. Other changes are not relevant to
+						// this controller.
+						return r.TargetNamespaceFilter(nsOld) != r.TargetNamespaceFilter(nsNew)
 					},
 					DeleteFunc: func(e event.DeleteEvent) bool {
 						// Ignore deletes.

--- a/pkg/controllers/namespacesync/suite_test.go
+++ b/pkg/controllers/namespacesync/suite_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 			Client:                      mgr.GetClient(),
 			UnstructuredCachingClient:   unstructuredCachingClient,
 			SourceClusterClassNamespace: sourceClusterClassNamespace,
-			TargetNamespaceFilter:       NamespaceHasLabelKey(targetNamespaceLabelKey),
+			IsTargetNamespace:           NamespaceHasLabelKey(targetNamespaceLabelKey),
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("unable to create reconciler: %v", err))
 		}


### PR DESCRIPTION
**What problem does this PR solve?**:
The namespacesync controller did not reconcile a namespace when it was updated. We anticipated namespaces to meet the criteria for "target namespace" when they were created. We also wanted to avoid reconciling namespaces unnecessarily.

This PR makes the controller reconcile an updated namespace, if the answer to question "is this a target namespace," has changed. It also adds an integration test (which fails without the subsequent fix commit).

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
