### PR TITLE
fix: Configure priorityClassName for Cilium Hubble

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
@@ -13,6 +13,7 @@ hubble:
     enabled: true
     image:
       useDigest: false
+    priorityClassName: system-cluster-critical
 ipam:
   mode: kubernetes
 image:


### PR DESCRIPTION
**What problem does this PR solve?**:
Assigns the `system-cluster-critical` PriorityClassName to Hubble. This is the same class name assigned to Cilium itself.

**Which issue(s) this PR fixes**:
Fixes https://jira.nutanix.com/browse/NCN-105637

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
