### PR TITLE
feat: enable Cilium's hubble relay mTLS

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
@@ -11,6 +11,10 @@ hubble:
       schedule: "0 0 1 * *"       # schedule on the 1st day regeneration of each month
   relay:
     enabled: true
+    tls:
+      server:
+        enabled: true
+        mtls: true
     image:
       useDigest: false
     priorityClassName: system-cluster-critical


### PR DESCRIPTION
**What problem does this PR solve?**:
Enables mTLS. The hubble relay server was already always enabled, this PR also enables its mTLS configuration.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
