### PR TITLE
feat: Enable Hubble Relay in Cilium deployment via CAAPH

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cni/cilium/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cni/cilium/manifests/helm-addon-installation.yaml
@@ -12,6 +12,7 @@ data:
       chainingMode: portmap
       exclusive: false
     hubble:
+      relay: enabled
       tls:
         auto:
           enabled: true               # enable automatic TLS certificate generation

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cni/cilium/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cni/cilium/manifests/helm-addon-installation.yaml
@@ -12,7 +12,8 @@ data:
       chainingMode: portmap
       exclusive: false
     hubble:
-      relay: enabled
+      relay:
+        enabled: true
       tls:
         auto:
           enabled: true               # enable automatic TLS certificate generation

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cni/cilium/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cni/cilium/manifests/helm-addon-installation.yaml
@@ -12,6 +12,7 @@ data:
       chainingMode: portmap
       exclusive: false
     hubble:
+      enabled: true
       relay:
         enabled: true
       tls:

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/cni/cilium/manifests/helm-addon-installation.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/cni/cilium/manifests/helm-addon-installation.yaml
@@ -13,14 +13,16 @@ data:
       exclusive: false
     hubble:
       enabled: true
-      relay:
-        enabled: true
       tls:
         auto:
           enabled: true               # enable automatic TLS certificate generation
           method: cronJob             # auto generate certificates using cronJob method
           certValidityDuration: 60    # certificates validity duration in days (default 2 months)
           schedule: "0 0 1 * *"       # schedule on the 1st day regeneration of each month
+      relay:
+        enabled: true
+        image:
+          useDigest: false
     ipam:
       mode: kubernetes
     image:

--- a/hack/addons/kustomize/cilium/helm-values.yaml
+++ b/hack/addons/kustomize/cilium/helm-values.yaml
@@ -7,6 +7,8 @@ cni:
   exclusive: false
 hubble:
   enabled: false
+  relay:
+    enabled: false
 ipam:
   mode: kubernetes
 image:

--- a/pkg/handlers/generic/lifecycle/ccm/aws/handler.go
+++ b/pkg/handlers/generic/lifecycle/ccm/aws/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,7 +24,7 @@ import (
 const (
 	awsCCMPrefix = "aws-ccm-"
 
-	defaultHelmReleaseNamespace = "kube-system"
+	defaultHelmReleaseNamespace = metav1.NamespaceSystem
 	defaultHelmReleaseName      = "aws-cloud-controller-manager"
 )
 

--- a/pkg/handlers/generic/lifecycle/ccm/nutanix/handler.go
+++ b/pkg/handlers/generic/lifecycle/ccm/nutanix/handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -25,7 +26,7 @@ import (
 
 const (
 	defaultHelmReleaseName      = "nutanix-ccm"
-	defaultHelmReleaseNamespace = "kube-system"
+	defaultHelmReleaseNamespace = metav1.NamespaceSystem
 
 	// This is the name of the Secret on the remote cluster that should match what is defined in Helm values.
 	//nolint:gosec // Does not contain hard coded credentials.

--- a/pkg/handlers/generic/lifecycle/cni/cilium/handler.go
+++ b/pkg/handlers/generic/lifecycle/cni/cilium/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -32,7 +33,7 @@ type CNIConfig struct {
 
 const (
 	defaultCiliumReleaseName = "cilium"
-	defaultCiliumNamespace   = "kube-system"
+	defaultCiliumNamespace   = metav1.NamespaceSystem
 )
 
 type helmAddonConfig struct {

--- a/pkg/handlers/generic/lifecycle/csi/awsebs/handler.go
+++ b/pkg/handlers/generic/lifecycle/csi/awsebs/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,7 +23,7 @@ import (
 
 const (
 	defaultHelmReleaseName      = "aws-ebs-csi-driver"
-	defaultHelmReleaseNamespace = "kube-system"
+	defaultHelmReleaseNamespace = metav1.NamespaceSystem
 )
 
 var DefaultStorageClassParameters = map[string]string{

--- a/pkg/handlers/generic/lifecycle/csi/localpath/handler.go
+++ b/pkg/handlers/generic/lifecycle/csi/localpath/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,7 +23,7 @@ import (
 
 const (
 	defaultHelmReleaseName      = "local-path-provisioner-csi"
-	defaultHelmReleaseNamespace = "kube-system"
+	defaultHelmReleaseNamespace = metav1.NamespaceSystem
 )
 
 type Config struct {

--- a/pkg/handlers/generic/lifecycle/csi/snapshotcontroller/handler.go
+++ b/pkg/handlers/generic/lifecycle/csi/snapshotcontroller/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -25,7 +26,7 @@ import (
 
 const (
 	defaultHelmReleaseName      = "snapshot-controller"
-	defaultHelmReleaseNamespace = "kube-system"
+	defaultHelmReleaseNamespace = metav1.NamespaceSystem
 )
 
 type Config struct {

--- a/test/e2e/clusterautoscaler_helpers.go
+++ b/test/e2e/clusterautoscaler_helpers.go
@@ -135,7 +135,7 @@ func WaitForClusterAutoscalerToBeReadyForWorkloadCluster(
 
 	statusConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "kube-system",
+			Namespace: metav1.NamespaceSystem,
 			Name:      "cluster-autoscaler-status",
 		},
 	}

--- a/test/e2e/framework/self_hosted.go
+++ b/test/e2e/framework/self_hosted.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -286,12 +287,12 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		Consistently(func() error {
 			kubeSystem := &corev1.Namespace{}
 			return input.BootstrapClusterProxy.GetClient().
-				Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+				Get(ctx, client.ObjectKey{Name: metav1.NamespaceSystem}, kubeSystem)
 		}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
 		Consistently(func() error {
 			kubeSystem := &corev1.Namespace{}
 			return selfHostedClusterProxy.GetClient().
-				Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+				Get(ctx, client.ObjectKey{Name: metav1.NamespaceSystem}, kubeSystem)
 		}, "5s", "100ms").Should(BeNil(), "Failed to assert self-hosted API server stability")
 
 		By("Moving the cluster to self hosted")
@@ -343,12 +344,12 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 			Consistently(func() error {
 				kubeSystem := &corev1.Namespace{}
 				return input.BootstrapClusterProxy.GetClient().
-					Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+					Get(ctx, client.ObjectKey{Name: metav1.NamespaceSystem}, kubeSystem)
 			}, "5s", "100ms").Should(BeNil(), "Failed to assert bootstrap API server stability")
 			Consistently(func() error {
 				kubeSystem := &corev1.Namespace{}
 				return selfHostedClusterProxy.GetClient().
-					Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
+					Get(ctx, client.ObjectKey{Name: metav1.NamespaceSystem}, kubeSystem)
 			}, "5s", "100ms").Should(BeNil(), "Failed to assert self-hosted API server stability")
 
 			By("Moving the cluster back to bootstrap")


### PR DESCRIPTION
**What problem does this PR solve?**:
Relay is required for network visibility of a cluster as a whole. See https://docs.cilium.io/en/stable/gettingstarted/hubble_intro/.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
