### PR TITLE
fix: skip UUID annotation webhook for clusters with nil topology

### DIFF
--- a/pkg/webhook/cluster/clusteruuidlabeler.go
+++ b/pkg/webhook/cluster/clusteruuidlabeler.go
@@ -50,6 +50,10 @@ func (a *clusterUUIDLabeler) defaulter(
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	if cluster.Spec.Topology == nil {
+		return admission.Allowed("")
+	}
+
 	if cluster.Annotations == nil {
 		cluster.Annotations = make(map[string]string, 1)
 	}
@@ -100,6 +104,10 @@ func (a *clusterUUIDLabeler) validate(
 	err := a.decoder.Decode(req, cluster)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if cluster.Spec.Topology == nil {
+		return admission.Allowed("")
 	}
 
 	clusterUUID, ok := cluster.Annotations[v1alpha1.ClusterUUIDAnnotationKey]

--- a/pkg/webhook/cluster/clusteruuidlabeler.go
+++ b/pkg/webhook/cluster/clusteruuidlabeler.go
@@ -64,7 +64,7 @@ func (a *clusterUUIDLabeler) defaulter(
 		// If this is an update request, copy the UUID from the old object if it exists. This prevents deletion of the
 		// annotation.
 		//
-		// This is also important for move operations where the clusterctl for some reason deletes
+		// This is especially important for move operations where the clusterctl for some reason deletes
 		// all annotations (see
 		// https://github.com/kubernetes-sigs/cluster-api/blob/v1.7.4/cmd/clusterctl/client/cluster/mover.go#L1188).
 		// Without this logic, the UUID would be deleted and the UUID validation webhook would fail.
@@ -81,6 +81,12 @@ func (a *clusterUUIDLabeler) defaulter(
 			oldClusterUUID, ok := oldCluster.Annotations[v1alpha1.ClusterUUIDAnnotationKey]
 			if ok {
 				cluster.Annotations[v1alpha1.ClusterUUIDAnnotationKey] = oldClusterUUID
+			} else {
+				// If the old cluster does not have a UUID, generate a new one. This can happen if the cluster was
+				// created before this webhook was installed or if the cluster began without spec.topology and was
+				// later converted to a ClusterClass based cluster.
+				cluster.Annotations[v1alpha1.ClusterUUIDAnnotationKey] = uuid.Must(uuid.NewV7()).
+					String()
 			}
 		// If this is a create request, generate a new UUID.
 		case v1.Create:

--- a/pkg/webhook/cluster/webhook_suite_test.go
+++ b/pkg/webhook/cluster/webhook_suite_test.go
@@ -4,12 +4,15 @@
 package cluster
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -24,8 +27,98 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	mutatingWebhook := &admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-defaulter.caren.nutanix.com",
+		},
+		Webhooks: []admissionv1.MutatingWebhook{
+			{
+				Name: "cluster-defaulter.caren.nutanix.com",
+				ClientConfig: admissionv1.WebhookClientConfig{
+					Service: &admissionv1.ServiceReference{
+						Path: ptr.To("/mutate-v1beta1-cluster"),
+					},
+				},
+				Rules: []admissionv1.RuleWithOperations{{
+					Operations: []admissionv1.OperationType{
+						admissionv1.Create,
+						admissionv1.Update,
+					},
+					Rule: admissionv1.Rule{
+						APIGroups:   []string{"cluster.x-k8s.io"},
+						APIVersions: []string{"*"},
+						Resources:   []string{"clusters"},
+					},
+				}},
+				SideEffects:             ptr.To(admissionv1.SideEffectClassNone),
+				AdmissionReviewVersions: []string{"v1"},
+				// Start the environment with this to ignore in order to create the pre-existing objects.
+				FailurePolicy: ptr.To(admissionv1.Ignore),
+			},
+		},
+	}
+	validatingWebhook := &admissionv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-validator.caren.nutanix.com",
+		},
+		Webhooks: []admissionv1.ValidatingWebhook{
+			{
+				Name: "cluster-validator.caren.nutanix.com",
+				ClientConfig: admissionv1.WebhookClientConfig{
+					Service: &admissionv1.ServiceReference{
+						Path: ptr.To("/validate-v1beta1-cluster"),
+					},
+				},
+				Rules: []admissionv1.RuleWithOperations{{
+					Operations: []admissionv1.OperationType{
+						admissionv1.Create,
+						admissionv1.Update,
+					},
+					Rule: admissionv1.Rule{
+						APIGroups:   []string{"cluster.x-k8s.io"},
+						APIVersions: []string{"*"},
+						Resources:   []string{"clusters"},
+					},
+				}},
+				SideEffects:             ptr.To(admissionv1.SideEffectClassNone),
+				AdmissionReviewVersions: []string{"v1"},
+				// Start the environment with this to ignore in order to create the pre-existing objects.
+				FailurePolicy: ptr.To(admissionv1.Ignore),
+			},
+		},
+	}
+
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
 		M: m,
