### PR TITLE
build: Properly ignore ntnx API client from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,6 @@ updates:
       update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     # Ignore ntnx-api-golang-clients modules major, minor, and patch as they are upgraded together with prism-go-client.
     - dependency-name: "github.com/nutanix/ntnx-api-golang-clients/*"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
 
   - package-ecosystem: "gomod"
     directory: "/hack/third-party/capa"


### PR DESCRIPTION
The existing configuration still allowed pre-release updates and there is no way to configure this. Removing the update-types means this will always be ignored and only updated when the NCN ntnx client is updated.

**What problem does this PR solve?**:

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
