### PR TITLE
build: rename caren-helm-reg to better match role

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -246,7 +246,7 @@ jobs:
             kind load docker-image \
               --name "${KIND_CLUSTER_NAME}" \
               "ko.local/cluster-api-runtime-extensions-nutanix:${{ steps.export-image-tag.outputs.test-image-tag }}" \
-              "ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:${{ steps.export-image-tag.outputs.test-image-tag }}"
+              "ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:${{ steps.export-image-tag.outputs.test-image-tag }}"
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Setup Cluster API and cert-manager

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -246,7 +246,7 @@ jobs:
             kind load docker-image \
               --name "${KIND_CLUSTER_NAME}" \
               "ko.local/cluster-api-runtime-extensions-nutanix:${{ steps.export-image-tag.outputs.test-image-tag }}" \
-              "ghcr.io/nutanix-cloud-native/caren-helm-reg:${{ steps.export-image-tag.outputs.test-image-tag }}"
+              "ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:${{ steps.export-image-tag.outputs.test-image-tag }}"
 
       - if: steps.list-changed.outputs.changed == 'true'
         name: Setup Cluster API and cert-manager

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,7 +101,7 @@ archives:
 
 dockers:
   - image_templates:
-      - 'ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}-amd64'
+      - 'ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:v{{ trimprefix .Version "v" }}-amd64'
     use: buildx
     dockerfile: ./hack/addons/helm-chart-bundler/Dockerfile
     extra_files:
@@ -111,13 +111,13 @@ dockers:
       - "--pull"
       - '--build-arg=VERSION=v{{ trimprefix .Version "v" }}'
       - "--label=org.opencontainers.image.created={{.CommitDate}}"
-      - "--label=org.opencontainers.image.title=caren-helm-reg"
+      - "--label=org.opencontainers.image.title=cluster-api-runtime-extensions-bundle-initializer"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - '--label=org.opencontainers.image.version=v{{ trimprefix .Version "v" }}'
       - "--label=org.opencontainers.image.source={{.GitURL}}"
     goarch: amd64
   - image_templates:
-      - 'ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}-arm64'
+      - 'ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:v{{ trimprefix .Version "v" }}-arm64'
     use: buildx
     dockerfile: ./hack/addons/helm-chart-bundler/Dockerfile
     extra_files:
@@ -127,17 +127,17 @@ dockers:
       - "--pull"
       - '--build-arg=VERSION=v{{ trimprefix .Version "v" }}'
       - "--label=org.opencontainers.image.created={{.CommitDate}}"
-      - "--label=org.opencontainers.image.title=caren-helm-reg"
+      - "--label=org.opencontainers.image.title=cluster-api-runtime-extensions-bundle-initializer"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - '--label=org.opencontainers.image.version=v{{ trimprefix .Version "v" }}'
       - "--label=org.opencontainers.image.source={{.GitURL}}"
     goarch: arm64
 
 docker_manifests:
-  - name_template: ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}
+  - name_template: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:v{{ trimprefix .Version "v" }}
     image_templates:
-      - ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}-amd64
-      - ghcr.io/nutanix-cloud-native/caren-helm-reg:v{{ trimprefix .Version "v" }}-arm64
+      - ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:v{{ trimprefix .Version "v" }}-amd64
+      - ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:v{{ trimprefix .Version "v" }}-arm64
 
 kos:
   - id: cluster-api-runtime-extensions-nutanix

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,7 +101,7 @@ archives:
 
 dockers:
   - image_templates:
-      - 'ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:v{{ trimprefix .Version "v" }}-amd64'
+      - 'ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:v{{ trimprefix .Version "v" }}-amd64'
     use: buildx
     dockerfile: ./hack/addons/helm-chart-bundler/Dockerfile
     extra_files:
@@ -111,13 +111,13 @@ dockers:
       - "--pull"
       - '--build-arg=VERSION=v{{ trimprefix .Version "v" }}'
       - "--label=org.opencontainers.image.created={{.CommitDate}}"
-      - "--label=org.opencontainers.image.title=cluster-api-runtime-extensions-bundle-initializer"
+      - "--label=org.opencontainers.image.title=cluster-api-runtime-extensions-helm-chart-bundle-initializer"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - '--label=org.opencontainers.image.version=v{{ trimprefix .Version "v" }}'
       - "--label=org.opencontainers.image.source={{.GitURL}}"
     goarch: amd64
   - image_templates:
-      - 'ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:v{{ trimprefix .Version "v" }}-arm64'
+      - 'ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:v{{ trimprefix .Version "v" }}-arm64'
     use: buildx
     dockerfile: ./hack/addons/helm-chart-bundler/Dockerfile
     extra_files:
@@ -127,17 +127,17 @@ dockers:
       - "--pull"
       - '--build-arg=VERSION=v{{ trimprefix .Version "v" }}'
       - "--label=org.opencontainers.image.created={{.CommitDate}}"
-      - "--label=org.opencontainers.image.title=cluster-api-runtime-extensions-bundle-initializer"
+      - "--label=org.opencontainers.image.title=cluster-api-runtime-extensions-helm-chart-bundle-initializer"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - '--label=org.opencontainers.image.version=v{{ trimprefix .Version "v" }}'
       - "--label=org.opencontainers.image.source={{.GitURL}}"
     goarch: arm64
 
 docker_manifests:
-  - name_template: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:v{{ trimprefix .Version "v" }}
+  - name_template: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:v{{ trimprefix .Version "v" }}
     image_templates:
