### PR TITLE
fix: Clean up MetalLB pod security standards labels

### DIFF
--- a/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/handler.go
+++ b/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/handler.go
@@ -35,9 +35,8 @@ const (
 // These labels allow the MetalLB speaker pod to obtain elevated permissions,
 // which it requires in order to perform its network functionalities.
 var podSecurityReleaseNamespaceLabels = map[string]string{
-	"pod-security.kubernetes.io/enforce": "privileged",
-	"pod-security.kubernetes.io/audit":   "privileged",
-	"pod-security.kubernetes.io/warn":    "privileged",
+	"pod-security.kubernetes.io/enforce":         "privileged",
+	"pod-security.kubernetes.io/enforce-version": "latest",
 }
 
 type Config struct {

--- a/pkg/handlers/utils/utils.go
+++ b/pkg/handlers/utils/utils.go
@@ -103,8 +103,7 @@ func EnsureNamespaceWithName(ctx context.Context, c ctrlclient.Client, name stri
 func EnsureNamespaceWithMetadata(ctx context.Context,
 	c ctrlclient.Client,
 	name string,
-	labels,
-	annotations map[string]string,
+	labels, annotations map[string]string,
 ) error {
 	ns := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
This commit removes the `pod-security.kubernetes.io/audit` and
`pod-security.kubernetes.io/warn` labels as they are redundant when
specifying the `pod-security.kubernetes.io/enforce` label to the same
level.

Also add the `pod-security.kubernetes.io/enforce-version` label to
always enforce the latest pod security policy version, even on upgrade.
This is fine because we are specifying the most privileged pod security
standard, `privileged`, and as such should be safe to always enforce the
latest policy version.
