### PR TITLE
fix: Remove deprecated toleration for node-role.kubernetes.io/master

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -100,4 +100,4 @@ A Helm chart for cluster-api-runtime-extensions-nutanix
 | service.annotations | object | `{}` |  |
 | service.port | int | `443` |  |
 | service.type | string | `"ClusterIP"` |  |
-| tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Equal"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Equal"}]` | Kubernetes pod tolerations |
+| tolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Equal"}]` | Kubernetes pod tolerations |

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/aws-ccm-v1.27.9-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/aws-ccm-v1.27.9-configmap.yaml
@@ -178,8 +178,6 @@ data:
             key: node.cloudprovider.kubernetes.io/uninitialized
             value: "true"
           - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-          - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
       updateStrategy:
         type: RollingUpdate

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/aws-ccm-v1.28.9-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/aws-ccm-v1.28.9-configmap.yaml
@@ -178,8 +178,6 @@ data:
             key: node.cloudprovider.kubernetes.io/uninitialized
             value: "true"
           - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-          - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
       updateStrategy:
         type: RollingUpdate

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/aws-ccm-v1.29.6-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/aws-ccm-v1.29.6-configmap.yaml
@@ -178,8 +178,6 @@ data:
             key: node.cloudprovider.kubernetes.io/uninitialized
             value: "true"
           - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-          - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
       updateStrategy:
         type: RollingUpdate

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/aws-ccm-v1.30.2-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/aws-ccm-v1.30.2-configmap.yaml
@@ -178,8 +178,6 @@ data:
             key: node.cloudprovider.kubernetes.io/uninitialized
             value: "true"
           - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-          - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
       updateStrategy:
         type: RollingUpdate

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/aws-ccm-v1.31.0-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/aws-ccm-v1.31.0-configmap.yaml
@@ -178,8 +178,6 @@ data:
             key: node.cloudprovider.kubernetes.io/uninitialized
             value: "true"
           - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-          - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
       updateStrategy:
         type: RollingUpdate

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/ccm/aws/manifests/helm-addon-installation.yaml
@@ -31,4 +31,13 @@ data:
     {{ "{{" }}$ccmVersion := get $k8sMinorVersionToCCMVersion ( print $clusterSemver.Major "." $clusterSemver.Minor ) {{ "}}" }}
     image:
       tag: {{ "{{ " }} $ccmVersion {{ "}}" }}
+
+    tolerations:
+    - key: node.cloudprovider.kubernetes.io/uninitialized
+      value: "true"
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
+
+
 {{- end -}}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/aws-ebs/manifests/aws-ebs-csi-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/aws-ebs/manifests/aws-ebs-csi-configmap.yaml
@@ -787,9 +787,6 @@ data:
             operator: Exists
             tolerationSeconds: 300
           - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-            operator: Exists
-          - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
             operator: Exists
           volumes:

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/aws-ebs/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/aws-ebs/manifests/helm-addon-installation.yaml
@@ -23,9 +23,6 @@ data:
           operator: Exists
           tolerationSeconds: 300
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: Exists
-        - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
           operator: Exists
     node:

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/local-path/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/local-path/manifests/helm-addon-installation.yaml
@@ -20,9 +20,6 @@ data:
         operator: Exists
         tolerationSeconds: 300
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
         operator: Exists
 {{- end -}}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/local-path/manifests/local-path-provisioner-csi-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/local-path/manifests/local-path-provisioner-csi-configmap.yaml
@@ -249,9 +249,6 @@ data:
             operator: Exists
             tolerationSeconds: 300
           - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-            operator: Exists
-          - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
             operator: Exists
           volumes:

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/nutanix/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/nutanix/manifests/helm-addon-installation.yaml
@@ -21,9 +21,6 @@ data:
         operator: Exists
         tolerationSeconds: 300
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
         operator: Exists
 {{- end -}}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/snapshot-controller/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/snapshot-controller/manifests/helm-addon-installation.yaml
@@ -17,9 +17,6 @@ data:
           operator: Exists
           tolerationSeconds: 300
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-          operator: Exists
-        - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
           operator: Exists
     webhook:

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/helm-addon-installation.yaml
@@ -23,15 +23,11 @@ data:
               - "vendor"
       tolerations:
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
     ### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>
 
     gc:
       tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
 {{- end -}}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/node-feature-discovery-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/node-feature-discovery-configmap.yaml
