### PR TITLE
fix: Use correct filename for runtime extensions component YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ node_modules/
 .hugo_build.lock
 
 /cluster.yaml
-/runtime-extension-components.yaml
+/runtime-extensions-components.yaml
 /_artifacts/
 test/e2e/config/caren-envsubst.yaml
 /release-metadata.yaml

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,14 +29,14 @@ release:
     - glob: ./examples/capi-quick-start/*.yaml
     - glob: release-metadata.yaml
       name_template: metadata.yaml
-    - glob: runtime-extension-components.yaml
+    - glob: runtime-extensions-components.yaml
     - glob: ./charts/{{ .ProjectName }}/defaultclusterclasses/*.yaml
     - glob: caren-images.txt
 
 before:
   hooks:
     - |
-      sh -ec 'cat <<EOF > runtime-extension-components.yaml
+      sh -ec 'cat <<EOF > runtime-extensions-components.yaml
       apiVersion: v1
       kind: Namespace
       metadata:
@@ -48,7 +48,7 @@ before:
         --set-string image.repository=ko.local/{{ .ProjectName }}{{ end }} \
       )
       EOF'
-    - sed -i -e 's/\${/$${/g' -e 's/v0.0.0-dev/v{{ trimprefix .Version "v" }}/g' runtime-extension-components.yaml
+    - sed -i -e 's/\${/$${/g' -e 's/v0.0.0-dev/v{{ trimprefix .Version "v" }}/g' runtime-extensions-components.yaml
     - |
       sh -ec 'gojq --yaml-input --yaml-output \
         ".releaseSeries |= (. + [{contract: \"v1beta1\", major: {{ .Major }}, minor: {{ .Minor }}}] | unique)" \

--- a/docs/content/getting-started/deployment/via-clusterctl.md
+++ b/docs/content/getting-started/deployment/via-clusterctl.md
@@ -12,7 +12,7 @@ key from this block below:
 ```yaml
 providers:
   - name: "caren"
-    url: "https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/releases/v{{< param "version" >}}/runtime-extension-components.yaml"
+    url: "https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/releases/v{{< param "version" >}}/runtime-extensions-components.yaml"
     type: "RuntimeExtensionProvider"
 ```
 

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -137,7 +137,7 @@ providers:
   # Upgrade e2e tests will use this as the "upgrade from" version.
   # This should reference the most recent successful release.
   - name: "{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.20}"
-    value: "https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/releases/download/{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.20}/runtime-extension-components.yaml"
+    value: "https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/releases/download/{go://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix@v0.20}/runtime-extensions-components.yaml"
     type: "url"
     contract: v1beta1
     files:
@@ -148,7 +148,7 @@ providers:
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
   - name: v0.21.99 # "vNext"; use manifests from local source files
-    value: "file://../../../runtime-extension-components.yaml"
+    value: "file://../../../runtime-extensions-components.yaml"
     type: "url"
     contract: v1beta1
     files:


### PR DESCRIPTION
Noticed that the clusterctl components filename was incorrect - should be
`runtime-extensions-components.yaml` as documented at
https://cluster-api.sigs.k8s.io/clusterctl/provider-contract#components-yaml.

Will do a patch release after this change is made. This will allow adding the
provider to the upstream clusterctl provider list.
