### PR TITLE
fix: Remove empty containerd _default/hosts.toml

### DIFF
--- a/pkg/handlers/generic/mutation/mirrors/containerd_files.go
+++ b/pkg/handlers/generic/mutation/mirrors/containerd_files.go
@@ -112,6 +112,10 @@ func generateContainerdDefaultHostsFile(
 		inputs = append(inputs, input)
 	}
 
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+
 	var b bytes.Buffer
 	err := containerdDefaultHostsConfigurationTemplate.Execute(&b, inputs)
 	if err != nil {

--- a/pkg/handlers/generic/mutation/mirrors/containerd_files_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/containerd_files_test.go
@@ -134,15 +134,7 @@ func Test_generateContainerdDefaultHostsFile(t *testing.T) {
 					CACert: "myregistrycert",
 				},
 			},
-			want: &cabpkv1.File{
-				Path:        "/etc/containerd/certs.d/_default/hosts.toml",
-				Owner:       "",
-				Permissions: "0600",
-				Encoding:    "",
-				Append:      false,
-				Content: `
-`,
-			},
+			want:    nil,
 			wantErr: nil,
 		},
 	}

--- a/pkg/handlers/generic/mutation/mirrors/inject_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/inject_test.go
@@ -163,9 +163,6 @@ var _ = Describe("Generate Global mirror patches", func() {
 					Path:      "/spec/template/spec/kubeadmConfigSpec/files",
 					ValueMatcher: gomega.HaveExactElements(
 						gomega.HaveKeyWithValue(
-							"path", "/etc/containerd/certs.d/_default/hosts.toml",
-						),
-						gomega.HaveKeyWithValue(
 							"path", "/etc/containerd/certs.d/registry.example.com/ca.crt",
 						),
 						gomega.HaveKeyWithValue(
@@ -323,9 +320,6 @@ var _ = Describe("Generate Global mirror patches", func() {
 					Operation: "add",
 					Path:      "/spec/template/spec/files",
 					ValueMatcher: gomega.HaveExactElements(
-						gomega.HaveKeyWithValue(
-							"path", "/etc/containerd/certs.d/_default/hosts.toml",
-						),
 						gomega.HaveKeyWithValue(
 							"path", "/etc/containerd/certs.d/registry.example.com:5050/ca.crt",
 						),


### PR DESCRIPTION
If there is no mirror configuration then this file is unnecessary so do not
create it.

Depends on #1039.