### PR TITLE
fix: category race condition by updating Nutanix CSI to 3.0.0-2458

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/nutanix/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/nutanix/manifests/helm-addon-installation.yaml
@@ -10,6 +10,7 @@ data:
   values.yaml: |-
     # The Secret containing the credentials will be created by the handler.
     createPrismCentralSecret: false
+    createSecret: false
     pcSecretName: nutanix-csi-credentials
 
     tolerations:

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/nutanix/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/nutanix/manifests/helm-addon-installation.yaml
@@ -8,8 +8,9 @@ metadata:
   name: '{{ .Values.hooks.csi.nutanix.helmAddonStrategy.defaultValueTemplateConfigMap.name }}'
 data:
   values.yaml: |-
-    # The Secret containing the credentials will be created by the handler.
+    # Disable creating the Prism Central credentials Secret, the Secret will be created by the handler.
     createPrismCentralSecret: false
+    # Disable creating the Prism Element credentials Secret, it won't be used the CSI driver as configured here.
     createSecret: false
     pcSecretName: nutanix-csi-credentials
 

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
@@ -41,8 +41,8 @@ data:
     RepositoryURL: {{ if .Values.selfHostedRegistry }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix.github.io/helm/{{ end }}
   nutanix-storage-csi: |
     ChartName: nutanix-csi-storage
-    ChartVersion: 3.0.0-beta.1912
-    RepositoryURL: {{ if .Values.selfHostedRegistry }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix.github.io/helm-releases/{{ end }}
+    ChartVersion: 3.0.0-2458
+    RepositoryURL: {{ if .Values.selfHostedRegistry }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix-scratch.github.io/helm/{{ end }}
   snapshot-controller: |
     ChartName: snapshot-controller
     ChartVersion: 3.0.5

--- a/hack/addons/kustomize/nutanix-storage-csi/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/nutanix-storage-csi/kustomization.yaml.tmpl
@@ -11,7 +11,7 @@ namespace: kube-system
 
 helmCharts:
 - name: nutanix-csi-storage
-  repo: https://nutanix.github.io/helm-releases/
+  repo: https://nutanix-scratch.github.io/helm/
   releaseName: nutanix-csi
   version: ${NUTANIX_STORAGE_CSI_CHART_VERSION}
   includeCRDs: true

--- a/hack/addons/mindthegap-helm-registry/repos.yaml
+++ b/hack/addons/mindthegap-helm-registry/repos.yaml
@@ -47,10 +47,10 @@ repositories:
       nutanix-cloud-provider:
       - 0.3.4
   nutanix-csi-storage:
-    repoURL: https://nutanix.github.io/helm-releases/
+    repoURL: https://nutanix-scratch.github.io/helm/
     charts:
       nutanix-csi-storage:
-      - 3.0.0-beta.1912
+      - 3.0.0-2458
   snapshot-controller:
     repoURL: https://piraeus.io/helm-charts/
     charts:

--- a/make/addons.mk
+++ b/make/addons.mk
@@ -6,7 +6,7 @@ export CILIUM_VERSION := 1.15.6
 export NODE_FEATURE_DISCOVERY_VERSION := 0.16.1
 export CLUSTER_AUTOSCALER_CHART_VERSION := 9.37.0
 export AWS_EBS_CSI_CHART_VERSION := 2.32.0
-export NUTANIX_STORAGE_CSI_CHART_VERSION := 3.0.0-beta.1912
+export NUTANIX_STORAGE_CSI_CHART_VERSION := 3.0.0-2458
 export LOCAL_PATH_CSI_CHART_VERSION := 0.0.29
 export SNAPSHOT_CONTROLLER_CHART_VERSION := 3.0.5
 # AWS CCM uses the same chart version for all kubernetes versions. The image used in the deployment will


### PR DESCRIPTION
**What problem does this PR solve?**:
This version fixes a race condition when creating multiple PVs.

https://github.com/nutanix-scratch/helm/releases/tag/nutanix-csi-storage-3.0.0-2458

Tested
```
kubectl get deploy -n ntnx-system -o yaml | grep "image: docker.io/nutanix/ntnx-csi"
          image: docker.io/nutanix/ntnx-csi:3.0.0-2458
```

```
kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                    STORAGECLASS     VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-d13bf2f8-644d-424b-a347-811a78bdd11b   10Gi       RWO            Delete           Bound    e2e-volume-pvc-bound-to-pv/pv-volume-volume-pvc-bound-to-pv-tester-2-0   nutanix-volume   <unset>                          8m36s
pvc-f1d988d2-5325-42cd-b873-6ed8649a4001   10Gi       RWO            Delete           Bound    e2e-volume-pvc-bound-to-pv/pv-volume-volume-pvc-bound-to-pv-tester-0     nutanix-volume   <unset>                          8m37s
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
