### PR TITLE
fix: set container name to manager to ensure we wait for it

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
@@ -69,7 +69,7 @@ spec:
         - name: charts-volume
           mountPath: "/helm-charts"
       containers:
-      - name: helm-repository
+      - name: manager
         ports:
           - name: serve
             protocol: TCP


### PR DESCRIPTION
**What problem does this PR solve?**:
changes name of container to manager to ensure a clusterctl waits for this core service caren depends on to be ready.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
