### PR TITLE
ci: Move govulncheck to nightly and push to main triggers

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -256,23 +256,3 @@ jobs:
         name: Delete chart-testing KinD cluster
         run: |
           devbox run -- make kind.delete
-
-  govulncheck:
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        module: [api, common, .]
-      fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install devbox
-        uses: jetify-com/devbox-install-action@v0.11.0
-        with:
-          enable-cache: true
-
-      - id: govulncheck
-        run: devbox run -- make govulncheck.${{ matrix.module }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,36 @@
+# Copyright 2023 Nutanix. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: govulncheck
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+jobs:
+  govulncheck:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        module: [api, common, .]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.11.0
+        with:
+          enable-cache: true
+
+      - id: govulncheck
+        run: devbox run -- make govulncheck.${{ matrix.module }}


### PR DESCRIPTION
This removes potentially confusing checks on PRs while still giving
early feedback on CVEs that may have been introduced.
