### PR TITLE
fix: bundle correct arch for the mindthegap binary

### DIFF
--- a/hack/addons/mindthegap-helm-registry/Dockerfile
+++ b/hack/addons/mindthegap-helm-registry/Dockerfile
@@ -3,10 +3,15 @@ FROM --platform=${BUILDPLATFORM} ghcr.io/mesosphere/mindthegap:${MINDTHEGAP_VERS
 # this gets called by goreleaser so the copy source has to be the path relative to the repo root.
 RUN --mount=source=./hack/addons/mindthegap-helm-registry/repos.yaml,target=/repos.yaml \
     ["/ko-app/mindthegap", "create", "bundle", "--helm-charts-file=/repos.yaml", "--output-file=/tmp/helm-charts.tar"]
+
+FROM --platform=${TARGETPLATFORM} ghcr.io/mesosphere/mindthegap:${MINDTHEGAP_VERSION} as mindthegap
+
 FROM --platform=${TARGETPLATFORM} alpine:3.20.3
+# Add mindthegap binary that matches TARGETPLATFORM
+COPY --from=mindthegap /ko-app/mindthegap /usr/bin/mindthegap
+# Add helm charts for the current version
 ARG VERSION
 COPY --from=bundle_builder /tmp/helm-charts.tar /charts/helm-charts-${VERSION}.tar
-COPY --from=bundle_builder /ko-app/mindthegap /usr/bin/mindthegap
 # TODO remove me as soon as its not needed to hold multiple versions of helm charts
 COPY --from=ghcr.io/nutanix-cloud-native/caren-helm-reg:v0.14.6 /tmp/helm-charts.tar /charts/helm-charts-v0.14.6.tar
 COPY --from=ghcr.io/nutanix-cloud-native/caren-helm-reg:v0.14.9 /tmp/helm-charts.tar /charts/helm-charts-v0.14.9.tar


### PR DESCRIPTION
**What problem does this PR solve?**:
Latest changes broke the published arm build. The `mindthegap` binary from `bundle_builder` will always be `BUILDPLATFORM`, but we want it to match `TARGETPLATFORM`.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
