### PR TITLE
fix: Only create MetalLB configuration when necessary

### DIFF
--- a/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/configuration.go
+++ b/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/configuration.go
@@ -26,6 +26,10 @@ type configurationInput struct {
 }
 
 func configurationObjects(input *configurationInput) ([]unstructured.Unstructured, error) {
+	if len(input.addressRanges) == 0 {
+		return nil, fmt.Errorf("must define one or more addressRanges")
+	}
+
 	ipAddressPool := unstructured.Unstructured{}
 	ipAddressPool.SetGroupVersionKind(groupVersionKind("IPAddressPool"))
 	ipAddressPool.SetName(input.name)

--- a/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/handler.go
+++ b/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/handler.go
@@ -178,6 +178,11 @@ func (n *MetalLB) Apply(
 		return fmt.Errorf("failed to wait for MetalLB to deploy: %w", err)
 	}
 
+	if slb.Configuration == nil {
+		// Nothing more to do.
+		return nil
+	}
+
 	log.Info(
 		fmt.Sprintf("Applying MetalLB configuration to cluster %s",
 			ctrlclient.ObjectKeyFromObject(cluster),


### PR DESCRIPTION
**What problem does this PR solve?**:
The ServiceLoadBalancer configuration is optional; when it is not set, we should not configure the provider.

Thanks to @dkoshkin for finding this bug.

The e2e tests in #788 did not catch this, because they do define configuration.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
