### PR TITLE
fix: use minimal image for NFD

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/node-feature-discovery-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/node-feature-discovery-configmap.yaml
@@ -1019,7 +1019,7 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.uid
-            image: registry.k8s.io/nfd/node-feature-discovery:v0.16.4
+            image: registry.k8s.io/nfd/node-feature-discovery:v0.16.4-minimal
             imagePullPolicy: IfNotPresent
             livenessProbe:
               grpc:
@@ -1164,7 +1164,7 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: registry.k8s.io/nfd/node-feature-discovery:v0.16.4
+            image: registry.k8s.io/nfd/node-feature-discovery:v0.16.4-minimal
             imagePullPolicy: IfNotPresent
             livenessProbe:
               grpc:
@@ -1251,7 +1251,7 @@ data:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: registry.k8s.io/nfd/node-feature-discovery:v0.16.4
+            image: registry.k8s.io/nfd/node-feature-discovery:v0.16.4-minimal
             imagePullPolicy: IfNotPresent
             name: gc
             ports:

--- a/hack/addons/kustomize/nfd/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/nfd/kustomization.yaml.tmpl
@@ -20,5 +20,8 @@ helmCharts:
   skipTests: true
   skipHooks: true
   namespace: node-feature-discovery
+  valuesInline:
+    image:
+      tag: v${NODE_FEATURE_DISCOVERY_VERSION}-minimal
 
 namespace: node-feature-discovery


### PR DESCRIPTION
**What problem does this PR solve?**:
This images was reverted (by accident?) in https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/commit/73b1648265a6bc9f26dccc76c19916c37a2fecf5#diff-b4f5af9dc43df286d19ee851401e0c36f5e5a1db0e902f8eec24718d93dfce72R1176

Setting the tag in the Helm values to use the minimal image.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
