### PR TITLE
build: pass the Chart version when listing images

### DIFF
--- a/hack/tools/fetch-images/main.go
+++ b/hack/tools/fetch-images/main.go
@@ -34,6 +34,7 @@ const (
 type ChartInfo struct {
 	repo             string
 	name             string
+	version          string
 	valuesFile       string
 	stringValues     []string
 	extraImagesFiles []string
@@ -155,8 +156,9 @@ func getImagesForAddons(helmChartConfigMap, carenChartDirectory string) ([]strin
 			return nil, fmt.Errorf("failed to unmarshal chart info from configmap %w", err)
 		}
 		info := &ChartInfo{
-			name: settings.ChartName,
-			repo: settings.Repository,
+			name:    settings.ChartName,
+			version: settings.Version,
+			repo:    settings.Repository,
 		}
 		valuesFile, err := getValuesFileForChartIfNeeded(settings.ChartName, carenChartDirectory)
 		if err != nil {
@@ -320,6 +322,7 @@ func getValuesFileForChartIfNeeded(chartName, carenChartDirectory string) (strin
 func getImagesForChart(info *ChartInfo) ([]string, error) {
 	images := pkg.Images{}
 	images.SetChart(info.name)
+	images.ChartVersionConstraint = info.version
 	images.RepoURL = info.repo
 	if info.valuesFile != "" {
 		_ = images.ValueFiles.Set(info.valuesFile)


### PR DESCRIPTION
**What problem does this PR solve?**:
Without this change the script always returned the latest Chart versions, not those defined in the repo

```
➜  CAREN_VERSION=v0.18.0 make list-images > fixed-images.txt
➜  diff fixed-images.txt caren-images.txt
3c3
< docker.io/rancher/local-path-provisioner:v0.0.27
---
> docker.io/rancher/local-path-provisioner:v0.0.30
8,14c8,14
< public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.35.0
< public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.7.0-eks-1-31-3
< public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v5.1.0-eks-1-31-3
< public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.12.0-eks-1-31-3
< public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v8.0.1-eks-1-31-3
< public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.14.0-eks-1-31-3
< public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.12.0-eks-1-31-3
---
> public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.36.0
> public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.7.0-eks-1-31-5
> public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v5.1.0-eks-1-31-5
> public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.12.0-eks-1-31-5
> public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v8.1.0-eks-1-31-5
> public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.14.0-eks-1-31-5
> public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.12.0-eks-1-31-5
25,28c25,28
< quay.io/cilium/cilium-envoy:v1.29.9-1726784081-a90146d13b4cd7d168d573396ccf2b3db5a3b047
< quay.io/cilium/cilium:v1.16.2
< quay.io/cilium/hubble-relay:v1.16.2
< quay.io/cilium/operator-generic:v1.16.2
---
> quay.io/cilium/cilium-envoy:v1.29.9-1728346947-0d05e48bfbb8c4737ec40d5781d970a550ed2bbd
> quay.io/cilium/cilium:v1.16.3
> quay.io/cilium/hubble-relay:v1.16.3
> quay.io/cilium/operator-generic:v1.16.3
34c34
< registry.k8s.io/nfd/node-feature-discovery:v0.16.4
---
> registry.k8s.io/nfd/node-feature-discovery:v0.16.5

``` 

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