-      - ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:v{{ trimprefix .Version "v" }}-amd64
-      - ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:v{{ trimprefix .Version "v" }}-arm64
+      - ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:v{{ trimprefix .Version "v" }}-amd64
+      - ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:v{{ trimprefix .Version "v" }}-arm64
 
 kos:
   - id: cluster-api-runtime-extensions-nutanix

--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -34,7 +34,7 @@ A Helm chart for cluster-api-runtime-extensions-nutanix
 | helmAddonsConfigMap | string | `"default-helm-addons-config"` |  |
 | helmRepository.enabled | bool | `true` |  |
 | helmRepository.images.bundleInitializer.pullPolicy | string | `"IfNotPresent"` |  |
-| helmRepository.images.bundleInitializer.repository | string | `"ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer"` |  |
+| helmRepository.images.bundleInitializer.repository | string | `"ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer"` |  |
 | helmRepository.images.bundleInitializer.tag | string | `""` |  |
 | helmRepository.images.mindthegap.pullPolicy | string | `"IfNotPresent"` |  |
 | helmRepository.images.mindthegap.repository | string | `"ghcr.io/mesosphere/mindthegap"` |  |

--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -34,7 +34,7 @@ A Helm chart for cluster-api-runtime-extensions-nutanix
 | helmAddonsConfigMap | string | `"default-helm-addons-config"` |  |
 | helmRepository.enabled | bool | `true` |  |
 | helmRepository.images.bundleInitializer.pullPolicy | string | `"IfNotPresent"` |  |
-| helmRepository.images.bundleInitializer.repository | string | `"ghcr.io/nutanix-cloud-native/caren-helm-reg"` |  |
+| helmRepository.images.bundleInitializer.repository | string | `"ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer"` |  |
 | helmRepository.images.bundleInitializer.tag | string | `""` |  |
 | helmRepository.images.mindthegap.pullPolicy | string | `"IfNotPresent"` |  |
 | helmRepository.images.mindthegap.repository | string | `"ghcr.io/mesosphere/mindthegap"` |  |

--- a/charts/cluster-api-runtime-extensions-nutanix/values.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.yaml
@@ -134,7 +134,7 @@ helmRepository:
   enabled: true
   images:
     bundleInitializer:
-      repository: ghcr.io/nutanix-cloud-native/caren-helm-reg
+      repository: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer
       tag: ""
       pullPolicy: IfNotPresent
     mindthegap:

--- a/charts/cluster-api-runtime-extensions-nutanix/values.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.yaml
@@ -134,7 +134,7 @@ helmRepository:
   enabled: true
   images:
     bundleInitializer:
-      repository: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer
+      repository: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer
       tag: ""
       pullPolicy: IfNotPresent
     mindthegap:

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -11,7 +11,7 @@ dev.run-on-kind: SNAPSHOT_VERSION = $(shell gojq -r '.version+"-"+.runtime.goarc
 dev.run-on-kind:
 	kind load docker-image --name $(KIND_CLUSTER_NAME) \
 		ko.local/cluster-api-runtime-extensions-nutanix:$(SNAPSHOT_VERSION) \
-		ghcr.io/nutanix-cloud-native/caren-helm-reg:$(SNAPSHOT_VERSION)
+		ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:$(SNAPSHOT_VERSION)
 	helm upgrade --install cluster-api-runtime-extensions-nutanix ./charts/cluster-api-runtime-extensions-nutanix \
 		--set-string image.repository=ko.local/cluster-api-runtime-extensions-nutanix \
 		--set-string image.tag=$(SNAPSHOT_VERSION) \

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -11,7 +11,7 @@ dev.run-on-kind: SNAPSHOT_VERSION = $(shell gojq -r '.version+"-"+.runtime.goarc
 dev.run-on-kind:
 	kind load docker-image --name $(KIND_CLUSTER_NAME) \
 		ko.local/cluster-api-runtime-extensions-nutanix:$(SNAPSHOT_VERSION) \
-		ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:$(SNAPSHOT_VERSION)
+		ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:$(SNAPSHOT_VERSION)
 	helm upgrade --install cluster-api-runtime-extensions-nutanix ./charts/cluster-api-runtime-extensions-nutanix \
 		--set-string image.repository=ko.local/cluster-api-runtime-extensions-nutanix \
 		--set-string image.tag=$(SNAPSHOT_VERSION) \

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -6,7 +6,7 @@ managementClusterName: caren-e2e
 images:
   - name: ko.local/cluster-api-runtime-extensions-nutanix:${E2E_IMAGE_TAG}
     loadBehavior: mustLoad
-  - name: ghcr.io/nutanix-cloud-native/caren-helm-reg:${E2E_IMAGE_TAG}
+  - name: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:${E2E_IMAGE_TAG}
     loadBehavior: mustLoad
 
 providers:

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -6,7 +6,7 @@ managementClusterName: caren-e2e
 images:
   - name: ko.local/cluster-api-runtime-extensions-nutanix:${E2E_IMAGE_TAG}
     loadBehavior: mustLoad
-  - name: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-bundle-initializer:${E2E_IMAGE_TAG}
+  - name: ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer:${E2E_IMAGE_TAG}
     loadBehavior: mustLoad
 
 providers:


### PR DESCRIPTION
**What problem does this PR solve?**:
While looking at https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/968 I noticed the image name.
The `caren-helm-reg` image is no longer used as a registry. The word registry was also recently changed to repository in the templates.

Renamed it to `cluster-api-runtime-extensions-bundle-initializer`, but open to suggestions!

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
