### PR TITLE
feat: Secure ciphers, min TLS v1.2, and disable auto TLS for etcd

### DIFF
--- a/pkg/handlers/generic/mutation/etcd/inject.go
+++ b/pkg/handlers/generic/mutation/etcd/inject.go
@@ -47,6 +47,10 @@ func newEtcdPatchHandler(
 	}
 }
 
+// defaultEtcdExtraArgs holds secure default flags for etcd. These flags are
+// set in order to satisfy both STIG and FIPS requirements by explicitly disabling certain
+// insecure features (e.g. `auto-tls`), setting a required minimum TLS version to v1.2,
+// and setting a list of secure cipher suites that satisfy both FIPS and non-FIPS scenarios.
 var defaultEtcdExtraArgs = map[string]string{
 	"auto-tls":      "false",
 	"peer-auto-tls": "false",

--- a/pkg/handlers/generic/mutation/etcd/inject_test.go
+++ b/pkg/handlers/generic/mutation/etcd/inject_test.go
@@ -56,6 +56,12 @@ var _ = Describe("Generate etcd patches", func() {
 							"local": map[string]interface{}{
 								"imageRepository": "my-registry.io/my-org/my-repo",
 								"imageTag":        "v3.5.99_custom.0",
+								"extraArgs": map[string]interface{}{
+									"auto-tls":        "false",
+									"peer-auto-tls":   "false",
+									"cipher-suites":   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", //nolint:lll // Long list of ciphers ok in test.
+									"tls-min-version": "TLS1.2",
+								},
 							},
 						},
 					),
@@ -85,6 +91,12 @@ var _ = Describe("Generate etcd patches", func() {
 						map[string]interface{}{
 							"local": map[string]interface{}{
 								"imageRepository": "my-registry.io/my-org/my-repo",
+								"extraArgs": map[string]interface{}{
+									"auto-tls":        "false",
+									"peer-auto-tls":   "false",
+									"cipher-suites":   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", //nolint:lll // Long list of ciphers ok in test.
+									"tls-min-version": "TLS1.2",
+								},
 							},
 						},
 					),
@@ -114,6 +126,12 @@ var _ = Describe("Generate etcd patches", func() {
 						map[string]interface{}{
 							"local": map[string]interface{}{
 								"imageTag": "v3.5.99_custom.0",
+								"extraArgs": map[string]interface{}{
+									"auto-tls":        "false",
+									"peer-auto-tls":   "false",
+									"cipher-suites":   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", //nolint:lll // Long list of ciphers ok in test.
+									"tls-min-version": "TLS1.2",
+								},
 							},
 						},
 					),

--- a/pkg/handlers/generic/mutation/etcd/inject_test.go
+++ b/pkg/handlers/generic/mutation/etcd/inject_test.go
@@ -22,6 +22,15 @@ func TestEtcdPolicyPatch(t *testing.T) {
 	RunSpecs(t, "etcd mutator suite")
 }
 
+// tlsExtraArgs holds the final set of extraArgs that should be set in the etcd for a default configuration.
+// See inject.go for the reasoning behind these values.
+var tlsExtraArgs = map[string]interface{}{
+	"auto-tls":        "false",
+	"peer-auto-tls":   "false",
+	"cipher-suites":   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", //nolint:lll // Long list of ciphers ok in test.
+	"tls-min-version": "TLS1.2",
+}
+
 var _ = Describe("Generate etcd patches", func() {
 	patchGenerator := func() mutation.GeneratePatches {
 		return mutation.NewMetaGeneratePatchesHandler("", helpers.TestEnv.Client, NewPatch()).(mutation.GeneratePatches)
@@ -56,12 +65,7 @@ var _ = Describe("Generate etcd patches", func() {
 							"local": map[string]interface{}{
 								"imageRepository": "my-registry.io/my-org/my-repo",
 								"imageTag":        "v3.5.99_custom.0",
-								"extraArgs": map[string]interface{}{
-									"auto-tls":        "false",
-									"peer-auto-tls":   "false",
-									"cipher-suites":   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", //nolint:lll // Long list of ciphers ok in test.
-									"tls-min-version": "TLS1.2",
-								},
+								"extraArgs":       tlsExtraArgs,
 							},
 						},
 					),
@@ -91,12 +95,7 @@ var _ = Describe("Generate etcd patches", func() {
 						map[string]interface{}{
 							"local": map[string]interface{}{
 								"imageRepository": "my-registry.io/my-org/my-repo",
-								"extraArgs": map[string]interface{}{
-									"auto-tls":        "false",
-									"peer-auto-tls":   "false",
-									"cipher-suites":   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", //nolint:lll // Long list of ciphers ok in test.
-									"tls-min-version": "TLS1.2",
-								},
+								"extraArgs":       tlsExtraArgs,
 							},
 						},
 					),
@@ -125,13 +124,8 @@ var _ = Describe("Generate etcd patches", func() {
 						"etcd",
 						map[string]interface{}{
 							"local": map[string]interface{}{
-								"imageTag": "v3.5.99_custom.0",
-								"extraArgs": map[string]interface{}{
-									"auto-tls":        "false",
-									"peer-auto-tls":   "false",
-									"cipher-suites":   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", //nolint:lll // Long list of ciphers ok in test.
-									"tls-min-version": "TLS1.2",
-								},
+								"imageTag":  "v3.5.99_custom.0",
+								"extraArgs": tlsExtraArgs,
 							},
 						},
 					),


### PR DESCRIPTION
This increases ootb security and provides STIG compliance for
this area at least.

Fixes #806.