### PR TITLE
fix: Fix ownership of ClusterAutoscaler resources

### DIFF
--- a/pkg/handlers/generic/lifecycle/ccm/aws/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/ccm/aws/strategy_crs.go
@@ -74,6 +74,7 @@ func (s crsStrategy) Apply(
 		ccmConfigMap.Name,
 		s.client,
 		cluster,
+		handlersutils.DefaultEnsureCRSForClusterFromObjectsOptions(),
 		ccmConfigMap,
 	)
 	if err != nil {

--- a/pkg/handlers/generic/lifecycle/cni/calico/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/cni/calico/strategy_crs.go
@@ -150,7 +150,15 @@ func (s crsStrategy) ensureCNICRSForCluster(
 		)
 	}
 
-	if err := utils.EnsureCRSForClusterFromObjects(ctx, cm.Name, s.client, cluster, tigeraConfigMap, cm); err != nil {
+	if err := utils.EnsureCRSForClusterFromObjects(
+		ctx,
+		cm.Name,
+		s.client,
+		cluster,
+		utils.DefaultEnsureCRSForClusterFromObjectsOptions(),
+		tigeraConfigMap,
+		cm,
+	); err != nil {
 		return fmt.Errorf(
 			"failed to apply Calico CNI installation ClusterResourceSet: %w",
 			err,

--- a/pkg/handlers/generic/lifecycle/cni/cilium/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/cni/cilium/strategy_crs.go
@@ -85,7 +85,14 @@ func (s crsStrategy) apply(
 		)
 	}
 
-	if err := utils.EnsureCRSForClusterFromObjects(ctx, cm.Name, s.client, cluster, cm); err != nil {
+	if err := utils.EnsureCRSForClusterFromObjects(
+		ctx,
+		cm.Name,
+		s.client,
+		cluster,
+		utils.DefaultEnsureCRSForClusterFromObjectsOptions(),
+		cm,
+	); err != nil {
 		return fmt.Errorf(
 			"failed to apply Cilium CNI installation ClusterResourceSet: %w",
 			err,

--- a/pkg/handlers/generic/lifecycle/csi/awsebs/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/csi/awsebs/strategy_crs.go
@@ -72,6 +72,7 @@ func (s crsStrategy) Apply(
 		cm.Name,
 		s.client,
 		cluster,
+		handlersutils.DefaultEnsureCRSForClusterFromObjectsOptions(),
 		cm,
 	)
 	if err != nil {

--- a/pkg/handlers/generic/lifecycle/csi/localpath/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/csi/localpath/strategy_crs.go
@@ -85,7 +85,14 @@ func (s crsStrategy) Apply(
 		)
 	}
 
-	if err := utils.EnsureCRSForClusterFromObjects(ctx, cm.Name, s.client, cluster, cm); err != nil {
+	if err := utils.EnsureCRSForClusterFromObjects(
+		ctx,
+		cm.Name,
+		s.client,
+		cluster,
+		utils.DefaultEnsureCRSForClusterFromObjectsOptions(),
+		cm,
+	); err != nil {
 		return fmt.Errorf(
 			"failed to apply local-path CSI installation ClusterResourceSet: %w",
 			err,

--- a/pkg/handlers/generic/lifecycle/csi/snapshotcontroller/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/csi/snapshotcontroller/strategy_crs.go
@@ -85,7 +85,14 @@ func (s crsStrategy) Apply(
 		)
 	}
 
-	if err := utils.EnsureCRSForClusterFromObjects(ctx, cm.Name, s.client, cluster, cm); err != nil {
+	if err := utils.EnsureCRSForClusterFromObjects(
+		ctx,
+		cm.Name,
+		s.client,
+		cluster,
+		utils.DefaultEnsureCRSForClusterFromObjectsOptions(),
+		cm,
+	); err != nil {
 		return fmt.Errorf(
 			"failed to apply snapshot-controller installation ClusterResourceSet: %w",
 			err,

--- a/pkg/handlers/generic/lifecycle/nfd/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/nfd/strategy_crs.go
@@ -85,7 +85,14 @@ func (s crsStrategy) Apply(
 		)
 	}
 
-	if err := utils.EnsureCRSForClusterFromObjects(ctx, cm.Name, s.client, cluster, cm); err != nil {
+	if err := utils.EnsureCRSForClusterFromObjects(
+		ctx,
+		cm.Name,
+		s.client,
+		cluster,
+		utils.DefaultEnsureCRSForClusterFromObjectsOptions(),
+		cm,
+	); err != nil {
 		return fmt.Errorf(
 			"failed to apply NFD installation ClusterResourceSet: %w",
 			err,

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/samber/lo"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	clusterctlcluster "sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	capie2e "sigs.k8s.io/cluster-api/test/e2e"
 	capiframework "sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
@@ -142,7 +141,7 @@ var _ = Describe("Quick start", func() {
 												capiframework.AssertOwnerReferences(
 													namespace,
 													proxy.GetKubeconfigPath(),
-													clusterctlcluster.FilterClusterObjectsWithNameFilter(
+													filterClusterObjectsWithNameFilterIgnoreClusterAutoscaler(
 														clusterName,
 													),
 													capiframework.CoreOwnerReferenceAssertion,


### PR DESCRIPTION
The Cluster Autoscaler addon (either HelmChartProxy or ClusterResourceSet
) has to be deployed in the management cluster namespace and as such cannot
be owned by the workload cluster, which commonly resides in a different
namespace.

This commit fixes that and introduces a BeforeClusterDelete hook to delete
the HelmChartProxy or ClusterResourceSet rather than relying no Kubernetes
GC as was previously expected.

Tested locally. Created workload cluster in different namespace to management cluster. HCP does not have ownership set:

```
apiVersion: addons.cluster.x-k8s.io/v1alpha1
kind: HelmChartProxy
metadata:
  creationTimestamp: "2024-07-18T13:02:30Z"
  finalizers:
  - helmchartproxy.addons.cluster.x-k8s.io
  generation: 1
  name: cluster-autoscaler-my-docker-cluster
  namespace: test
  resourceVersion: "6238"
  uid: 0a5ebb11-5318-4114-bedd-9bcc9459f85e
spec:
``` 

And is properly cleaned up on deletion:

```
$ k get hcp -A
No resources found
```