### PR TITLE
fix: include kube-vip image in generated caren-images.txt

### DIFF
--- a/make/addons.mk
+++ b/make/addons.mk
@@ -90,4 +90,5 @@ list-images:
 	cd hack/tools/fetch-images && go run . \
 	  -chart-directory=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/ \
 	  -helm-chart-configmap=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml \
-	  -caren-version=$(CAREN_VERSION)
+	  -caren-version=$(CAREN_VERSION) \
+	  -additional-yaml-files=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/templates/virtual-ip/kube-vip/manifests/kube-vip-configmap.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
Noticed that the kube-vip image was missing in the last release. This is because kube-vip is deployed as a static Pod and not as a Helm chart.

<details>
  <summary>$ make list-images</summary>

  ```
docker.io/nutanix/ntnx-csi-precheck:3.0.0
docker.io/nutanix/ntnx-csi:3.0.0
docker.io/rancher/local-path-provisioner:v0.0.30
ghcr.io/kube-vip/kube-vip:v0.8.3
ghcr.io/nutanix-cloud-native/caren-helm-reg:v0.0.0-dev
ghcr.io/nutanix-cloud-native/cloud-provider-nutanix/controller:v0.4.1
ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix:v0.0.0-dev
public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.35.0
public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.7.0-eks-1-31-3
public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v5.1.0-eks-1-31-3
public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.12.0-eks-1-31-3
public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.14.0-eks-1-31-3
public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.12.0-eks-1-31-3
quay.io/calico/apiserver:v3.28.2
quay.io/calico/cni:v3.28.2
quay.io/calico/csi:v3.28.2
quay.io/calico/ctl:v3.28.2
quay.io/calico/kube-controllers:v3.28.2
quay.io/calico/node-driver-registrar:v3.28.2
quay.io/calico/node:v3.28.2
quay.io/calico/pod2daemon-flexvol:v3.28.2
quay.io/calico/typha:v3.28.2
quay.io/cilium/certgen:v0.2.0
quay.io/cilium/cilium-envoy:v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
quay.io/cilium/cilium:v1.16.2
quay.io/cilium/hubble-relay:v1.16.2
quay.io/cilium/operator-generic:v1.16.2
quay.io/frrouting/frr:9.1.0
quay.io/metallb/controller:v0.14.8
quay.io/metallb/speaker:v0.14.8
quay.io/tigera/operator:v1.34.5
registry.k8s.io/autoscaling/cluster-autoscaler:v1.31.0
registry.k8s.io/nfd/node-feature-discovery:v0.16.4
registry.k8s.io/provider-aws/cloud-controller-manager:v1.27.9
registry.k8s.io/provider-aws/cloud-controller-manager:v1.28.9
registry.k8s.io/provider-aws/cloud-controller-manager:v1.29.6
registry.k8s.io/provider-aws/cloud-controller-manager:v1.30.3
registry.k8s.io/provider-aws/cloud-controller-manager:v1.31.0
registry.k8s.io/sig-storage/csi-attacher:v4.4.3
registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.10.0
registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.3
registry.k8s.io/sig-storage/csi-provisioner:v3.6.3
registry.k8s.io/sig-storage/csi-resizer:v1.9.3
registry.k8s.io/sig-storage/csi-snapshotter:v3.0.3
registry.k8s.io/sig-storage/livenessprobe:v2.11.0
registry.k8s.io/sig-storage/snapshot-controller:v8.1.0

  ```
</details>

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
