### PR TITLE
fix: image registries with no credentials but with a CA

### DIFF
--- a/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/credential_provider_config_files.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"text/template"
 
+	corev1 "k8s.io/api/core/v1"
 	credentialproviderv1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
 	cabpkv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 
@@ -28,6 +29,8 @@ const (
 	kubeletDynamicCredentialProviderConfigOnRemote = "/etc/kubernetes/dynamic-credential-provider-config.yaml"
 
 	azureCloudConfigFilePath = "/etc/kubernetes/azure.json"
+
+	secretKeyForCACert = "ca.crt"
 )
 
 var (
@@ -47,10 +50,11 @@ var (
 )
 
 type providerConfig struct {
-	URL      string
-	Username string
-	Password string
-	Mirror   bool
+	URL       string
+	Username  string
+	Password  string
+	HasCACert bool
+	Mirror    bool
 }
 
 func (c providerConfig) isCredentialsEmpty() bool {
@@ -248,4 +252,13 @@ func fileFromTemplate(
 		Content:     b.String(),
 		Permissions: "0600",
 	}, nil
+}
+
+func secretHasCACert(secret *corev1.Secret) bool {
+	if secret == nil {
+		return false
+	}
+
+	_, ok := secret.Data[secretKeyForCACert]
+	return ok
 }

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/inject.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/inject.go
@@ -131,19 +131,19 @@ func (h *imageRegistriesPatchHandler) Mutate(
 		)
 	}
 
