### PR TITLE
build: Include debug symbols in release image executable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,8 +61,6 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s
-      - -w
       - -X 'k8s.io/component-base/version.buildDate={{ .CommitDate }}'
       - -X 'k8s.io/component-base/version.gitCommit={{ .FullCommit }}'
       - -X 'k8s.io/component-base/version.gitTreeState={{ .Env.GIT_TREE_STATE }}'


### PR DESCRIPTION
**What problem does this PR solve?**:
Allows the user of a release image to set breakpoints and tracepoints.

Size of executable increases from 47MB to 65MB, or approximately 38 percent.
 
**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
