### PR TITLE
ci(release/v0.14.x): enable creating release-please PR from release branches

### DIFF
--- a/docs/content/contributing/releasing.md
+++ b/docs/content/contributing/releasing.md
@@ -10,7 +10,10 @@ This project uses [release-please] to automate changelog updates per release. Du
 [release-please-action].
 
 When a release has been cut, a new release PR can be created manually using the `release-please` CLI locally. This needs
-to be run by someone with write permissions to the repository. Create the `release-please` branch and PR:
+to be run by someone with write permissions to the repository.
+The new release PR can be only created against `main` or `release/*` branch.
+Ensure to checkout `main` or `release/*` branch locally.
+Create the `release-please` branch and PR from `main` or `release/*` branch:
 
 ```shell
 make release-please

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -45,7 +45,8 @@ dev.update-bootstrap-credentials-aws:
 
 .PHONY: release-please
 release-please:
-ifneq ($(shell [[ "$(GIT_CURRENT_BRANCH)" = "main" ]] || [[ "$(GIT_CURRENT_BRANCH)" == release/v* ]]; echo $$?),0)
+# filter Returns all whitespace-separated words in text that do match any of the pattern words.
+ifeq ($(filter main release/v%,$(GIT_CURRENT_BRANCH)),)
 	$(error "release-please should only be run on the main or release branch")
 else
 	release-please release-pr --repo-url $(GITHUB_ORG)/$(GITHUB_REPOSITORY) --target-branch $(GIT_CURRENT_BRANCH) --token "$$(gh auth token)"

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -45,11 +45,10 @@ dev.update-bootstrap-credentials-aws:
 
 .PHONY: release-please
 release-please:
-ifneq ($(GIT_CURRENT_BRANCH),main)
-	$(error "release-please should only be run on the main branch")
+ifneq ($(shell [[ "$(GIT_CURRENT_BRANCH)" = "main" ]] || [[ "$(GIT_CURRENT_BRANCH)" == release/v* ]]; echo $$?),0)
+	$(error "release-please should only be run on the main or release branch")
 else
-	release-please release-pr \
-	  --repo-url $(GITHUB_ORG)/$(GITHUB_REPOSITORY) --token "$$(gh auth token)"
+	release-please release-pr --repo-url $(GITHUB_ORG)/$(GITHUB_REPOSITORY) --target-branch $(GIT_CURRENT_BRANCH) --token "$$(gh auth token)"
 endif
 
 .PHONY: .envrc.e2e

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -134,8 +134,8 @@ providers:
 - name: caren
   type: RuntimeExtensionProvider
   versions:
-  - name: "{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.13}"
-    value: "https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/releases/download/{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.13}/runtime-extension-components.yaml"
+  - name: "{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.14}"
+    value: "https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/releases/download/{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.14}/runtime-extension-components.yaml"
     type: "url"
     contract: v1beta1
     files:


### PR DESCRIPTION
**What problem does this PR solve?**:
- enable creating first release-please PR for release branches
- change CAREN e2e config to use version 0.14.x

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
on branches other than `main` and `release/*`
```
make release-please
make/dev.mk:49: *** "release-please should only be run on the main or release branch".  Stop.
```
on `release/v0.1.4.x` branch
https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/910

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
