### PR TITLE
ci: Disable nix cache on self-hosted runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0
         with:
-          enable-cache: "true"
+          enable-cache: ${{ inputs.runs-on != 'self-hosted-ncn-dind' }}
           skip-nix-installation: ${{ inputs.runs-on == 'self-hosted-ncn-dind' }}
 
       - name: Go cache


### PR DESCRIPTION
In an attempt to speed up Nutanix e2e tests.
