### PR TITLE
build: Fix up metadata missed in v0.16.0 release process

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -46,3 +46,6 @@ releaseSeries:
   - contract: v1beta1
     major: 0
     minor: 15
+  - contract: v1beta1
+    major: 0
+    minor: 16

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -145,7 +145,7 @@ providers:
       new: "--v=8"
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
-  - name: v0.16.99 # "vNext"; use manifests from local source files
+  - name: v0.17.99 # "vNext"; use manifests from local source files
     value: "file://../../../runtime-extension-components.yaml"
     type: "url"
     contract: v1beta1

--- a/test/e2e/data/shared/v1beta1-caren/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1-caren/metadata.yaml
@@ -37,3 +37,6 @@ releaseSeries:
   - contract: v1beta1
     major: 0
     minor: 16
+  - contract: v1beta1
+    major: 0
+    minor: 17


### PR DESCRIPTION
Metadata files were not correctly updated at time of release so fixing
up here.
