### PR TITLE
feat: go 1.24.2 to fix CVE

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/ap
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 replace github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common => ../common
 

--- a/common/go.mod
+++ b/common/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/co
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.11

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix
 
 go 1.23.0
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 replace (
 	github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api => ./api


### PR DESCRIPTION
Fixes https://pkg.go.dev/vuln/GO-2025-3563.
