### PR TITLE
build: Derive GH owner/repo via gh

### DIFF
--- a/make/repo.mk
+++ b/make/repo.mk
@@ -9,8 +9,8 @@ GIT_COMMIT := $(shell git rev-parse "HEAD^{commit}")
 export GIT_TAG ?= $(shell git describe --tags "$(GIT_COMMIT)^{commit}" --match v* --abbrev=0 2>/dev/null)
 export GIT_CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
-export GITHUB_ORG := $(notdir $(realpath $(dir $(REPO_ROOT))))
-export GITHUB_REPOSITORY := $(notdir $(REPO_ROOT))
+export GITHUB_ORG := $(shell gh repo view --jq '.owner.login' --json owner)
+export GITHUB_REPOSITORY := $(shell gh repo view --jq '.name' --json name)
 
 ifneq ($(shell git status --porcelain 2>/dev/null; echo $$?), 0)
 	export GIT_TREE_STATE := dirty


### PR DESCRIPTION
Using directory path previously was fragile dependent on where the repo was
cloned to locally.
