### PR TITLE
fix: CRS generated CA Deployment has extra quotes

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cluster-autoscaler/manifests/cluster-autoscaler-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cluster-autoscaler/manifests/cluster-autoscaler-configmap.yaml
@@ -17,7 +17,7 @@ data:
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
       name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
-      namespace: '{{ `{{ .Cluster.Namespace }}` }}'
+      namespace: {{ `{{ .Cluster.Namespace }}` }}
     spec:
       maxUnavailable: 1
       selector:
@@ -35,7 +35,7 @@ data:
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
       name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
-      namespace: '{{ `{{ .Cluster.Namespace }}` }}'
+      namespace: {{ `{{ .Cluster.Namespace }}` }}
     ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
@@ -46,7 +46,7 @@ data:
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
       name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
-      namespace: '{{ `{{ .Cluster.Namespace }}` }}'
+      namespace: {{ `{{ .Cluster.Namespace }}` }}
     rules:
     - apiGroups:
       - ""
@@ -110,7 +110,7 @@ data:
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
       name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
-      namespace: '{{ `{{ .Cluster.Namespace }}` }}'
+      namespace: {{ `{{ .Cluster.Namespace }}` }}
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
@@ -118,7 +118,7 @@ data:
     subjects:
     - kind: ServiceAccount
       name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
-      namespace: '{{ `{{ .Cluster.Namespace }}` }}'
+      namespace: {{ `{{ .Cluster.Namespace }}` }}
     ---
     apiVersion: v1
     kind: Service
@@ -129,7 +129,7 @@ data:
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
       name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
-      namespace: '{{ `{{ .Cluster.Namespace }}` }}'
+      namespace: {{ `{{ .Cluster.Namespace }}` }}
     spec:
       ports:
       - name: http
@@ -150,7 +150,7 @@ data:
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
       name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
-      namespace: '{{ `{{ .Cluster.Namespace }}` }}'
+      namespace: {{ `{{ .Cluster.Namespace }}` }}
     spec:
       replicas: 1
       revisionHistoryLimit: 10
@@ -169,7 +169,7 @@ data:
             - ./cluster-autoscaler
             - --cloud-provider=clusterapi
             - --namespace=kube-system
-            - --node-group-auto-discovery=clusterapi:clusterName='{{ `{{ .Cluster.Name }}` }}',namespace='{{ `{{ .Cluster.Namespace }}` }}'
+            - --node-group-auto-discovery=clusterapi:clusterName={{ `{{ .Cluster.Name }}` }},namespace={{ `{{ .Cluster.Namespace }}` }}
             - --kubeconfig=/cluster/kubeconfig
             - --clusterapi-cloud-config-authoritative
             - --enforce-node-group-min-size=true
@@ -211,7 +211,7 @@ data:
               items:
               - key: value
                 path: kubeconfig
-              secretName: '{{ `{{ .Cluster.Name }}` }}-kubeconfig'
+              secretName: {{ `{{ .Cluster.Name }}` }}-kubeconfig
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cluster-autoscaler/manifests/cluster-autoscaler-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cluster-autoscaler/manifests/cluster-autoscaler-configmap.yaml
@@ -12,17 +12,17 @@ data:
     kind: PodDisruptionBudget
     metadata:
       labels:
-        app.kubernetes.io/instance: 'ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+        app.kubernetes.io/instance: ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
-      name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+      name: cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
       namespace: {{ `{{ .Cluster.Namespace }}` }}
     spec:
       maxUnavailable: 1
       selector:
         matchLabels:
-          app.kubernetes.io/instance: 'ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+          app.kubernetes.io/instance: ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
           app.kubernetes.io/name: clusterapi-cluster-autoscaler
     ---
     apiVersion: v1
@@ -30,22 +30,22 @@ data:
     kind: ServiceAccount
     metadata:
       labels:
-        app.kubernetes.io/instance: 'ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+        app.kubernetes.io/instance: ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
-      name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+      name: cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
       namespace: {{ `{{ .Cluster.Namespace }}` }}
     ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
       labels:
-        app.kubernetes.io/instance: 'ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+        app.kubernetes.io/instance: ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
-      name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+      name: cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
       namespace: {{ `{{ .Cluster.Namespace }}` }}
     rules:
     - apiGroups:
@@ -105,30 +105,30 @@ data:
     kind: RoleBinding
     metadata:
       labels:
-        app.kubernetes.io/instance: 'ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+        app.kubernetes.io/instance: ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
-      name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+      name: cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
       namespace: {{ `{{ .Cluster.Namespace }}` }}
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
-      name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+      name: cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
     subjects:
     - kind: ServiceAccount