+		EnvironmentOpts: []envtest.EnvironmentOpt{
+			envtest.WithPreexistingObjects(
+				// Create a pre-existing object without topology or the UUID annotation.
+				&clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "preexisting-without-topology-or-uuid-annotation",
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+				// Create a pre-existing object with topology but without the UUID annotation.
+				&clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "preexisting-with-topology-without-uuid-annotation",
+						Namespace: metav1.NamespaceDefault,
+					},
+					Spec: clusterv1.ClusterSpec{
+						Topology: &clusterv1.Topology{},
+					},
+				},
+			),
+		},
+		WebhookInstallOptions: ctrlenvtest.WebhookInstallOptions{
+			MutatingWebhooks: []*admissionv1.MutatingWebhookConfiguration{
+				mutatingWebhook,
+			},
+			ValidatingWebhooks: []*admissionv1.ValidatingWebhookConfiguration{
+				validatingWebhook,
+			},
+		},
 		SetupEnv: func(e *envtest.Environment) {
 			e.GetWebhookServer().Register("/mutate-v1beta1-cluster", &webhook.Admission{
 				Handler: NewDefaulter(e.GetClient(), admission.NewDecoder(e.GetScheme())),
@@ -33,65 +126,22 @@ func TestMain(m *testing.M) {
 			e.GetWebhookServer().Register("/validate-v1beta1-cluster", &webhook.Admission{
 				Handler: NewValidator(e.GetClient(), admission.NewDecoder(e.GetScheme())),
 			})
+
+			// The webhooks are initially installed with Ignore failure policy above to allow creating objects before
+			// actually registering the webhooks so now the webhooks are installed above we can the webhooks to failure
+			// policy to ensure they fail if not installed or called correctly.
+			mutatingWebhook.Webhooks[0].FailurePolicy = ptr.To(admissionv1.Fail)
+			err := e.GetClient().Update(context.Background(), mutatingWebhook)
+			if err != nil {
+				klog.Fatalf("failed to update the mutating webhook failure policy: %v", err)
+			}
+			validatingWebhook.Webhooks[0].FailurePolicy = ptr.To(admissionv1.Fail)
+			err = e.GetClient().Update(context.Background(), validatingWebhook)
+			if err != nil {
+				klog.Fatalf("failed to update the validating webhook failure policy: %v", err)
+			}
+
 			env = e
-		},
-		WebhookInstallOptions: ctrlenvtest.WebhookInstallOptions{
-			MutatingWebhooks: []*admissionv1.MutatingWebhookConfiguration{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster-defaulter.caren.nutanix.com",
-				},
-				Webhooks: []admissionv1.MutatingWebhook{
-					{
-						Name: "cluster-defaulter.caren.nutanix.com",
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service: &admissionv1.ServiceReference{
-								Path: ptr.To("/mutate-v1beta1-cluster"),
-							},
-						},
-						Rules: []admissionv1.RuleWithOperations{{
-							Operations: []admissionv1.OperationType{
-								admissionv1.Create,
-								admissionv1.Update,
-							},
-							Rule: admissionv1.Rule{
-								APIGroups:   []string{"cluster.x-k8s.io"},
-								APIVersions: []string{"*"},
-								Resources:   []string{"clusters"},
-							},
-						}},
-						SideEffects:             ptr.To(admissionv1.SideEffectClassNone),
-						AdmissionReviewVersions: []string{"v1"},
-					},
-				},
-			}},
-			ValidatingWebhooks: []*admissionv1.ValidatingWebhookConfiguration{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster-validator.caren.nutanix.com",
-				},
-				Webhooks: []admissionv1.ValidatingWebhook{
-					{
-						Name: "cluster-validator.caren.nutanix.com",
-						ClientConfig: admissionv1.WebhookClientConfig{
-							Service: &admissionv1.ServiceReference{
-								Path: ptr.To("/validate-v1beta1-cluster"),
-							},
-						},
-						Rules: []admissionv1.RuleWithOperations{{
-							Operations: []admissionv1.OperationType{
-								admissionv1.Create,
-								admissionv1.Update,
-							},
-							Rule: admissionv1.Rule{
-								APIGroups:   []string{"cluster.x-k8s.io"},
-								APIVersions: []string{"*"},
-								Resources:   []string{"clusters"},
-							},
-						}},
-						SideEffects:             ptr.To(admissionv1.SideEffectClassNone),
-						AdmissionReviewVersions: []string{"v1"},
-					},
-				},
-			}},
 		},
 	}))
 }

