### PR TITLE
feat: implementation for user defined configmap for cilium addon in cluster creation

### DIFF
--- a/api/v1alpha1/addon_types.go
+++ b/api/v1alpha1/addon_types.go
@@ -140,8 +140,8 @@ type AddonValues struct {
 // typed referenced object inside the same namespace.
 // This is redacted from the upstream https://pkg.go.dev/k8s.io/api/core/v1#TypedLocalObjectReference
 type ValuesReference struct {
-	// Kind is the type of resource being referenced, valid values are ('Secret', 'ConfigMap').
-	// +kubebuilder:validation:Enum=Secret;ConfigMap
+	// Kind is the type of resource being referenced, valid values are ('ConfigMap').
+	// +kubebuilder:validation:Enum=ConfigMap
 	// +kubebuilder:validation:Required
 	Kind string `json:"kind"`
 

--- a/api/v1alpha1/crds/caren.nutanix.com_awsclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_awsclusterconfigs.yaml
@@ -110,9 +110,8 @@ spec:
                                 which contains inline YAML representing the values for the Helm chart.
                               properties:
                                 kind:
-                                  description: Kind is the type of resource being referenced, valid values are ('Secret', 'ConfigMap').
+                                  description: Kind is the type of resource being referenced, valid values are ('ConfigMap').
                                   enum:
-                                    - Secret
                                     - ConfigMap
                                   type: string
                                 name:

--- a/api/v1alpha1/crds/caren.nutanix.com_dockerclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_dockerclusterconfigs.yaml
@@ -110,9 +110,8 @@ spec:
                                 which contains inline YAML representing the values for the Helm chart.
                               properties:
                                 kind:
-                                  description: Kind is the type of resource being referenced, valid values are ('Secret', 'ConfigMap').
+                                  description: Kind is the type of resource being referenced, valid values are ('ConfigMap').
                                   enum:
-                                    - Secret
                                     - ConfigMap
                                   type: string
                                 name:

--- a/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
@@ -110,9 +110,8 @@ spec:
                                 which contains inline YAML representing the values for the Helm chart.
                               properties:
                                 kind:
-                                  description: Kind is the type of resource being referenced, valid values are ('Secret', 'ConfigMap').
+                                  description: Kind is the type of resource being referenced, valid values are ('ConfigMap').
                                   enum:
-                                    - Secret
                                     - ConfigMap
                                   type: string
                                 name:

--- a/docs/content/addons/cni.md
+++ b/docs/content/addons/cni.md
@@ -56,11 +56,11 @@ spec:
               strategy: HelmAddon
               values:
                 sourceRef:
-                  name: <NAME> #name of ConfigMap/Secret present in same namespace
-                  kind: <ConfigMap/Secret>
+                  name: <NAME> #name of ConfigMap present in same namespace
+                  kind: <ConfigMap>
 ```
 
-NOTE: Only ConfigMap/Secret kind objects will be allowed to refer helm values from.
+NOTE: Only ConfigMap kind objects will be allowed to refer helm values from.
 
 ConfigMap Format -
 
@@ -81,27 +81,7 @@ metadata:
   namespace: <CLUSTER_NAMESPACE>
 ```
 
-Secret Format -
-
-```yaml
-apiVersion: v1
-stringData:
-  values.yaml: |-
-    cni:
-      chainingMode: portmap
-      exclusive: false
-    ipam:
-      mode: kubernetes
-kind: Secret
-metadata:
-  labels:
-    clusterctl.cluster.x-k8s.io/move: ""
-  name: <CLUSTER_NAME>-cilium-cni-helm-values-template
-  namespace: <CLUSTER_NAMESPACE>
-type: Opaque
-```
-
-NOTE: ConfigMap/Secret should contain complete helm values for Cilium as same will be applied
+NOTE: ConfigMap should contain complete helm values for Cilium as same will be applied
 to Cilium helm chart as it is.
 
 To deploy the addon via `ClusterResourceSet` replace the value of `strategy` with `ClusterResourceSet`.

--- a/pkg/handlers/generic/lifecycle/cni/variables_test.go
+++ b/pkg/handlers/generic/lifecycle/cni/variables_test.go
@@ -41,6 +41,26 @@ var testDefs = []capitest.VariableTestDef{{
 		},
 	},
 }, {
+	Name: "set with valid provider using HelmAddon strategy and custom helm values",
+	Vals: apivariables.ClusterConfigSpec{
+		Addons: &apivariables.Addons{
+			GenericAddons: v1alpha1.GenericAddons{
+				CNI: &v1alpha1.CNI{
+					Provider: v1alpha1.CNIProviderCilium,
+					Strategy: ptr.To(v1alpha1.AddonStrategyHelmAddon),
+					AddonConfig: v1alpha1.AddonConfig{
+						Values: &v1alpha1.AddonValues{
+							SourceRef: &v1alpha1.ValuesReference{
+								Name: "custom-cilium-cni-helm-values",
+								Kind: "ConfigMap",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}, {
 	Name: "set with invalid provider",
 	Vals: apivariables.ClusterConfigSpec{
 		Addons: &apivariables.Addons{


### PR DESCRIPTION
**What problem does this PR solve?**:

implementation for user defined cilium configmap in cluster creation, current PR's implementation covers only configmap kind and assumes that `clusterctl.cluster.x-k8s.io/move` label is added on configmap by user. 

pending PRs:
1. Implementation for Secret kind object for user defined cilium spec.

**Which issue(s) this PR fixes**:
Fixes #
[NCN-105148](https://jira.nutanix.com/browse/NCN-105148)

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

```
$ kg cluster
NAME               CLUSTERCLASS          PHASE         AGE   VERSION
nkp-mgmt-cluster   nutanix-quick-start   Provisioned   15m   v1.31.4

$ kg cm custom-cilium-cni-helm-values-template -oyaml
apiVersion: v1
data:
  values.yaml: |-
    cni:
      chainingMode: portmap
      exclusive: false
    hubble:
      enabled: true
      tls:
        auto:
          enabled: true               # enable automatic TLS certificate generation
          method: cronJob             # auto generate certificates using cronJob method
          certValidityDuration: 60    # certificates validity duration in days (default 2 months)
          schedule: "0 0 5 * *"       
      relay:
        enabled: true
        image:
          useDigest: false
    ipam:
      mode: kubernetes
    image:
      useDigest: false
    operator:
      image:
        useDigest: false
    certgen:
      image:
        useDigest: false
    socketLB:
      hostNamespaceOnly: true
    envoy:
      image:
        useDigest: false
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"values.yaml":"cni:\n  chainingMode: portmap\n  exclusive: false\nhubble:\n  enabled: true\n  tls:\n    auto:\n      enabled: true               # enable automatic TLS certificate generation\n      method: cronJob             # auto generate certificates using cronJob method\n      certValidityDuration: 60    # certificates validity duration in days (default 2 months)\n      schedule: \"0 0 5 * *\"       # schedule on the 1st day regeneration of each month\n  relay:\n    enabled: true\n    image:\n      useDigest: false\nipam:\n  mode: kubernetes\nimage:\n  useDigest: false\noperator:\n  image:\n    useDigest: false\ncertgen:\n  image:\n    useDigest: false\nsocketLB:\n  hostNamespaceOnly: true\nenvoy:\n  image:\n    useDigest: false"},"kind":"ConfigMap","metadata":{"annotations":{},"labels":{"cluster.x-k8s.io/cluster-name":"nkp-mgmt-cluster","clusterctl.cluster.x-k8s.io/move":""},"name":"custom-cilium-cni-helm-values-template","namespace":"default"}}
  creationTimestamp: "2025-02-04T14:55:33Z"
  labels:
    cluster.x-k8s.io/cluster-name: nkp-mgmt-cluster
    clusterctl.cluster.x-k8s.io/move: ""
  name: custom-cilium-cni-helm-values-template
  namespace: default
  resourceVersion: "23373"
  uid: 943620cd-a1a0-4d99-8383-d68e4329d029

$ kg hcp cilium-0194d059-494c-7879-a6bd-fe281ba362d9 -oyaml
apiVersion: addons.cluster.x-k8s.io/v1alpha1
kind: HelmChartProxy
metadata:
  creationTimestamp: "2025-02-04T14:56:33Z"
  finalizers:
  - helmchartproxy.addons.cluster.x-k8s.io
  generation: 1
  name: cilium-0194d059-494c-7879-a6bd-fe281ba362d9
  namespace: default
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta1
    kind: Cluster
    name: nkp-mgmt-cluster
    uid: 83c0cc69-7100-41f5-a415-ccff87c8d03e
  resourceVersion: "26337"
  uid: f70e9e27-45a8-4832-9497-a94306b7ec30
spec:
  chartName: cilium
  clusterSelector:
    matchLabels:
      cluster.x-k8s.io/cluster-name: nkp-mgmt-cluster
  namespace: kube-system
  options:
    enableClientCache: false
    install:
      createNamespace: true
    timeout: 10m0s
    upgrade:
      maxHistory: 10
  releaseName: cilium
  repoURL: oci://helm-repository.default.svc/charts
  tlsConfig:
    caSecret:
      name: helm-repository-tls
      namespace: default
  valuesTemplate: |-
    cni:
      chainingMode: portmap
      exclusive: false
    hubble:
      enabled: true
      tls:
        auto:
          enabled: true               # enable automatic TLS certificate generation
          method: cronJob             # auto generate certificates using cronJob method
          certValidityDuration: 60    # certificates validity duration in days (default 2 months)
          schedule: "0 0 5 * *"       # schedule on the 1st day regeneration of each month
      relay:
        enabled: true
        image:
          useDigest: false
    ipam:
      mode: kubernetes
    image:
      useDigest: false
    operator:
      image:
        useDigest: false
    certgen:
      image:
        useDigest: false
    socketLB:
      hostNamespaceOnly: true
    envoy:
      image:
        useDigest: false
  version: 1.16.4
status:
  conditions:
  - lastTransitionTime: "2025-02-04T15:04:13Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-02-04T15:04:13Z"
    status: "True"
    type: HelmReleaseProxiesReady
  - lastTransitionTime: "2025-02-04T15:02:45Z"
    status: "True"
    type: HelmReleaseProxySpecsUpToDate
  matchingClusters:
  - apiVersion: cluster.x-k8s.io/v1beta1
    kind: Cluster
    name: nkp-mgmt-cluster
    namespace: default
  observedGeneration: 1
```