-      name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+      name: cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
       namespace: {{ `{{ .Cluster.Namespace }}` }}
     ---
     apiVersion: v1
     kind: Service
     metadata:
       labels:
-        app.kubernetes.io/instance: 'ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+        app.kubernetes.io/instance: ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
-      name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+      name: cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
       namespace: {{ `{{ .Cluster.Namespace }}` }}
     spec:
       ports:
@@ -137,7 +137,7 @@ data:
         protocol: TCP
         targetPort: 8085
       selector:
-        app.kubernetes.io/instance: 'ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+        app.kubernetes.io/instance: ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
       type: ClusterIP
     ---
@@ -145,23 +145,23 @@ data:
     kind: Deployment
     metadata:
       labels:
-        app.kubernetes.io/instance: 'ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+        app.kubernetes.io/instance: ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: clusterapi-cluster-autoscaler
         helm.sh/chart: cluster-autoscaler-9.37.0
-      name: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+      name: cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
       namespace: {{ `{{ .Cluster.Namespace }}` }}
     spec:
       replicas: 1
       revisionHistoryLimit: 10
       selector:
         matchLabels:
-          app.kubernetes.io/instance: 'ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+          app.kubernetes.io/instance: ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
           app.kubernetes.io/name: clusterapi-cluster-autoscaler
       template:
         metadata:
           labels:
-            app.kubernetes.io/instance: 'ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+            app.kubernetes.io/instance: ca-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
             app.kubernetes.io/name: clusterapi-cluster-autoscaler
         spec:
           containers:
@@ -201,7 +201,7 @@ data:
               readOnly: true
           dnsPolicy: ClusterFirst
           priorityClassName: system-cluster-critical
-          serviceAccountName: 'cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}'
+          serviceAccountName: cluster-autoscaler-{{ `{{ index .Cluster.Annotations "caren.nutanix.com/cluster-uuid" }}` }}
           tolerations:
           - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane

