### PR TITLE
fix: run systemctl daemon-reload before Containerd restart

### DIFF
--- a/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/templates/containerd-restart.sh
+++ b/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/templates/containerd-restart.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-systemctl daemon-reload
+if [ "$(systemctl show containerd -p NeedDaemonReload --value)" == "yes" ]; then
+  systemctl daemon-reload
+fi
 systemctl restart containerd
 
 if ! command -v crictl; then

--- a/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/templates/containerd-restart.sh
+++ b/pkg/handlers/generic/mutation/containerdapplypatchesandrestart/templates/containerd-restart.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+systemctl daemon-reload
 systemctl restart containerd
 
 if ! command -v crictl; then


### PR DESCRIPTION
**What problem does this PR solve?**:
During Machine bootstrapping Contianerd drop in files may be added. 
These files are written to the disk before `preKubeadmCommmands` are run. 
Always run systemctl daemon-reload along with systemctl restart containerd to pick up these dropins.

I saw a warning about the drop-ins when cloud init runs the Containerd restart script, so figured it makes sense to add it here instead of a separate script.
```
[2024-08-05 16:35:46] /tmp/tmp.MzIe5jTIdG
[2024-08-05 16:35:46] Warning: The unit file, source configuration file or drop-ins of containerd.service changed on disk. Run 'systemctl daemon-reload' to reload units.
[2024-08-05 16:35:46] /usr/bin/crictl
[2024-08-05 16:35:46] {
...
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
