### PR TITLE
fix: Shorten readiness probe period to try to prevent races

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         resources:
-          {{ with .Values.resources }}
+          {{- with .Values.resources }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         volumeMounts:
@@ -93,9 +93,10 @@ spec:
             port: probes
             scheme: HTTP
             path: /readyz
+          periodSeconds: 1
       priorityClassName: {{ .Values.priorityClassName }}
       securityContext:
-        {{ with .Values.securityContext }}
+        {{- with .Values.securityContext }}
         {{- toYaml . | nindent 8}}
         {{- end }}
       volumes:

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
@@ -63,6 +63,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: serve
+          periodSeconds: 1
       priorityClassName: {{ .Values.priorityClassName }}
       securityContext:
         {{ with .Values.securityContext }}


### PR DESCRIPTION
Default readiness probe period is 10s so this should reduce timeouts
caused by overzealous probes.

This will need to backported to 0.14 release branch.