### PR TITLE
build: Update patch only for local release branch dev builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -154,4 +154,4 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incminor .Tag }}-dev"
+  name_template: "{{ incpatch .Tag }}-dev"


### PR DESCRIPTION
Prevents confusion over what version is being built locally.
