### PR TITLE
fix: check HelmReleaseReadyCondition when status is up-to-date

### DIFF
--- a/pkg/handlers/generic/lifecycle/addons/helmaddon.go
+++ b/pkg/handlers/generic/lifecycle/addons/helmaddon.go
@@ -228,6 +228,9 @@ func waitToBeReady(
 			Reader: client,
 			Target: hcp.DeepCopy(),
 			Check: func(_ context.Context, obj *caaphv1.HelmChartProxy) (bool, error) {
+				if obj.ObjectMeta.Generation != obj.Status.ObservedGeneration {
+					return false, nil
+				}
 				return conditions.IsTrue(obj, caaphv1.HelmReleaseProxiesReadyCondition), nil
 			},
 			Interval: 5 * time.Second,


### PR DESCRIPTION
**What problem does this PR solve?**:
Only checking for HelmReleaseReadyCondition may not be enough, especially during cluster upgrades where the values in the HCP have changed.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
