### PR TITLE
fix: use correct securityContext for Alpine based helm-repository Pod

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -35,6 +35,9 @@ A Helm chart for cluster-api-runtime-extensions-nutanix
 | helmRepositoryImage.pullPolicy | string | `"IfNotPresent"` |  |
 | helmRepositoryImage.repository | string | `"ghcr.io/nutanix-cloud-native/caren-helm-reg"` |  |
 | helmRepositoryImage.tag | string | `""` |  |
+| helmRepositorySecurityContext.fsGroup | int | `100` |  |
+| helmRepositorySecurityContext.runAsGroup | int | `100` |  |
+| helmRepositorySecurityContext.runAsUser | int | `405` |  |
 | hooks.ccm.aws.helmAddonStrategy.defaultValueTemplateConfigMap.create | bool | `true` |  |
 | hooks.ccm.aws.helmAddonStrategy.defaultValueTemplateConfigMap.name | string | `"default-aws-ccm-helm-values-template"` |  |
 | hooks.ccm.aws.k8sMinorVersionToCCMVersion."1.27" | string | `"v1.27.9"` |  |

--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -35,9 +35,9 @@ A Helm chart for cluster-api-runtime-extensions-nutanix
 | helmRepositoryImage.pullPolicy | string | `"IfNotPresent"` |  |
 | helmRepositoryImage.repository | string | `"ghcr.io/nutanix-cloud-native/caren-helm-reg"` |  |
 | helmRepositoryImage.tag | string | `""` |  |
-| helmRepositorySecurityContext.fsGroup | int | `100` |  |
-| helmRepositorySecurityContext.runAsGroup | int | `100` |  |
-| helmRepositorySecurityContext.runAsUser | int | `405` |  |
+| helmRepositorySecurityContext.fsGroup | int | `65534` |  |
+| helmRepositorySecurityContext.runAsGroup | int | `65534` |  |
+| helmRepositorySecurityContext.runAsUser | int | `65534` |  |
 | hooks.ccm.aws.helmAddonStrategy.defaultValueTemplateConfigMap.create | bool | `true` |  |
 | hooks.ccm.aws.helmAddonStrategy.defaultValueTemplateConfigMap.name | string | `"default-aws-ccm-helm-values-template"` |  |
 | hooks.ccm.aws.k8sMinorVersionToCCMVersion."1.27" | string | `"v1.27.9"` |  |

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
@@ -101,7 +101,7 @@ spec:
           periodSeconds: 1
       priorityClassName: {{ .Values.priorityClassName }}
       securityContext:
-        {{ with .Values.securityContext }}
+        {{ with .Values.helmRepositorySecurityContext }}
         {{- toYaml . | nindent 8}}
         {{- end }}
       volumes:

--- a/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
@@ -52,6 +52,20 @@
             },
             "type": "object"
         },
+        "helmRepositorySecurityContext": {
+            "properties": {
+                "fsGroup": {
+                    "type": "integer"
+                },
+                "runAsGroup": {
+                    "type": "integer"
+                },
+                "runAsUser": {
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
         "hooks": {
             "properties": {
                 "ccm": {

--- a/charts/cluster-api-runtime-extensions-nutanix/values.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.yaml
@@ -156,8 +156,16 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+
 securityContext:
   runAsUser: 65532
+
+# The helm-repository containers are based on an Alpine image with a different nonroot user
+helmRepositorySecurityContext:
+  runAsUser: 405
+  runAsGroup: 100
+  fsGroup: 100
+
 service:
   annotations: {}
   type: ClusterIP

--- a/charts/cluster-api-runtime-extensions-nutanix/values.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.yaml
@@ -162,9 +162,9 @@ securityContext:
 
 # The helm-repository containers are based on an Alpine image with a different nonroot user
 helmRepositorySecurityContext:
-  runAsUser: 405
-  runAsGroup: 100
-  fsGroup: 100
+  runAsUser: 65534
+  runAsGroup: 65534
+  fsGroup: 65534
 
 service:
   annotations: {}


### PR DESCRIPTION
**What problem does this PR solve?**:
User `65532` is the default UID in distroless based images, but in Alpine it's a different user and group. 

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
