### PR TITLE
build: Update k8s.io/{kubelet,utils} deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,12 @@ updates:
     # Ignore controller-runtime major and minor as it's upgraded together with sigs.k8s.io/cluster-api.
     - dependency-name: "sigs.k8s.io/controller-runtime"
       update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Ignore k8s modules major and minor as they are upgraded together with controller-runtime.
-    - dependency-name: "k8s.io/*"
+    # Ignore specific k8s modules major and minor as they are upgraded together with controller-runtime.
+    # This prevents Dependabot from creating a PR for every minor update of these modules which would be
+    # incompatible with the current version of controller-runtime and therefore just closed.
+    - dependency-name: "k8s.io/api*"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    - dependency-name: "k8s.io/client-go"
       update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     # Ignore ntnx-api-golang-clients modules major, minor, and patch as they are upgraded together with prism-go-client.
     - dependency-name: "github.com/nutanix/ntnx-api-golang-clients/*"


### PR DESCRIPTION
These are skipped by dependabot which ignores `k8s.io/*` in order for
dependencies in order to retain compatibility with `sigs.k8s.io/controller-runtime`,
but as `controller-runtime` does not have dependencies on `k8s.io/kubelet` then it
gets skipped on update. This commit brings it up to date.
