### PR TITLE
build: Include Calico images in image list

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,7 +56,7 @@ before:
     - make template-helm-repository
     - |
       sh -ec 'if [ {{ .IsSnapshot }} == false ] ; then
-        env CAREN_VERSION=v{{ trimprefix .Version "v" }} make list-images
+        make --no-print-directory CAREN_VERSION=v{{ trimprefix .Version "v" }} list-images >caren-images.txt
       fi'
 
 builds:

--- a/make/addons.mk
+++ b/make/addons.mk
@@ -87,8 +87,7 @@ template-helm-repository: generate-mindthegap-repofile ## this is used by goreal
 
 .PHONY: list-images
 list-images:
-	cd hack/tools/fetch-images && go build
-	./hack/tools/fetch-images/fetch-images \
-		-chart-directory=./charts/cluster-api-runtime-extensions-nutanix/ \
-		-helm-chart-configmap=./charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml \
-		-caren-version=$(CAREN_VERSION) >> caren-images.txt
+	cd hack/tools/fetch-images && go run . \
+	  -chart-directory=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/ \
+	  -helm-chart-configmap=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml \
+	  -caren-version=$(CAREN_VERSION)


### PR DESCRIPTION
Calico images are deployed by the tigera-operator and as such are not
discoverable by the helm list images plugin. Using the extra images file
functionality of the helm list images plugin allows for adding these
images as templated strings that will adapt with the chart version as it
is updated in future.

This commit also fixes up some other things:

- Use `filepath` instead of `path` for portabiity
- Output the image list to stdout from make to allow user to decide
  where to redirect list to
- Omit changing dir from image list when running as goreleaser hook
- Slightly more defensive when checking errors

Final output is:

```shell
$ make list-images

docker.io/nutanix/ntnx-csi-precheck:3.0.0
docker.io/nutanix/ntnx-csi:3.0.0
docker.io/rancher/local-path-provisioner:v0.0.28
ghcr.io/nutanix-cloud-native/caren-helm-reg:v0.0.0-dev
ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.4.1
ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix:v0.0.0-dev
public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.34.0
public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.6.1-eks-1-30-10
public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v5.0.1-eks-1-30-10
public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.11.1-eks-1-30-10
public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-10
public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.11.0-eks-1-30-10
quay.io/calico/apiserver:v3.28.1
quay.io/calico/cni:v3.28.1
quay.io/calico/csi:v3.28.1
quay.io/calico/ctl:v3.28.1
quay.io/calico/kube-controllers:v3.28.1
quay.io/calico/node-driver-registrar:v3.28.1
quay.io/calico/node:v3.28.1
quay.io/calico/pod2daemon-flexvol:v3.28.1
quay.io/calico/typha:v3.28.1
quay.io/cilium/certgen:v0.2.0
quay.io/cilium/cilium-envoy@sha256:bd5ff8c66716080028f414ec1cb4f7dc66f40d2fb5a009fff187f4a9b90b566b
quay.io/cilium/cilium:v1.16.1
quay.io/cilium/operator-generic:v1.16.1
quay.io/frrouting/frr:9.1.0
quay.io/metallb/controller:v0.14.8
quay.io/metallb/speaker:v0.14.8
quay.io/tigera/operator:v1.34.3
registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0
registry.k8s.io/nfd/node-feature-discovery:v0.16.4
registry.k8s.io/provider-aws/cloud-controller-manager:v1.27.9
registry.k8s.io/provider-aws/cloud-controller-manager:v1.28.9
registry.k8s.io/provider-aws/cloud-controller-manager:v1.29.6
registry.k8s.io/provider-aws/cloud-controller-manager:v1.30.2
registry.k8s.io/provider-aws/cloud-controller-manager:v1.31.0
registry.k8s.io/sig-storage/csi-attacher:v4.4.3
registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.10.0
registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.3
registry.k8s.io/sig-storage/csi-provisioner:v3.6.3
registry.k8s.io/sig-storage/csi-resizer:v1.9.3
registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
registry.k8s.io/sig-storage/livenessprobe:v2.11.0
registry.k8s.io/sig-storage/snapshot-controller:v8.1.0
```

Depends on #822.
