### PR TITLE
feat: bumped frr-routing to 9.1.3

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/serviceloadbalancer/metallb/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/serviceloadbalancer/metallb/values-template.yaml
@@ -10,6 +10,9 @@ controller:
       operator: Exists
       tolerationSeconds: 300
 speaker:
+  frr:
+    image:
+      tag: 9.1.3
   priorityClassName: system-cluster-critical
   tolerations:
     - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
What problem does this PR solve?:

Adds an override for frr routing

Which issue(s) this PR fixes:
Fixes # pkg:docker/frrouting/frr@9.1.0?repository_url=quay.io

How Has This Been Tested?:

Special notes for your reviewer:
arvinder.pal@GHH4XN27GC kubetunnel % trivy i quay.io/frrouting/frr:9.1.3 --severity=HIGH,MEDIUM
2025-02-26T10:50:16+05:30	INFO	[db] Need to update DB
2025-02-26T10:50:16+05:30	INFO	[db] Downloading DB...	repository="ghcr.io/aquasecurity/trivy-db:2"
59.46 MiB / 59.46 MiB [-----------------------------------------------------------------------] 100.00% 3.06 MiB p/s 20s
2025-02-26T10:50:38+05:30	INFO	[vuln] Vulnerability scanning is enabled
2025-02-26T10:50:38+05:30	INFO	[secret] Secret scanning is enabled
2025-02-26T10:50:38+05:30	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-02-26T10:50:38+05:30	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.55/docs/scanner/secret#recommendation for faster secret detection
2025-02-26T10:50:42+05:30	INFO	Detected OS	family="alpine" version="3.18.9"
2025-02-26T10:50:42+05:30	INFO	[alpine] Detecting vulnerabilities...	os_version="3.18" repository="3.18" pkg_num=71
2025-02-26T10:50:42+05:30	INFO	Number of language-specific files	num=0
2025-02-26T10:50:42+05:30	WARN	Using severities from other vendors for some vulnerabilities. Read https://aquasecurity.github.io/trivy/v0.55/docs/scanner/vulnerability#severity-selection for details.

quay.io/frrouting/frr:9.1.3 (alpine 3.18.9)

Total: 2 (MEDIUM: 2, HIGH: 0)