### PR TITLE
fix: Ensure MetalLB lifecycle handler is independent of other handlers

### DIFF
--- a/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/configuration.go
+++ b/pkg/handlers/generic/lifecycle/serviceloadbalancer/metallb/configuration.go
@@ -5,8 +5,11 @@ package metallb
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 )
@@ -25,12 +28,12 @@ type ConfigurationInput struct {
 	AddressRanges []v1alpha1.AddressRange
 }
 
-func ConfigurationObjects(input *ConfigurationInput) ([]*unstructured.Unstructured, error) {
+func ConfigurationObjects(input *ConfigurationInput) ([]unstructured.Unstructured, error) {
 	if len(input.AddressRanges) == 0 {
 		return nil, fmt.Errorf("must define one or more AddressRanges")
 	}
 
-	ipAddressPool := &unstructured.Unstructured{}
+	ipAddressPool := unstructured.Unstructured{}
 	ipAddressPool.SetGroupVersionKind(GroupVersionKind("IPAddressPool"))
 	ipAddressPool.SetName(input.Name)
 	ipAddressPool.SetNamespace(input.Namespace)
@@ -48,7 +51,7 @@ func ConfigurationObjects(input *ConfigurationInput) ([]*unstructured.Unstructur
 		return nil, fmt.Errorf("failed to set IPAddressPool .spec.addresses: %w", err)
 	}
 
-	l2Advertisement := &unstructured.Unstructured{}
+	l2Advertisement := unstructured.Unstructured{}
 	l2Advertisement.SetGroupVersionKind(GroupVersionKind("L2Advertisement"))
 	l2Advertisement.SetName(input.Name)
 	l2Advertisement.SetNamespace(input.Namespace)
@@ -64,8 +67,37 @@ func ConfigurationObjects(input *ConfigurationInput) ([]*unstructured.Unstructur
 		return nil, fmt.Errorf("failed to set L2Advertisement .spec.ipAddressPools: %w", err)
 	}
 
-	return []*unstructured.Unstructured{
+	return []unstructured.Unstructured{
 		ipAddressPool,
 		l2Advertisement,
+	}, nil
+}
+
+func configMapForClusterResourceSet(
+	namespace,
+	name string,
+	objs []unstructured.Unstructured,
+) (
+	*corev1.ConfigMap,
+	error,
+) {
+	// Marshal all objects into a one, multi-resource YAML document.
+	bytes, err := utilyaml.FromUnstructured(objs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "metallb-configuration-" + name,
+		},
+		Data: map[string]string{
+			"metallb": string(bytes),
+		},
 	}, nil
 }

--- a/test/e2e/serviceloadbalancer_helpers.go
+++ b/test/e2e/serviceloadbalancer_helpers.go
@@ -128,7 +128,7 @@ func waitForMetalLBServiceLoadBalancerToBeReadyInWorkloadCluster(
 
 	resources := make([]client.Object, len(cos))
 	for i := range cos {
-		resources[i] = cos[i]
+		resources[i] = cos[i].DeepCopy()
 	}
 
 	WaitForResources(ctx, WaitForResourcesInput{


### PR DESCRIPTION
**What problem does this PR solve?**:
Previously, the MetalLB handler created custom resources on the workload cluster. These required a webhook to be ready. The webhook required one or more Nodes to be Ready. That required CNI to be deployed.

When CAPI called the MetalLB handler before the CNI handler, this condition would never be satisified. No handlers after the MetalLB would be called.

With this PR, we delegate the creation of MetalLB configuration on the workload cluster to the ClusterResourceSet controller.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
Deployed a Nutanix cluster.

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