-	needCredentials, err := needImageRegistryCredentialsConfiguration(
+	registriesThatNeedConfiguration, err := providerConfigsThatNeedConfiguration(
 		registriesWithOptionalCredentials,
 	)
 	if err != nil {
 		return err
 	}
-	if !needCredentials {
-		log.V(5).Info("Only Global Registry Mirror is defined but credentials are not needed")
+	if len(registriesThatNeedConfiguration) == 0 {
+		log.V(5).Info("Image registry credentials are not needed")
 		return nil
 	}
 
 	files, commands, generateErr := generateFilesAndCommands(
-		registriesWithOptionalCredentials,
+		registriesThatNeedConfiguration,
 		clusterKey.Name,
 	)
 	if generateErr != nil {
@@ -185,7 +185,7 @@ func (h *imageRegistriesPatchHandler) Mutate(
 				return err
 			}
 
-			err = createSecretIfNeeded(ctx, h.client, registriesWithOptionalCredentials, cluster)
+			err = createSecretIfNeeded(ctx, h.client, registriesThatNeedConfiguration, cluster)
 			if err != nil {
 				return err
 			}
@@ -243,7 +243,7 @@ func (h *imageRegistriesPatchHandler) Mutate(
 				return err
 			}
 
-			err = createSecretIfNeeded(ctx, h.client, registriesWithOptionalCredentials, cluster)
+			err = createSecretIfNeeded(ctx, h.client, registriesThatNeedConfiguration, cluster)
 			if err != nil {
 				return err
 			}
@@ -444,30 +444,30 @@ func createSecretIfNeeded(
 // and if that is not the case we assume the users missed setting static credentials and return an error.
 // However, in addition to passing credentials with the globalImageRegistryMirror variable,
 // it can also be used to only set Containerd mirror configuration,
-// in that case it valid for static credentials to not be set and will return false, no error
+// in which case it is valid for static credentials to not be set and will be skipped, no error
 // and this handler will skip generating any credential plugin related configuration.
-func needImageRegistryCredentialsConfiguration(configs []providerConfig) (bool, error) {
-	var needConfiguration bool
+func providerConfigsThatNeedConfiguration(configs []providerConfig) ([]providerConfig, error) {
+	var needConfiguration []providerConfig //nolint:prealloc // We don't know the size of the slice yet.
 	for _, config := range configs {
 		requiresStaticCredentials, err := config.requiresStaticCredentials()
 		if err != nil {
-			return false,
+			return nil,
 				fmt.Errorf("error determining if Image Registry is a supported provider: %w", err)
 		}
 		// verify the credentials are actually set if the plugin requires static credentials
 		if config.isCredentialsEmpty() && requiresStaticCredentials {
 			if config.Mirror || config.HasCACert {
-				// not setting credentials for a mirror is valid
-				// not setting credentials for a registry with a CA cert is valid
+				// not setting credentials for a mirror is valid, but won't need any configuration
+				// not setting credentials for a registry with a CA cert is valid, but won't need any configuration
 				continue
 			}
-			return false, fmt.Errorf(
+			return nil, fmt.Errorf(
 				"invalid image registry: %s: %w",
 				config.URL,
 				ErrCredentialsNotFound,
 			)
 		}
-		needConfiguration = true
+		needConfiguration = append(needConfiguration, config)
 	}
 
 	return needConfiguration, nil

--- a/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
+++ b/pkg/handlers/generic/mutation/imageregistries/credentials/inject_test.go
@@ -43,7 +43,7 @@ func Test_needImageRegistryCredentialsConfiguration(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "ECR credentials",
+			name: "ECR registry with no credentials",
 			configs: []providerConfig{
 				{URL: "https://123456789.dkr.ecr.us-east-1.amazonaws.com"},
 			},
@@ -59,7 +59,7 @@ func Test_needImageRegistryCredentialsConfiguration(t *testing.T) {
 			need: true,
 		},
 		{
-			name: "ECR mirror",
+			name: "ECR mirror with no credentials",
 			configs: []providerConfig{
 				{
 					URL:    "https://123456789.dkr.ecr.us-east-1.amazonaws.com",
@@ -71,7 +71,7 @@ func Test_needImageRegistryCredentialsConfiguration(t *testing.T) {
 		{
 			name: "mirror with static credentials",
 			configs: []providerConfig{{
-				URL:      "https://myregistry.com",
+				URL:      "https://mymirror.com",
 				Username: "myuser",
 				Password: "mypassword",
 				Mirror:   true,
@@ -81,7 +81,7 @@ func Test_needImageRegistryCredentialsConfiguration(t *testing.T) {
 		{
 			name: "mirror with no credentials",
 			configs: []providerConfig{{
-				URL:    "https://myregistry.com",
+				URL:    "https://mymirror.com",
 				Mirror: true,
 			}},
 			need: false,
@@ -93,14 +93,29 @@ func Test_needImageRegistryCredentialsConfiguration(t *testing.T) {
 					URL:      "https://myregistry.com",
 					Username: "myuser",
 					Password: "mypassword",
-					Mirror:   true,
+					Mirror:   false,
 				},
 				{
-					URL:    "https://myregistry.com",
+					URL:    "https://mymirror.com",
 					Mirror: true,
 				},
 			},
 			need: true,
+		},
+		{
+			name: "a registry with missing credentials and a mirror with no credentials",
+			configs: []providerConfig{
+				{
+					URL:    "https://myregistry.com",
+					Mirror: false,
+				},
+				{
+					URL:    "https://mymirror.com",
+					Mirror: true,
+				},
+			},
+			need:    false,
+			wantErr: ErrCredentialsNotFound,
 		},
 		{
 			name: "registry with missing credentials",
@@ -109,6 +124,23 @@ func Test_needImageRegistryCredentialsConfiguration(t *testing.T) {
 			}},
 			need:    false,
 			wantErr: ErrCredentialsNotFound,
+		},
+		{
+			name: "registry with missing credentials but with a CA",
+			configs: []providerConfig{{
+				URL:       "https://myregistry.com",
+				HasCACert: true,
+			}},
+			need: false,
+		},
+		{
+			name: "mirror with missing credentials but with a CA",
+			configs: []providerConfig{{
+				URL:       "https://mymirror.com",
+				HasCACert: true,
+				Mirror:    true,
+			}},
+			need: false,
 		},
 	}
 


### PR DESCRIPTION
**What problem does this PR solve?**:
Passing `imageRegistries` with a CA but without credentials is still a valid configuration and should not error.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
