### PR TITLE
ci: Fix ct check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -193,6 +193,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       KIND_CLUSTER_NAME: chart-testing
+      KIND_KUBECONFIG: ct-kind-kubeconfig
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -223,8 +224,6 @@ jobs:
       - if: steps.list-changed.outputs.changed == 'true'
         name: Create kind cluster
         run: devbox run -- make kind.create
-        env:
-          KUBECONFIG: ct-kind-kubeconfig
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Build Docker images
@@ -242,8 +241,6 @@ jobs:
       - if: steps.list-changed.outputs.changed == 'true'
         name: Setup Cluster API and cert-manager
         run: devbox run -- make clusterctl.init
-        env:
-          KIND_KUBECONFIG: ct-kind-kubeconfig
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Run chart-testing (install)
@@ -253,7 +250,7 @@ jobs:
               --config charts/ct-config.yaml \
               --helm-extra-set-args "--set-string image.repository=ko.local/cluster-api-runtime-extensions-nutanix --set-string image.tag=$(devbox run -- gojq -r .version dist/metadata.json) --set-string helmRepositoryImage.tag=$(devbox run -- gojq -r .version dist/metadata.json)-$(devbox run -- go env GOARCH)"
         env:
-          KUBECONFIG: ct-kind-kubeconfig
+          KUBECONFIG: ${{ env.KIND_KUBECONFIG }}
 
       - if: steps.list-changed.outputs.changed == 'true' && always()
         name: Delete chart-testing KinD cluster

--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2023 Nutanix. All rights reserved.
+ Copyright 2024 Nutanix. All rights reserved.
  SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/charts/cluster-api-runtime-extensions-nutanix/README.md.gotmpl
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md.gotmpl
@@ -1,5 +1,5 @@
 <!--
- Copyright 2023 Nutanix. All rights reserved.
+ Copyright 2024 Nutanix. All rights reserved.
  SPDX-License-Identifier: Apache-2.0
  -->
 


### PR DESCRIPTION
Broken in previous update by not setting the `KUBECONFIG`
correctly.

Also update the date in chart README to trigger the ct
workflow which only runs when the chart is updated to
ensure this is actually fixed.