@@ -1080,8 +1080,6 @@ data:
           serviceAccountName: node-feature-discovery-worker
           tolerations:
           - effect: NoSchedule
-            key: node-role.kubernetes.io/master
-          - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
           volumes:
           - hostPath:
@@ -1145,13 +1143,6 @@ data:
           affinity:
             nodeAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - preference:
-                  matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: In
-                    values:
-                    - ""
-                weight: 1
               - preference:
                   matchExpressions:
                   - key: node-role.kubernetes.io/control-plane
@@ -1287,8 +1278,6 @@ data:
           securityContext: {}
           serviceAccountName: node-feature-discovery-gc
           tolerations:
-          - effect: NoSchedule
-            key: node-role.kubernetes.io/master
           - effect: NoSchedule
             key: node-role.kubernetes.io/control-plane
 kind: ConfigMap

--- a/charts/cluster-api-runtime-extensions-nutanix/values.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.yaml
@@ -170,9 +170,6 @@ nodeSelector: {}
 
 # -- Kubernetes pod tolerations
 tolerations:
-  - key: node-role.kubernetes.io/master
-    operator: Equal
-    effect: NoSchedule
   - key: node-role.kubernetes.io/control-plane
     operator: Equal
     effect: NoSchedule

--- a/hack/addons/kustomize/aws-ccm/helm-values.yaml
+++ b/hack/addons/kustomize/aws-ccm/helm-values.yaml
@@ -15,3 +15,10 @@ args:
   - --v=2
   - --cloud-provider=aws
   - --configure-cloud-routes=false
+
+tolerations:
+- key: node.cloudprovider.kubernetes.io/uninitialized
+  value: "true"
+  effect: NoSchedule
+- key: node-role.kubernetes.io/control-plane
+  effect: NoSchedule

--- a/hack/addons/kustomize/aws-ebs-csi/helm-values.yaml
+++ b/hack/addons/kustomize/aws-ebs-csi/helm-values.yaml
@@ -17,9 +17,6 @@ controller:
       operator: Exists
       tolerationSeconds: 300
     - effect: NoSchedule
-      key: node-role.kubernetes.io/master
-      operator: Exists
-    - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
       operator: Exists
 node:

--- a/hack/addons/kustomize/local-path-provisioner-csi/helm-values.yaml
+++ b/hack/addons/kustomize/local-path-provisioner-csi/helm-values.yaml
@@ -14,8 +14,5 @@ tolerations:
     operator: Exists
     tolerationSeconds: 300
   - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Exists
-  - effect: NoSchedule
     key: node-role.kubernetes.io/control-plane
     operator: Exists

--- a/hack/addons/kustomize/nfd/helm-values.yaml
+++ b/hack/addons/kustomize/nfd/helm-values.yaml
@@ -7,6 +7,15 @@ master:
     - nvidia.com
     - beta.amd.com
     - amd.com
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: In
+                values: [""]
 
 worker: ### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
   config:
@@ -17,14 +26,10 @@ worker: ### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
           - "vendor"
   tolerations:
     - effect: NoSchedule
-      key: node-role.kubernetes.io/master
-    - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
 ### <NFD-WORKER-CONF-END-DO-NOT-REMOVE>
 
 gc:
   tolerations:
-    - effect: NoSchedule
-      key: node-role.kubernetes.io/master
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane

--- a/pkg/handlers/generic/lifecycle/ccm/aws/handler_test.go
+++ b/pkg/handlers/generic/lifecycle/ccm/aws/handler_test.go
@@ -70,8 +70,6 @@ spec:
         key: node.cloudprovider.kubernetes.io/uninitialized
         value: "true"
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
This was removed in Kubernetes v1.24 so is no longer needed and actually
throws a warning now if it is kept when applying manifests:

```
[KubeAPIWarningLogger] spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[1].preference.matchExpressions[0].key: node-role.kubernetes.io/master is use "node-role.kubernetes.io/control-plane" instead
```

Removal note in https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/#api-removals-deprecations-and-other-changes-for-kubernetes-1-24.

Blocked by #893.