### PR TITLE
revert: "build: Update k8s.io/{kubelet,utils} deps"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,12 +23,8 @@ updates:
     # Ignore controller-runtime major and minor as it's upgraded together with sigs.k8s.io/cluster-api.
     - dependency-name: "sigs.k8s.io/controller-runtime"
       update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Ignore specific k8s modules major and minor as they are upgraded together with controller-runtime.
-    # This prevents Dependabot from creating a PR for every minor update of these modules which would be
-    # incompatible with the current version of controller-runtime and therefore just closed.
-    - dependency-name: "k8s.io/api*"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    - dependency-name: "k8s.io/client-go"
+    # Ignore k8s modules major and minor as they are upgraded together with controller-runtime.
+    - dependency-name: "k8s.io/*"
       update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
     # Ignore ntnx-api-golang-clients modules major, minor, and patch as they are upgraded together with prism-go-client.
     - dependency-name: "github.com/nutanix/ntnx-api-golang-clients/*"


### PR DESCRIPTION
Reverts nutanix-cloud-native/cluster-api-runtime-extensions-nutanix#1078

This actually led to broken PRs - let's manually update the other dependencies when we need to instead.