### PR TITLE
fix: use republished COSI controller image

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
@@ -25,7 +25,7 @@ data:
     RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://kubernetes.github.io/autoscaler{{ end }}'
   cosi-controller: |
     ChartName: cosi
-    ChartVersion: 0.0.1-alpha.2
+    ChartVersion: 0.0.1-alpha.4
     RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://mesosphere.github.io/charts/stable/{{ end }}'
   local-path-provisioner-csi: |
     ChartName: local-path-provisioner

--- a/hack/addons/helm-chart-bundler/repos.yaml
+++ b/hack/addons/helm-chart-bundler/repos.yaml
@@ -30,7 +30,7 @@ repositories:
     repoURL: https://mesosphere.github.io/charts/stable/
     charts:
       cosi:
-      - 0.0.1-alpha.2
+      - 0.0.1-alpha.4
   local-path-provisioner:
     repoURL: https://charts.containeroo.ch
     charts:

--- a/make/addons.mk
+++ b/make/addons.mk
@@ -25,7 +25,7 @@ export KUBE_VIP_VERSION := v0.8.3
 
 export METALLB_CHART_VERSION := 0.14.8
 
-export COSI_CONTROLLER_VERSION := 0.0.1-alpha.2
+export COSI_CONTROLLER_VERSION := 0.0.1-alpha.4
 
 .PHONY: addons.sync
 addons.sync: $(addprefix update-addon.,calico cilium nfd cluster-autoscaler snapshot-controller local-path-provisioner-csi aws-ebs-csi kube-vip)


### PR DESCRIPTION
**What problem does this PR solve?**:
The `gcr.io/k8s-staging-sig-storage` repository is being shut down. Temporarily moving the image until upstream moves it to a more permanent location.

This pulls in the changes:
- https://github.com/mesosphere/charts/pull/1542
- https://github.com/mesosphere/charts/pull/1543

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
The e2e tests will verify the controller is running.
I've also verified the image by following the examples in https://github.com/nutanix-cloud-native/cosi-driver-nutanix 

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
