### PR TITLE
ci: Support release branches for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - release/v*
 
 permissions:
   contents: write
@@ -21,8 +22,10 @@ jobs:
   release-please:
     runs-on: ubuntu-22.04
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release-please
+        with:
+          target-branch: ${{ github.ref_name }}
 
       - uses: actions/checkout@v4
         if: ${{ steps.release-please.outputs.release_created }}


### PR DESCRIPTION
Required to continue iterating on CAREN while creating backports
for previous versions as required.
