### PR TITLE
build: Consistently format even generated files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,15 @@ repos:
     entry: make schema-chart
     language: system
     files: "^charts/cluster-api-runtime-extensions-nutanix/values.yaml$"
+  - id: go-generate
+    name: go-generate
+    entry: make go-generate
+    language: system
+    files: "(.*\\.go|go.mod|go.sum|go.mk)$"
+    pass_filenames: false
   - id: golangci-lint
     name: golangci-lint
-    entry: make go-generate lint
+    entry: make lint
     language: system
     files: "(.*\\.go|go.mod|go.sum|go.mk)$"
     pass_filenames: false

--- a/make/make.mk
+++ b/make/make.mk
@@ -3,3 +3,4 @@
 
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-builtin-variables
+MAKEFLAGS += --no-print-directory


### PR DESCRIPTION
Reworked checks in pre-commit config to check if generated files are
consistent after running `make go-generate`, which is called when
building the release so we are confident this doesn't get broken in any
future PRs.

Calling golines when generating deepcopy, etc will ensure a consistent
formatting for these generated files.

Also reinstated go fix as this is now properly supported in recent go versions.

And finally simplify the ignore external call by using golines flag rather than
a grep on the go source dirs.