### PR TITLE
fix: Update mindthegap to fix cert rotation

### DIFF
--- a/hack/addons/helm-chart-bundler/Dockerfile
+++ b/hack/addons/helm-chart-bundler/Dockerfile
@@ -1,4 +1,4 @@
-ARG MINDTHEGAP_VERSION=v1.16.0
+ARG MINDTHEGAP_VERSION=v1.17.0
 
 FROM --platform=${BUILDPLATFORM} ghcr.io/mesosphere/mindthegap:${MINDTHEGAP_VERSION} as bundle_builder
 # This gets called by goreleaser so the copy source has to be the path relative to the repo root.


### PR DESCRIPTION
**What problem does this PR solve?**:
Previously, mindthegap required a restart rollout after its certificate was rotated. It will now use updated certificates without restarting.

Also see https://github.com/mesosphere/mindthegap/releases/tag/v1.17.0 

**Which issue(s) this PR fixes**:
Fixes https://jira.nutanix.com/browse/NCN-104087

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
