### PR TITLE
fix: Use same security context & priority class for helm-repository pod

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
@@ -57,7 +57,17 @@ spec:
         - name: certs-vol
           mountPath: "/certs"
           readOnly: true
-        env:
+        livenessProbe:
+          tcpSocket:
+            port: serve
+        readinessProbe:
+          tcpSocket:
+            port: serve
+      priorityClassName: {{ .Values.priorityClassName }}
+      securityContext:
+        {{ with .Values.securityContext }}
+        {{- toYaml . | nindent 8}}
+        {{- end }}
       volumes:
       - name: certs-vol
         secret:


### PR DESCRIPTION
The helm-repository should be a system critical pod as if it is unavaialable
then no clusters will be creatable.
