### PR TITLE
fix: Tolerate all NoSchedule taints for NFD and CSI deployments

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/csi/aws-ebs/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/csi/aws-ebs/values-template.yaml
@@ -13,7 +13,6 @@ controller:
       operator: Exists
       tolerationSeconds: 300
     - effect: NoSchedule
-      key: node-role.kubernetes.io/control-plane
       operator: Exists
 node:
   priorityClassName: system-node-critical

--- a/charts/cluster-api-runtime-extensions-nutanix/addons/csi/local-path/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/csi/local-path/values-template.yaml
@@ -10,5 +10,4 @@ tolerations:
     operator: Exists
     tolerationSeconds: 300
   - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
     operator: Exists

--- a/charts/cluster-api-runtime-extensions-nutanix/addons/csi/nutanix/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/csi/nutanix/values-template.yaml
@@ -11,5 +11,4 @@ tolerations:
     operator: Exists
     tolerationSeconds: 300
   - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
     operator: Exists

--- a/charts/cluster-api-runtime-extensions-nutanix/addons/nfd/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/nfd/values-template.yaml
@@ -29,7 +29,7 @@ worker: ### <NFD-WORKER-CONF-START-DO-NOT-REMOVE>
           - "vendor"
   tolerations:
     - effect: NoSchedule
-      key: node-role.kubernetes.io/control-plane
+      operator: Exists
 
 gc:
   tolerations:

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/aws-ebs/manifests/aws-ebs-csi-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/aws-ebs/manifests/aws-ebs-csi-configmap.yaml
@@ -777,7 +777,6 @@ data:
             operator: Exists
             tolerationSeconds: 300
           - effect: NoSchedule
-            key: node-role.kubernetes.io/control-plane
             operator: Exists
           volumes:
           - emptyDir: {}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/csi/local-path/manifests/local-path-provisioner-csi-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/csi/local-path/manifests/local-path-provisioner-csi-configmap.yaml
@@ -249,7 +249,6 @@ data:
             operator: Exists
             tolerationSeconds: 300
           - effect: NoSchedule
-            key: node-role.kubernetes.io/control-plane
             operator: Exists
           volumes:
           - configMap:

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/node-feature-discovery-configmap.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/nfd/manifests/node-feature-discovery-configmap.yaml
@@ -1091,7 +1091,7 @@ data:
           serviceAccountName: node-feature-discovery-worker
           tolerations:
           - effect: NoSchedule
-            key: node-role.kubernetes.io/control-plane
+            operator: Exists
           volumes:
           - hostPath:
               path: /boot


### PR DESCRIPTION
This allows tainting nodepools and still using e.g. GPUs or CSI.
