### PR TITLE
fix: delete correct cluster-autoscaler HCP

### DIFF
--- a/pkg/handlers/generic/lifecycle/clusterautoscaler/strategy_helmaddon.go
+++ b/pkg/handlers/generic/lifecycle/clusterautoscaler/strategy_helmaddon.go
@@ -77,10 +77,18 @@ func (s helmAddonStrategy) delete(
 	cluster *clusterv1.Cluster,
 	log logr.Logger,
 ) error {
+	// The cluster-autoscaler is different from other addons.
+	// It requires all resources to be created in the management cluster,
+	// which means creating the HelmChartProxy always targeting the management cluster.
+	targetCluster, err := findTargetCluster(ctx, s.client, cluster)
+	if err != nil {
+		return err
+	}
+
 	hcp := &caaphv1.HelmChartProxy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      addonResourceNameForCluster(cluster),
-			Namespace: cluster.Namespace,
+			Namespace: targetCluster.Namespace,
 		},
 	}
 


### PR DESCRIPTION
**What problem does this PR solve?**:
The HCP will always be deployed in the management cluster's namespace.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
