### PR TITLE
fix: Use mindthegap v1.17.0 for the helm-repository container

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -38,7 +38,7 @@ A Helm chart for cluster-api-runtime-extensions-nutanix
 | helmRepository.images.bundleInitializer.tag | string | `""` |  |
 | helmRepository.images.mindthegap.pullPolicy | string | `"IfNotPresent"` |  |
 | helmRepository.images.mindthegap.repository | string | `"ghcr.io/mesosphere/mindthegap"` |  |
-| helmRepository.images.mindthegap.tag | string | `"v1.16.0"` |  |
+| helmRepository.images.mindthegap.tag | string | `"v1.17.0"` |  |
 | helmRepository.securityContext.fsGroup | int | `65532` |  |
 | helmRepository.securityContext.runAsGroup | int | `65532` |  |
 | helmRepository.securityContext.runAsUser | int | `65532` |  |

--- a/charts/cluster-api-runtime-extensions-nutanix/values.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.yaml
@@ -145,7 +145,7 @@ helmRepository:
       pullPolicy: IfNotPresent
     mindthegap:
       repository: ghcr.io/mesosphere/mindthegap
-      tag: "v1.16.0"
+      tag: "v1.17.0"
       pullPolicy: IfNotPresent
   securityContext:
     runAsUser: 65532


### PR DESCRIPTION
**What problem does this PR solve?**:
The helm-repository container is defaulting to the wrong mindthegap version, one that is missing an [important fix](https://github.com/mesosphere/mindthegap/pull/805).

**Which issue(s) this PR fixes**:
Fixes https://jira.nutanix.com/browse/NCN-104087

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
