### PR TITLE
fix: use production repo for Nutanix CSI to 3.0.0-2458

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
@@ -42,7 +42,7 @@ data:
   nutanix-storage-csi: |
     ChartName: nutanix-csi-storage
     ChartVersion: 3.0.0-2458
-    RepositoryURL: {{ if .Values.selfHostedRegistry }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix-scratch.github.io/helm/{{ end }}
+    RepositoryURL: {{ if .Values.selfHostedRegistry }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix.github.io/helm-releases/{{ end }}
   snapshot-controller: |
     ChartName: snapshot-controller
     ChartVersion: 3.0.5

--- a/hack/addons/kustomize/nutanix-storage-csi/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/nutanix-storage-csi/kustomization.yaml.tmpl
@@ -11,7 +11,7 @@ namespace: kube-system
 
 helmCharts:
 - name: nutanix-csi-storage
-  repo: https://nutanix-scratch.github.io/helm/
+  repo: https://nutanix.github.io/helm-releases/
   releaseName: nutanix-csi
   version: ${NUTANIX_STORAGE_CSI_CHART_VERSION}
   includeCRDs: true

--- a/hack/addons/mindthegap-helm-registry/repos.yaml
+++ b/hack/addons/mindthegap-helm-registry/repos.yaml
@@ -47,7 +47,7 @@ repositories:
       nutanix-cloud-provider:
       - 0.3.4
   nutanix-csi-storage:
-    repoURL: https://nutanix-scratch.github.io/helm/
+    repoURL: https://nutanix.github.io/helm-releases/
     charts:
       nutanix-csi-storage:
       - 3.0.0-2458


### PR DESCRIPTION
**What problem does this PR solve?**:
The GA version of the Nutanix CSI was just released, using the production repo.

Tested locally:
```
k get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                  STORAGECLASS     VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-d5fc542d-0cb8-4051-bc5a-334fc22693b8   10Gi       RWO            Delete           Bound    e2e-volume-pvc-bound-to-pv/pv-volume-volume-pvc-bound-to-pv-tester-0   nutanix-volume   <unset>                          28s
```

And a PV with a hypervisor attached volume:
```
k get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                                  STORAGECLASS     VOLUMEATTRIBUTESCLASS   REASON   AGE
pvc-f400e56c-a794-4365-859b-2414d008771b   10Gi       RWO            Delete           Bound    e2e-volume-pvc-bound-to-pv/pv-volume-volume-pvc-bound-to-pv-tester-0   nutanix-volume   <unset>                          26s
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
