### PR TITLE
ci: Run e2e jobs only if unit-test, lint-*, and pre-commit jobs pass

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,6 +55,12 @@ jobs:
           test-results: test.json
 
   e2e-quick-start:
+    needs:
+      - "lint-gha"
+      - "lint-go"
+      - "lint-test-helm"
+      - "pre-commit"
+      - "unit-test"
     strategy:
       matrix:
         provider:
@@ -82,6 +88,12 @@ jobs:
       checks: write
 
   e2e-self-hosted:
+    needs:
+      - "lint-gha"
+      - "lint-go"
+      - "lint-test-helm"
+      - "pre-commit"
+      - "unit-test"
     strategy:
       matrix:
         provider:


### PR DESCRIPTION
**What problem does this PR solve?**:
It's wasteful to run the e2e jobs before the other jobs pass, since making the other jobs pass almost certainly requires a change to the PR, which then requires the e2e jobs to run again, discarding the previous result.

Before:
![image](https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/assets/3445370/93928c9f-c6a4-4bbf-891e-e3554f4aca42)


After:
![image](https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/assets/3445370/17dfafad-e06a-4027-8a31-c0a99960ba22)

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
