### PR TITLE
build: set helmRepository tag in list-images target

### DIFF
--- a/hack/tools/fetch-images/main.go
+++ b/hack/tools/fetch-images/main.go
@@ -93,7 +93,7 @@ func main() {
 	if carenVersion != "" {
 		i.stringValues = []string{
 			fmt.Sprintf("image.tag=%s", carenVersion),
-			fmt.Sprintf("helmRepositoryImage.tag=%s", carenVersion),
+			fmt.Sprintf("helmRepository.images.bundleInitializer.tag=%s", carenVersion),
 		}
 	}
 	images, err := getImagesForChart(i)


### PR DESCRIPTION
**What problem does this PR solve?**:
Noticed in the [last release](https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/releases/download/v0.22.0/caren-images.txt) this image tag was set to `v0.0.0-dev`, fixing it to get the release version.

```
$ make list-images
...
ghcr.io/nutanix-cloud-native/caren-helm-reg:v0.22.1
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
