### PR TITLE
feat: Apply MetalLB configuration to remote cluster

### DIFF
--- a/pkg/handlers/generic/lifecycle/serviceloadbalancer/handler.go
+++ b/pkg/handlers/generic/lifecycle/serviceloadbalancer/handler.go
@@ -22,6 +22,7 @@ import (
 type ServiceLoadBalancerProvider interface {
 	Apply(
 		ctx context.Context,
+		slb v1alpha1.ServiceLoadBalancer,
 		cluster *clusterv1.Cluster,
 		log logr.Logger,
 	) error
@@ -131,6 +132,7 @@ func (s *ServiceLoadBalancerHandler) apply(
 	log.Info(fmt.Sprintf("Deploying ServiceLoadBalancer provider %s", slb.Provider))
 	err = handler.Apply(
 		ctx,
+		slb,
 		cluster,
 		log,
 	)

--- a/pkg/handlers/generic/lifecycle/serviceloadbalancer/handler_test.go
+++ b/pkg/handlers/generic/lifecycle/serviceloadbalancer/handler_test.go
@@ -25,6 +25,7 @@ type fakeServiceLoadBalancerProvider struct {
 
 func (p *fakeServiceLoadBalancerProvider) Apply(
 	ctx context.Context,
+	slb v1alpha1.ServiceLoadBalancer,
 	cluster *clusterv1.Cluster,
 	log logr.Logger,
 ) error {

--- a/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/configuration.go
+++ b/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/configuration.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package metallb
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+)
+
+func groupVersionKind(kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "metallb.io",
+		Version: "v1beta1",
+		Kind:    kind,
+	}
+}
+
+type configurationInput struct {
+	name          string
+	namespace     string
+	addressRanges []v1alpha1.AddressRange
+}
+
+func configurationObjects(input *configurationInput) ([]unstructured.Unstructured, error) {
+	ipAddressPool := unstructured.Unstructured{}
+	ipAddressPool.SetGroupVersionKind(groupVersionKind("IPAddressPool"))
+	ipAddressPool.SetName(input.name)
+	ipAddressPool.SetNamespace(input.namespace)
+
+	addresses := []string{}
+	for _, ar := range input.addressRanges {
+		addresses = append(addresses, fmt.Sprintf("%s-%s", ar.Start, ar.End))
+	}
+	if err := unstructured.SetNestedStringSlice(
+		ipAddressPool.Object,
+		addresses,
+		"spec",
+		"addresses",
+	); err != nil {
+		return nil, fmt.Errorf("failed to set IPAddressPool .spec.addresses: %w", err)
+	}
+
+	l2Advertisement := unstructured.Unstructured{}
+	l2Advertisement.SetGroupVersionKind(groupVersionKind("L2Advertisement"))
+	l2Advertisement.SetName(input.name)
+	l2Advertisement.SetNamespace(input.namespace)
+
+	if err := unstructured.SetNestedStringSlice(
+		l2Advertisement.Object,
+		[]string{
+			ipAddressPool.GetName(),
+		},
+		"spec",
+		"ipAddressPools",
+	); err != nil {
+		return nil, fmt.Errorf("failed to set L2Advertisement .spec.ipAddressPools: %w", err)
+	}
+
+	return []unstructured.Unstructured{
+		ipAddressPool,
+		l2Advertisement,
+	}, nil
+}

--- a/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/handler.go
+++ b/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/handler.go
@@ -6,20 +6,25 @@ package metallb
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	caaphv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/k8s/client"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/lifecycle/config"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/options"
 	handlersutils "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/utils"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/wait"
 )
 
 const (
@@ -70,6 +75,7 @@ func New(
 
 func (n *MetalLB) Apply(
 	ctx context.Context,
+	slb v1alpha1.ServiceLoadBalancer,
 	cluster *clusterv1.Cluster,
 	log logr.Logger,
 ) error {
@@ -150,6 +156,78 @@ func (n *MetalLB) Apply(
 
 	if err = client.ServerSideApply(ctx, n.client, hcp); err != nil {
 		return fmt.Errorf("failed to apply MetalLB installation HelmChartProxy: %w", err)
+	}
+
+	if err := wait.ForObject(
+		ctx,
+		wait.ForObjectInput[*caaphv1.HelmChartProxy]{
+			Reader: n.client,
+			Target: hcp.DeepCopy(),
+			Check: func(_ context.Context, obj *caaphv1.HelmChartProxy) (bool, error) {
+				for _, c := range obj.GetConditions() {
+					if c.Type == caaphv1.HelmReleaseProxiesReadyCondition && c.Status == corev1.ConditionTrue {
+						return true, nil
+					}
+				}
+				return false, nil
+			},
+			Interval: 5 * time.Second,
+			Timeout:  10 * time.Second,
+		},
+	); err != nil {
+		return fmt.Errorf("failed to wait for MetalLB to deploy: %w", err)
+	}
+
+	log.Info(
+		fmt.Sprintf("Applying MetalLB configuration to cluster %s",
+			ctrlclient.ObjectKeyFromObject(cluster),
+		),
+	)
+
+	cos, err := configurationObjects(&configurationInput{
+		name:          defaultHelmReleaseName,
+		namespace:     defaultHelmReleaseNamespace,
+		addressRanges: slb.Configuration.AddressRanges,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to generate MetalLB configuration: %w", err)
+	}
+
+	var applyErr error
+	if waitErr := kwait.PollUntilContextTimeout(
+		ctx,
+		5*time.Second,
+		10*time.Second,
+		true,
+		func(ctx context.Context) (done bool, err error) {
+			for i := range cos {
+				o := &cos[i]
+				if err = client.ServerSideApply(
+					ctx,
+					remoteClient,
+					o,
+					&ctrlclient.PatchOptions{
+						Raw: &metav1.PatchOptions{
+							FieldValidation: metav1.FieldValidationStrict,
+						},
+					},
+				); err != nil {
+					applyErr = fmt.Errorf(
+						"failed to apply MetalLB configuration %s %s: %w",
+						o.GetKind(),
+						ctrlclient.ObjectKeyFromObject(o),
+						err,
+					)
+					return false, nil
+				}
+			}
+			return true, nil
+		},
+	); waitErr != nil {
+		if applyErr != nil {
+			return fmt.Errorf("%w: last apply error: %w", waitErr, applyErr)
+		}
+		return fmt.Errorf("%w: failed to apply MetalLB configuration", waitErr)
 	}
 
 	return nil

--- a/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/handler.go
+++ b/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/handler.go
@@ -172,7 +172,7 @@ func (n *MetalLB) Apply(
 				return false, nil
 			},
 			Interval: 5 * time.Second,
-			Timeout:  10 * time.Second,
+			Timeout:  30 * time.Second,
 		},
 	); err != nil {
 		return fmt.Errorf("failed to wait for MetalLB to deploy: %w", err)
@@ -197,7 +197,7 @@ func (n *MetalLB) Apply(
 	if waitErr := kwait.PollUntilContextTimeout(
 		ctx,
 		5*time.Second,
-		10*time.Second,
+		30*time.Second,
 		true,
 		func(ctx context.Context) (done bool, err error) {
 			for i := range cos {


### PR DESCRIPTION
**What problem does this PR solve?**:
- Generates MetalLB configuration from ServiceLoadBalancer Configuration API (added in #778)
- Waits for MetalLB helm chart to be successfully deployed (using waiter added in #777)
- Applies MetalLB configuration to remote cluster, also using a wait.

To apply MetalLB configuration, the MetalLB CRD webhooks must be ready. This is not guaranteed to happen once the MetalLB helm chart is successfully deployed.

Because the MetalLB configuration is applied in a non-blocking lifecycle hook, the topology controller retries the hook immediately after it returns; we cannot ask for a delay. Because the topology controller backs off its requests exponentially, this often results in the hook requests being delayed for 3+ minutes before succeeding. 

To mitigate this exponential backoff, the hook retries internally for to up to 20 seconds, within the 30 seconds recommended by the Cluster API.

<details>
<summary>Related log excerpt</summary>

```
    I0628 19:39:31.051929       1 handler.go:132] "Deploying ServiceLoadBalancer provider MetalLB" cluster="default/dlipovetsky"
    I0628 19:39:31.051954       1 handler.go:82] "Applying MetalLB installation" cluster="default/dlipovetsky"
    I0628 19:39:31.100706       1 cm.go:82] "Fetching HelmChart info for \"metallb\" from configmap default/default-helm-addons-config" cluster="default/dlipovetsky"
    E0628 19:39:41.031497       1 handler.go:140] "failed to deploy ServiceLoadBalancer provider MetalLB" err="context canceled: last apply error: failed to apply MetalLB configuration IPAddressPool metallb-system/metallb: server-side apply failed: Patch \"https://172.18.0.2:6443/apis/metallb.io/v1beta1/namespaces/metallb-system/ipaddresspools/metallb?fieldManager=cluster-api-runtime-extensions-nutanix&fieldValidation=Strict&timeout=10s\": context canceled" cluster="default/dlipovetsky"
    ...
    E0628 19:43:49.496027       1 handler.go:140] "failed to deploy ServiceLoadBalancer provider MetalLB" err="context canceled: last apply error: failed to apply MetalLB configuration IPAddressPool metallb-system/metallb: server-side apply failed: Internal error occurred: failed calling webhook \"ipaddresspoolvalidationwebhook.metallb.io\": failed to call webhook: Post \"https://metallb-webhook-service.metallb-system.svc:443/validate-metallb-io-v1beta1-ipaddresspool?timeout=10s\": dial tcp 10.130.84.48:443: connect: connection refused" cluster="default/dlipovetsky"
    I0628 19:43:51.785907       1 handler.go:132] "Deploying ServiceLoadBalancer provider MetalLB" cluster="default/dlipovetsky"
    I0628 19:43:51.785923       1 handler.go:82] "Applying MetalLB installation" cluster="default/dlipovetsky"
    I0628 19:43:51.790521       1 cm.go:82] "Fetching HelmChart info for \"metallb\" from configmap default/default-helm-addons-config" cluster="default/dlipovetsky"
```

</details>

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