--- a/pkg/webhook/cluster/webhook_test.go
+++ b/pkg/webhook/cluster/webhook_test.go
@@ -21,6 +21,7 @@ func TestWebhookBehaviour(t *testing.T) {
 			GenerateName: "test-cluster-",
 			Namespace:    metav1.NamespaceDefault,
 		},
+		Spec: clusterv1.ClusterSpec{Topology: &clusterv1.Topology{}},
 	}
 
 	g.Expect(env.Client.Create(ctx, cluster)).To(Succeed())
@@ -43,4 +44,24 @@ func TestWebhookBehaviour(t *testing.T) {
 	g.Expect(env.Client.Update(ctx, cluster)).To(Succeed())
 	g.Expect(cluster.Annotations).
 		To(HaveKeyWithValue(v1alpha1.ClusterUUIDAnnotationKey, assignedUUID))
+}
+
+func TestWebhookSkipsClusterWithNilTopology(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-cluster-",
+			Namespace:    metav1.NamespaceDefault,
+		},
+	}
+
+	g.Expect(env.Client.Create(ctx, cluster)).To(Succeed())
+	t.Cleanup(func() {
+		g.Expect(env.Client.Delete(ctx, cluster)).To(Succeed())
+	})
+
+	// Validate the cluster has not been assigned a UUID.
+	g.Expect(cluster.Annotations).
+		NotTo(HaveKey(v1alpha1.ClusterUUIDAnnotationKey))
 }

--- a/pkg/webhook/cluster/webhook_test.go
+++ b/pkg/webhook/cluster/webhook_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 )
@@ -64,4 +65,47 @@ func TestWebhookSkipsClusterWithNilTopology(t *testing.T) {
 	// Validate the cluster has not been assigned a UUID.
 	g.Expect(cluster.Annotations).
 		NotTo(HaveKey(v1alpha1.ClusterUUIDAnnotationKey))
+}
+
+func TestUUIDIsAddedToAPreexistingClusterWhenTopologyIsAdded(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preexisting-without-topology-or-uuid-annotation",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+
+	g.Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+	g.Expect(cluster.Annotations).ToNot(HaveKey(v1alpha1.ClusterUUIDAnnotationKey))
+
+	// Validate that the webhook does assign a UUID to the cluster if the Cluster has topology added.
+	cluster.Spec.Topology = &clusterv1.Topology{}
+	g.Expect(env.Client.Update(ctx, cluster)).To(Succeed())
+	g.Expect(cluster.Annotations).
+		To(HaveKeyWithValue(v1alpha1.ClusterUUIDAnnotationKey, Not(BeEmpty())))
+}
+
+func TestUUIDIsAddedToAPreexistingClusterWhenTopologyIsUpdated(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preexisting-with-topology-without-uuid-annotation",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+
+	g.Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+	g.Expect(cluster.Annotations).ToNot(HaveKey(v1alpha1.ClusterUUIDAnnotationKey))
+	g.Expect(cluster.Spec.Topology).ToNot(BeNil())
+
+	// Validate that the webhook does assign a UUID to the cluster if the topology is updated. This could be when
+	// a cluster changes to use CAREN for example, but we just change topology version here as an example of
+	// a change that would trigger the webhook.
+	cluster.Spec.Topology.Version = "dummy-version"
+	g.Expect(env.Client.Update(ctx, cluster)).To(Succeed())
+	g.Expect(cluster.Annotations).
+		To(HaveKeyWithValue(v1alpha1.ClusterUUIDAnnotationKey, Not(BeEmpty())))
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
We only want this webhook to run on Clusters that are created with cluster topology. This also fixes an issue when an existing Cluster that was created before deploying CAREN and this webhook is moved to the bootstrap cluster.
Currently it fails the move with 
```
  2024-08-14 11:14:55 ERR     err="unable to pivot to the to-cluster: error setting Cluster.Spec.Paused=true: action failed after 10 attempts: error patching Cluster default/e2e-preprovisioned-upgrade-573225644: admission webhook "cluster-validator.caren.nutanix.com" denied the request: missing cluster UUID annotation caren.nutanix.com/cluster-uuid"
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
I'm also now wondering if we want the validate to fail when the annotation is missing. Its possible that an existing Cluster that was created using another ClusterClass that does not use CAREN and then when CAREN gets installed, it prevents those existing Clusters from being updated because of a missing annotation that won't even be used.
**Should this webhook be smarter and only validate and default Clusters that are referencing a CC that is using CAREN?**
