### PR TITLE
fix: don't generate empty _default containerd mirror file

### DIFF
--- a/pkg/handlers/generic/mutation/mirrors/containerd_files.go
+++ b/pkg/handlers/generic/mutation/mirrors/containerd_files.go
@@ -112,6 +112,11 @@ func generateContainerdDefaultHostsFile(
 		inputs = append(inputs, input)
 	}
 
+	// No need to generate the file if there are no mirrors.
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+
 	var b bytes.Buffer
 	err := containerdDefaultHostsConfigurationTemplate.Execute(&b, inputs)
 	if err != nil {

--- a/pkg/handlers/generic/mutation/mirrors/containerd_files_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/containerd_files_test.go
@@ -134,15 +134,8 @@ func Test_generateContainerdDefaultHostsFile(t *testing.T) {
 					CACert: "myregistrycert",
 				},
 			},
-			want: &cabpkv1.File{
-				Path:        "/etc/containerd/certs.d/_default/hosts.toml",
-				Owner:       "",
-				Permissions: "0600",
-				Encoding:    "",
-				Append:      false,
-				Content: `
-`,
-			},
+			want: nil,
+
 			wantErr: nil,
 		},
 	}

--- a/pkg/handlers/generic/mutation/mirrors/inject_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/inject_test.go
@@ -163,9 +163,6 @@ var _ = Describe("Generate Global mirror patches", func() {
 					Path:      "/spec/template/spec/kubeadmConfigSpec/files",
 					ValueMatcher: gomega.HaveExactElements(
 						gomega.HaveKeyWithValue(
-							"path", "/etc/containerd/certs.d/_default/hosts.toml",
-						),
-						gomega.HaveKeyWithValue(
 							"path", "/etc/containerd/certs.d/registry.example.com/ca.crt",
 						),
 						gomega.HaveKeyWithValue(
@@ -323,9 +320,6 @@ var _ = Describe("Generate Global mirror patches", func() {
 					Operation: "add",
 					Path:      "/spec/template/spec/files",
 					ValueMatcher: gomega.HaveExactElements(
-						gomega.HaveKeyWithValue(
-							"path", "/etc/containerd/certs.d/_default/hosts.toml",
-						),
 						gomega.HaveKeyWithValue(
 							"path", "/etc/containerd/certs.d/registry.example.com:5050/ca.crt",
 						),


### PR DESCRIPTION
**What problem does this PR solve?**:
Now that we're fixing how the `_default` file is being generated just for mirrors, we should skip creating the file if only registries are provided.

Depends on #1039.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
