### PR TITLE
fix: [release/v0.14.x] Rename webhook container to manager

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: {{ template "chart.name" . }}
       terminationGracePeriodSeconds: 10
       containers:
-      - name: webhook
+      - name: manager
         image: "{{ .Values.image.repository }}:{{ default $.Chart.AppVersion .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         args:


### PR DESCRIPTION
The clusterctl logic to wait for providers to be ready depends on the
container name being manager (see
https://github.com/kubernetes-sigs/cluster-api/blob/main/cmd/clusterctl/internal/util/objs.go#L181)
otherwise it will not wait for the provider to be ready and hence
potentially
return too early for other client operations.

Backport of #932.