### PR TITLE
build: Ensure clean go build environment for goreleaser and ko

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,8 +41,8 @@ before:
         name: caren-system
       $(helm template {{ .ProjectName }} ./charts/{{ .ProjectName }} \
         --namespace caren-system \
-        --set-string image.tag=v{{ trimprefix .Version "v" }} \
-        --set-string helmRepositoryImage.tag=v{{ trimprefix .Version "v" }}{{ if .IsSnapshot }}-{{ .Env.GOARCH }} \
+        --set-string image.tag=v{{ trimprefix .Version "v" }}{{ if .IsSnapshot }}-{{ .Runtime.Goarch }}{{ end }} \
+        --set-string helmRepositoryImage.tag=v{{ trimprefix .Version "v" }}{{ if .IsSnapshot }}-{{ .Runtime.Goarch }} \
         --set-string image.repository=ko.local/{{ .ProjectName }}{{ end }} \
       )
       EOF'
@@ -80,12 +80,13 @@ builds:
       post:
         - |
           sh -ec 'if [ {{ .IsSnapshot }} == true ] && [ {{ .Runtime.Goarch }} == {{ .Arch }} ]; then
-            env GOOS=linux GOARCH={{ .Arch }} \
-                SOURCE_DATE_EPOCH=$(date +%s) \
+            env SOURCE_DATE_EPOCH=$(date +%s) \
+                KO_DATA_DATE_EPOCH=$(date +%s) \
                 KO_DOCKER_REPO=ko.local/{{ .ProjectName }} \
                 ko build \
                   --bare \
-                  -t v{{ trimprefix .Version "v" }} \
+                  --platform linux/{{ .Arch }} \
+                  -t v{{ trimprefix .Version "v" }}-{{ .Arch }} \
                   ./cmd
           fi'
 
@@ -135,16 +136,6 @@ docker_manifests:
 kos:
   - id: cluster-api-runtime-extensions-nutanix
     build: cluster-api-runtime-extensions-nutanix
-    ldflags:
-      - -s
-      - -w
-      - -X 'k8s.io/component-base/version.buildDate={{ .CommitDate }}'
-      - -X 'k8s.io/component-base/version.gitCommit={{ .FullCommit }}'
-      - -X 'k8s.io/component-base/version.gitTreeState={{ .Env.GIT_TREE_STATE }}'
-      - -X 'k8s.io/component-base/version.gitVersion=v{{ trimprefix .Version "v" }}'
-      - -X 'k8s.io/component-base/version.major={{ .Major }}'
-      - -X 'k8s.io/component-base/version.minor={{ .Minor }}'
-      - -X 'k8s.io/component-base/version/verflag.programName={{ .ProjectName }}'
     labels:
       org.opencontainers.image.created: "{{ .CommitDate }}"
       org.opencontainers.image.title: "{{ .ProjectName }}"
@@ -156,6 +147,8 @@ kos:
       - linux/arm64
     repository: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix
     bare: true
+    creation_time: "{{.CommitTimestamp}}"
+    ko_data_creation_time: "{{.CommitTimestamp}}"
     tags:
       - 'v{{ trimprefix .Version "v" }}'
 

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -7,14 +7,15 @@ dev.run-on-kind: kind.create clusterctl.init
 ifndef SKIP_BUILD
 dev.run-on-kind: release-snapshot
 endif
+dev.run-on-kind: SNAPSHOT_VERSION := $(shell gojq -r '.version+"-"+.runtime.goarch' dist/metadata.json)
 dev.run-on-kind:
 	kind load docker-image --name $(KIND_CLUSTER_NAME) \
-		ko.local/cluster-api-runtime-extensions-nutanix:$$(gojq -r .version dist/metadata.json) \
-		ghcr.io/nutanix-cloud-native/caren-helm-reg:$$(gojq -r .version dist/metadata.json)-$(GOARCH)
+		ko.local/cluster-api-runtime-extensions-nutanix:$(SNAPSHOT_VERSION) \
+		ghcr.io/nutanix-cloud-native/caren-helm-reg:$(SNAPSHOT_VERSION)
 	helm upgrade --install cluster-api-runtime-extensions-nutanix ./charts/cluster-api-runtime-extensions-nutanix \
 		--set-string image.repository=ko.local/cluster-api-runtime-extensions-nutanix \
-		--set-string image.tag=$$(gojq -r .version dist/metadata.json) \
-		--set-string helmRepositoryImage.tag=$$(gojq -r .version dist/metadata.json)-$(GOARCH) \
+		--set-string image.tag=$(SNAPSHOT_VERSION) \
+		--set-string helmRepositoryImage.tag=$(SNAPSHOT_VERSION) \
 		--wait --wait-for-jobs
 	kubectl rollout restart deployment cluster-api-runtime-extensions-nutanix
 	kubectl rollout restart deployment helm-repository
@@ -26,11 +27,12 @@ dev.update-webhook-image-on-kind: export KUBECONFIG := $(KIND_KUBECONFIG)
 ifndef SKIP_BUILD
 dev.update-webhook-image-on-kind: release-snapshot
 endif
+dev.update-webhook-image-on-kind: SNAPSHOT_VERSION := $(shell gojq -r '.version+"-"+.runtime.goarch' dist/metadata.json)
 dev.update-webhook-image-on-kind:
 	kind load docker-image --name $(KIND_CLUSTER_NAME) \
-	  ko.local/cluster-api-runtime-extensions-nutanix:$$(gojq -r .version dist/metadata.json)
+	  ko.local/cluster-api-runtime-extensions-nutanix:$(SNAPSHOT_VERSION)
 	kubectl set image deployment \
-	  cluster-api-runtime-extensions-nutanix webhook=ko.local/cluster-api-runtime-extensions-nutanix:$$(gojq -r .version dist/metadata.json)
+	  cluster-api-runtime-extensions-nutanix webhook=ko.local/cluster-api-runtime-extensions-nutanix:$(SNAPSHOT_VERSION)
 	kubectl rollout restart deployment cluster-api-runtime-extensions-nutanix
 	kubectl rollout status deployment cluster-api-runtime-extensions-nutanix
 

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -6,7 +6,7 @@ managementClusterName: caren-e2e
 images:
   - name: ko.local/cluster-api-runtime-extensions-nutanix:${E2E_IMAGE_TAG}
     loadBehavior: mustLoad
-  - name: ghcr.io/nutanix-cloud-native/caren-helm-reg:${E2E_IMAGE_TAG}-${GOARCH}
+  - name: ghcr.io/nutanix-cloud-native/caren-helm-reg:${E2E_IMAGE_TAG}
     loadBehavior: mustLoad
 
 providers:


### PR DESCRIPTION
Previous builds were overriding the `GOOS` and `GOARCH` enviroment
variables, which is fine to do when using `ko` directly, but appears to be
broken when building via ko using `goreleaser`.

This commit ensures that `GOOS` and `GOARCH` are always unset when
running builds by undefining them via `make` `undefine`. The `override`
keyword ensures that the env vars are always undefined regardless of the
source (e.g. enviroment, make variables, etc) to ensure a clean build
environment.

Instead of using `GOARCH` env var for building for the local build
architecure, this commit uses `goreleaser`'s `{{ .Runtime.Goarch }}`
variable available via templating which contains the architecture of the
build machine.

This commit also removes the `ldflags` config from the `ko`
configuration in `goreleaser` config as this is automatically inherited
from the `build` config referenced in the `ko` config.
