### PR TITLE
build: use correct frr image for metallb

### DIFF
--- a/hack/tools/fetch-images/main.go
+++ b/hack/tools/fetch-images/main.go
@@ -316,6 +316,8 @@ func getValuesFileForChartIfNeeded(chartName, carenChartDirectory string) (strin
 		return tempFile.Name(), nil
 	case "cosi-controller":
 		return filepath.Join(carenChartDirectory, "addons", "cosi", "controller", defaultHelmAddonFilename), nil
+	case "metallb":
+		return filepath.Join(carenChartDirectory, "addons", "serviceloadbalancer", "metallb", defaultHelmAddonFilename), nil
 	default:
 		return "", nil
 	}


### PR DESCRIPTION
**What problem does this PR solve?**:
Use the helm values for Metallb images, with this fix:
```
$ make list-images
...
quay.io/frrouting/frr:9.1.3
quay.io/metallb/controller:v0.14.9
quay.io/metallb/speaker:v0.14.9
...
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
