### PR TITLE
fix: update CoreDNS mapping file

### DIFF
--- a/api/versions/coredns.go
+++ b/api/versions/coredns.go
@@ -24,6 +24,7 @@ const (
 	Kubernetes_V1_29 = "v1.29"
 	Kubernetes_V1_30 = "v1.30"
 	Kubernetes_V1_31 = "v1.31"
+	Kubernetes_V1_32 = "v1.32"
 )
 
 // CoreDNS versions
@@ -49,6 +50,7 @@ var kubernetesToCoreDNSVersion = map[string]string{
 	Kubernetes_V1_29: CoreDNS_V1_11_1,
 	Kubernetes_V1_30: CoreDNS_V1_11_3,
 	Kubernetes_V1_31: CoreDNS_V1_11_3,
+	Kubernetes_V1_32: CoreDNS_V1_11_3,
 }
 
 // GetCoreDNSVersion returns the CoreDNS version for a given Kubernetes version.

--- a/api/versions/coredns_test.go
+++ b/api/versions/coredns_test.go
@@ -46,6 +46,7 @@ func TestReturnsCorrectMappingForGetKubernetesToCoreDNSVersionMap(t *testing.T) 
 		"v1.29": "v1.11.1",
 		"v1.30": "v1.11.3",
 		"v1.31": "v1.11.3",
+		"v1.32": "v1.11.3",
 	}
 	assert.Equal(t, expected, mapping)
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
Adds CoreDNS version mapping for Kubernetes v1.32

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
