### PR TITLE
build: Add CAREN release to cluster class artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ test/e2e/config/caren-envsubst.yaml
 /release-metadata.yaml
 hack/tools/fetch-images/fetch-images
 caren-images.txt
+hack/examples/release/*-cluster-class.yaml

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ release:
     - glob: release-metadata.yaml
       name_template: metadata.yaml
     - glob: runtime-extensions-components.yaml
-    - glob: ./charts/{{ .ProjectName }}/defaultclusterclasses/*.yaml
+    - glob: ./hack/examples/release/*-cluster-class.yaml
     - glob: caren-images.txt
 
 before:
@@ -57,6 +57,10 @@ before:
     - |
       sh -ec 'if [ {{ .IsSnapshot }} == false ] ; then
         make --no-print-directory CAREN_VERSION=v{{ trimprefix .Version "v" }} list-images >caren-images.txt
+      fi'
+    - |
+      sh -ec 'if [ {{ .IsSnapshot }} == false ] ; then
+        make --no-print-directory CAREN_VERSION=v{{ trimprefix .Version "v" }} add-version-to-clusterclasses
       fi'
 
 builds:

--- a/hack/examples/release/add-version-to-clusterclasses.sh
+++ b/hack/examples/release/add-version-to-clusterclasses.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Nutanix. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
+trap 'find "${SCRIPT_DIR}" -name kustomization.yaml -delete' EXIT
+
+export CAREN_RELEASE_VERSION="${1}"
+
+for CC_TEMPLATE in "${SCRIPT_DIR}"/../../../charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/*.yaml; do
+  export CC_TEMPLATE
+  envsubst -no-empty -no-unset -i "${SCRIPT_DIR}/kustomization.yaml.tmpl" -o "${SCRIPT_DIR}/kustomization.yaml"
+
+  kustomize build "${SCRIPT_DIR}" --load-restrictor LoadRestrictionsNone >"${SCRIPT_DIR}/$(basename "${CC_TEMPLATE}")"
+done

--- a/hack/examples/release/kustomization.yaml.tmpl
+++ b/hack/examples/release/kustomization.yaml.tmpl
@@ -1,0 +1,14 @@
+# Copyright 2023 Nutanix. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+sortOptions:
+  order: fifo
+
+commonAnnotations:
+  caren.nutanix.com/version: "${CAREN_RELEASE_VERSION}"
+
+resources:
+  - "${CC_TEMPLATE}"

--- a/make/goreleaser.mk
+++ b/make/goreleaser.mk
@@ -42,3 +42,7 @@ release-snapshot: go-generate ; $(info $(M) building snapshot release $*)
 .PHONY: list-releases
 list-releases: ## List releases from GitHub
 	gh release list --json tagName | gojq -r .[].tagName
+
+.PHONY: add-version-to-clusterclasses
+add-version-to-clusterclasses:
+	./hack/examples/release/add-version-to-clusterclasses.sh $(CAREN_VERSION)


### PR DESCRIPTION
This attaches the updated cluster class artifacts containing the
CAREN release version to the release artifacts on release.
