### PR TITLE
build: Enable building binary only on macos

### DIFF
--- a/make/goreleaser.mk
+++ b/make/goreleaser.mk
@@ -16,6 +16,7 @@ build-snapshot: go-generate ; $(info $(M) building snapshot $*)
 		--snapshot \
 		--clean \
 		--parallelism=$(GORELEASER_PARALLELISM) \
+		--config=<(env GOOS=$(shell go env GOOS) gojq --yaml-input --yaml-output '.builds[0].goos |= (. + [env.GOOS] | unique)' .goreleaser.yml) \
 		$(if $(BUILD_ALL),,--single-target)
 
 .PHONY: release


### PR DESCRIPTION
Current config only allows building local binaries on Linux machines so
adding config to allow building binaries on macos without changing the
release config (and hence still only releasing linux binaries as required).
