### PR TITLE
fix: ClusterAutoscaler addon ownership for move

### DIFF
--- a/pkg/handlers/generic/lifecycle/clusterautoscaler/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/clusterautoscaler/strategy_crs.go
@@ -119,7 +119,7 @@ func (s crsStrategy) apply(
 		cm.Name,
 		s.client,
 		targetCluster,
-		utils.EnsureCRSForClusterFromObjectsOptions{SetClusterOwnership: false},
+		utils.DefaultEnsureCRSForClusterFromObjectsOptions().WithOwnerCluster(targetCluster),
 		cm,
 	); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
This commit changes ownership of the CA addon to be owned by the
management cluster (either the bootstrap cluster or the managemen
cluster) which fixes moving the resources only after the cluster
exists on the target cluster.