--- a/hack/addons/update-cluster-autoscaler.sh
+++ b/hack/addons/update-cluster-autoscaler.sh
@@ -25,7 +25,7 @@ cp "${KUSTOMIZE_BASE_DIR}"/*.yaml "${ASSETS_DIR}"
 
 kustomize build --enable-helm "${ASSETS_DIR}" >"${ASSETS_DIR}/${FILE_NAME}"
 
-sed -i -e "s/\([a-z-]*\)tmpl-clustername\([^-]*\)-tmpl\([a-z-]*\)/'\1{{ \`{{ .Cluster.Name\2 }}\` }}\3'/g" \
+sed -i -e "s/\([a-z-]*\)tmpl-clustername\([^-]*\)-tmpl\([a-z-]*\)/\1{{ \`{{ .Cluster.Name\2 }}\` }}\3/g" \
   -e "s/\([a-z-]*\)tmpl-clusteruuid-tmpl\([a-z-]*\)/'\1{{ \`{{ index .Cluster.Annotations \"caren.nutanix.com\/cluster-uuid\" }}\` }}\2'/g" \
   "${ASSETS_DIR}/${FILE_NAME}"
 

--- a/hack/addons/update-cluster-autoscaler.sh
+++ b/hack/addons/update-cluster-autoscaler.sh
@@ -26,7 +26,7 @@ cp "${KUSTOMIZE_BASE_DIR}"/*.yaml "${ASSETS_DIR}"
 kustomize build --enable-helm "${ASSETS_DIR}" >"${ASSETS_DIR}/${FILE_NAME}"
 
 sed -i -e "s/\([a-z-]*\)tmpl-clustername\([^-]*\)-tmpl\([a-z-]*\)/\1{{ \`{{ .Cluster.Name\2 }}\` }}\3/g" \
-  -e "s/\([a-z-]*\)tmpl-clusteruuid-tmpl\([a-z-]*\)/'\1{{ \`{{ index .Cluster.Annotations \"caren.nutanix.com\/cluster-uuid\" }}\` }}\2'/g" \
+  -e "s/\([a-z-]*\)tmpl-clusteruuid-tmpl\([a-z-]*\)/\1{{ \`{{ index .Cluster.Annotations \"caren.nutanix.com\/cluster-uuid\" }}\` }}\2/g" \
   "${ASSETS_DIR}/${FILE_NAME}"
 
 kubectl create configmap "{{ .Values.hooks.clusterAutoscaler.crsStrategy.defaultInstallationConfigMap.name }}" --dry-run=client --output yaml \

--- a/test/e2e/configmap_helpers.go
+++ b/test/e2e/configmap_helpers.go
@@ -1,0 +1,62 @@
+//go:build e2e
+
+// Copyright 2024 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	capie2e "sigs.k8s.io/cluster-api/test/e2e"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type WaitForConfigMapDataInput struct {
+	Getter        framework.Getter
+	ConfigMap     *corev1.ConfigMap
+	DataValidator func(data map[string]string) bool
+}
+
+func WaitForConfigMapData(
+	ctx context.Context,
+	input WaitForConfigMapDataInput,
+	intervals ...interface{},
+) {
+	start := time.Now()
+	key := client.ObjectKeyFromObject(input.ConfigMap)
+	capie2e.Byf("waiting for ConfigMap %s to have expected data", key)
+	Log("starting to wait for ConfigMap to have expected data")
+	Eventually(func() bool {
+		if err := input.Getter.Get(ctx, key, input.ConfigMap); err == nil {
+			return input.DataValidator(input.ConfigMap.Data)
+		}
+		return false
+	}, intervals...).Should(BeTrue(), func() string {
+		return DescribeIncorrectConfigMapData(input, input.ConfigMap)
+	})
+	Logf("ConfigMap %s has expected data, took %v", key, time.Since(start))
+}
+
+// DescribeIncorrectConfigMapData returns detailed output to help debug a ConfigMap data validation failure in e2e.
+func DescribeIncorrectConfigMapData(
+	input WaitForConfigMapDataInput,
+	configMap *corev1.ConfigMap,
+) string {
+	b := strings.Builder{}
+	b.WriteString(fmt.Sprintf("ConfigMap %s failed to get expected data:\n",
+		klog.KObj(input.ConfigMap)))
+	if configMap == nil {
+		b.WriteString("\nConfigMap: nil\n")
+	} else {
+		b.WriteString(fmt.Sprintf("\nConfigMap:\n%s\n", framework.PrettyPrint(configMap)))
+	}
+	return b.String()
+}


### PR DESCRIPTION
**What problem does this PR solve?**:
Fixes an issue with CRS genertated CA Deployment not working because of extra quotes.
```
I0815 20:12:58.376871       1 reflector.go:332] Listing and watching cluster.x-k8s.io/v1beta1, Resource=machines from k8s.io/client-go/dynamic/dynamicinformer/informer.go:108
W0815 20:12:58.379140       1 reflector.go:547] k8s.io/client-go/dynamic/dynamicinformer/informer.go:108: failed to list cluster.x-k8s.io/v1beta1, Resource=machines: machines.cluster.x-k8s.io is forbidden: User "system:serviceaccount:default:cluster-autoscaler-0191579a-2104-7ace-a5a2-ceae4590d7fe" cannot list resource "machines" in API group "cluster.x-k8s.io" in the namespace "'default'"
E0815 20:12:58.379170       1 reflector.go:150] k8s.io/client-go/dynamic/dynamicinformer/informer.go:108: Failed to watch cluster.x-k8s.io/v1beta1, Resource=machines: failed to list cluster.x-k8s.io/v1beta1, Resource=machines: machines.cluster.x-k8s.io is forbidden: User "system:serviceaccount:default:cluster-autoscaler-0191579a-2104-7ace-a5a2-ceae4590d7fe" cannot list resource "machines" in API group "cluster.x-k8s.io" in the namespace "'default'"
```

The extra quotes are only an issue in `--node-group-auto-discovery=`, but the [same script](https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/blob/f632224257cb159b04abc2c6c6eb6874c503bb1c/hack/addons/update-cluster-autoscaler.sh#L28) replaces all occurrences. It should be safe to drop the single quotes everywhere though because the name and namespace will be strings and won't be interpreted as numbers by yaml.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
~I think we can improve the e2e tests by checking that all Deployments are Ready on the self-managed clusters, but I did not do that as part of this PR.~ The tests already do that https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/blob/f632224257cb159b04abc2c6c6eb6874c503bb1c/test/e2e/clusterautoscaler_helpers.go#L115

Instead we can also wait for the status ConfigMap to be `Running`
This is what the data will contain for a working Deployment:
```
data:
  status: |+
    time: 2024-05-22 19:33:34.074058252 +0000 UTC
    autoscalerStatus: Running
```
And for non working:
```
data:
  status: |+
    time: 2024-08-15 20:07:37.204175116 +0000 UTC
    autoscalerStatus: Initializing
```