### PR TITLE
fix: correctly copy Helm charts in init container

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
@@ -63,7 +63,7 @@ spec:
       initContainers:
       - name: copy-charts
         image: "{{ .Values.helmRepository.images.bundleInitializer.repository }}:{{ default $.Chart.AppVersion .Values.helmRepository.images.bundleInitializer.tag }}"
-        command: ["/bin/cp", "-r", "/charts/",  "/helm-charts/bundles/"]
+        command: ["/bin/cp", "-r", "/charts/.",  "/helm-charts/bundles/"]
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         volumeMounts:
         - name: charts-volume

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-repository.yaml
@@ -63,7 +63,18 @@ spec:
       initContainers:
       - name: copy-charts
         image: "{{ .Values.helmRepository.images.bundleInitializer.repository }}:{{ default $.Chart.AppVersion .Values.helmRepository.images.bundleInitializer.tag }}"
-        command: ["/bin/cp", "-r", "/charts/.",  "/helm-charts/bundles/"]
+        # Copy the charts bundled in the image to the mounted PVC.
+        # The combination of flags `--recursive --no-target-directory` ensure that the bundled directory contents only are copied to the destination,
+        # rather than copying the source directory itself to the destination, which would lead to incorrect nesting.
+        # See https://unix.stackexchange.com/a/94838 for further explanation.
+        # Globs cannot be used here because we are not running in a shell and `cp` does not natively support globbing.
+        command:
+          - /bin/cp
+          - --recursive
+          - --no-target-directory
+          - --verbose
+          - /charts/
+          - /helm-charts/bundles/
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         volumeMounts:
         - name: charts-volume


### PR DESCRIPTION
During upgrades the init container was incorrectly copying the whole directory, instead of just the tars.
```
# bundles directory in the container
$ ls /helm-charts/bundles/
charts                   helm-charts-v0.14.6.tar  helm-charts-v0.14.9.tar  helm-charts-v0.23.1.tar
# incorrectly nested directory with the new charts
$ ls /helm-charts/bundles/charts/
helm-charts-v0.14.6.tar  helm-charts-v0.14.9.tar  helm-charts-v0.25.0.tar
```


**What problem does this PR solve?**:

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
The file gets copied correctly when the directory does not exist:
```
$ cp -r charts/ dst/
$ ls dst
foo.tar
```

When the dir already exists (ie upgrade scenario), the whole directory gets copied:
```
$ mkdir dst
$ cp -r charts/ dst/
$ ls dst
charts
```

Copying the file works correctly into an existing dst if using .:
```
$ mkdir dst
$ cp -r charts/. dst/
$ ls dst
foo.tar
```

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
