### PR TITLE
fix: use a new version for control-plane and worker mutation handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ See [upstream documentation](https://cluster-api.sigs.k8s.io/tasks/experimental-
 
 ## Development
 
+### Implementing Topology Mutation Handler
+
+See examples of existing [topology mutation handlers] in the `pkg/handlers/../mutation/` directory.
+When adding a new handler, or modifying an existing one, pay close attention to what happens to existing clusters
+when a new version of this extension is deployed in the management cluster,
+and avoid rollouts of Machines in those existing clusters.
+
+During CAPI provider upgrades, and periodically, all managed clusters are reconciled and mutation handler patches
+are applied.
+Any new handlers that return a new set of patches, or updated handlers that return a different set of patches,
+will be applied causing a rollout of Machines in all managed clusters.
+
+For example, when adding a new handler, a handler that is enabled by default and returns CAPI resources patches,
+will cause a rollout of Machines.
+Similarly, if a handler is modified to return a different set of patches, it will also cause a rollout of Machines.
+
+### Run Locally
+
 Install tools
 
 - [Devbox](https://github.com/jetpack-io/devbox?tab=readme-ov-file#installing-devbox)
@@ -153,3 +171,5 @@ To delete the dev KinD cluster, run:
 ```shell
 make kind.delete
 ```
+
+[topology mutation handlers]: https://cluster-api.sigs.k8s.io/tasks/experimental-features/runtime-sdk/implement-topology-mutation-hook#implementing-topology-mutation-hook-runtime-extensions

--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/aws-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/aws-cluster-class.yaml
@@ -27,7 +27,7 @@ spec:
     name: cluster-config
   - external:
       discoverVariablesExtension: awsworkerconfigvars-dv.cluster-api-runtime-extensions-nutanix
-      generateExtension: awsworkerconfigpatch-gp.cluster-api-runtime-extensions-nutanix
+      generateExtension: awsworkerv3configpatch-gp.cluster-api-runtime-extensions-nutanix
     name: worker-config
   - definitions:
     - jsonPatches:

--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/docker-cluster-class.yaml
@@ -35,7 +35,7 @@ spec:
     name: cluster-config
   - external:
       discoverVariablesExtension: dockerworkerconfigvars-dv.cluster-api-runtime-extensions-nutanix
-      generateExtension: dockerworkerconfigpatch-gp.cluster-api-runtime-extensions-nutanix
+      generateExtension: dockerworkerv3configpatch-gp.cluster-api-runtime-extensions-nutanix
     name: worker-config
   workers:
     machineDeployments:

--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
@@ -71,7 +71,7 @@ spec:
     name: cluster-config
   - external:
       discoverVariablesExtension: nutanixworkerconfigvars-dv.cluster-api-runtime-extensions-nutanix
-      generateExtension: nutanixworkerconfigpatch-gp.cluster-api-runtime-extensions-nutanix
+      generateExtension: nutanixworkerv3configpatch-gp.cluster-api-runtime-extensions-nutanix
     name: worker-config
   workers:
     machineDeployments:

--- a/docs/content/getting-started/integrating-with-your-clusterclass/_index.md
+++ b/docs/content/getting-started/integrating-with-your-clusterclass/_index.md
@@ -21,11 +21,11 @@ The required values are shown below per provider.
   patches:
   - external:
       discoverVariablesExtension: awsclusterconfigvars.cluster-api-runtime-extensions-nutanix
-      generateExtension: awsclusterconfigpatch.cluster-api-runtime-extensions-nutanix
+      generateExtension: awsclusterv3configpatch.cluster-api-runtime-extensions-nutanix
     name: cluster-config
   - external:
       discoverVariablesExtension: awsworkerconfigvars.cluster-api-runtime-extensions-nutanix
-      generateExtension: awsworkerconfigpatch.cluster-api-runtime-extensions-nutanix
+      generateExtension: awsworkerv3configpatch.cluster-api-runtime-extensions-nutanix
     name: worker-config
 ```
 
@@ -35,11 +35,11 @@ The required values are shown below per provider.
   patches:
   - external:
       discoverVariablesExtension: nutanixclusterconfigvars.cluster-api-runtime-extensions-nutanix
-      generateExtension: nutanixclusterconfigpatch.cluster-api-runtime-extensions-nutanix
+      generateExtension: nutanixclusterv3configpatch.cluster-api-runtime-extensions-nutanix
     name: cluster-config
   - external:
       discoverVariablesExtension: nutanixworkerconfigvars.cluster-api-runtime-extensions-nutanix
-      generateExtension: nutanixworkerconfigpatch.cluster-api-runtime-extensions-nutanix
+      generateExtension: nutanixworkerv3configpatch.cluster-api-runtime-extensions-nutanix
     name: worker-config
 ```
 
@@ -49,11 +49,11 @@ The required values are shown below per provider.
   patches:
   - external:
       discoverVariablesExtension: dockerclusterconfigvars.cluster-api-runtime-extensions-nutanix
-      generateExtension: dockerclusterconfigpatch.cluster-api-runtime-extensions-nutanix
+      generateExtension: dockerclusterv3configpatch.cluster-api-runtime-extensions-nutanix
     name: cluster-config
   - external:
       discoverVariablesExtension: dockerworkerconfigvars.cluster-api-runtime-extensions-nutanix
-      generateExtension: dockerworkerconfigpatch.cluster-api-runtime-extensions-nutanix
+      generateExtension: dockerworkerv3configpatch.cluster-api-runtime-extensions-nutanix
     name: worker-config
 ```
 
@@ -63,7 +63,7 @@ The required values are shown below per provider.
   patches:
   - external:
       discoverVariablesExtension: genericclusterconfigvars.cluster-api-runtime-extensions-nutanix
-      generateExtension: genericclusterconfigpatch.cluster-api-runtime-extensions-nutanix
+      generateExtension: genericclusterv3configpatch.cluster-api-runtime-extensions-nutanix
     name: cluster-config
 ```
 

--- a/hack/examples/overlays/clusterclasses/aws/kustomization.yaml.tmpl
+++ b/hack/examples/overlays/clusterclasses/aws/kustomization.yaml.tmpl
@@ -23,7 +23,7 @@ patches:
               discoverVariablesExtension: "awsclusterconfigvars-dv.cluster-api-runtime-extensions-nutanix"
           - name: "worker-config"
             external:
-              generateExtension: "awsworkerconfigpatch-gp.cluster-api-runtime-extensions-nutanix"
+              generateExtension: "awsworkerv3configpatch-gp.cluster-api-runtime-extensions-nutanix"
               discoverVariablesExtension: "awsworkerconfigvars-dv.cluster-api-runtime-extensions-nutanix"
           - name: identityRef
             definitions:

--- a/hack/examples/overlays/clusterclasses/docker/kustomization.yaml.tmpl
+++ b/hack/examples/overlays/clusterclasses/docker/kustomization.yaml.tmpl
@@ -23,5 +23,5 @@ patches:
               discoverVariablesExtension: "dockerclusterconfigvars-dv.cluster-api-runtime-extensions-nutanix"
           - name: "worker-config"
             external:
-              generateExtension: "dockerworkerconfigpatch-gp.cluster-api-runtime-extensions-nutanix"
+              generateExtension: "dockerworkerv3configpatch-gp.cluster-api-runtime-extensions-nutanix"
               discoverVariablesExtension: "dockerworkerconfigvars-dv.cluster-api-runtime-extensions-nutanix"

--- a/hack/examples/overlays/clusterclasses/nutanix/kustomization.yaml.tmpl
+++ b/hack/examples/overlays/clusterclasses/nutanix/kustomization.yaml.tmpl
@@ -23,5 +23,5 @@ patches:
               discoverVariablesExtension: "nutanixclusterconfigvars-dv.cluster-api-runtime-extensions-nutanix"
           - name: "worker-config"
             external:
-              generateExtension: "nutanixworkerconfigpatch-gp.cluster-api-runtime-extensions-nutanix"
+              generateExtension: "nutanixworkerv3configpatch-gp.cluster-api-runtime-extensions-nutanix"
               discoverVariablesExtension: "nutanixworkerconfigvars-dv.cluster-api-runtime-extensions-nutanix"

--- a/pkg/handlers/aws/handlers.go
+++ b/pkg/handlers/aws/handlers.go
@@ -30,6 +30,7 @@ func (h *Handlers) AllHandlers(mgr manager.Manager) []handlers.Named {
 		awsmutation.MetaPatchHandler(mgr),
 		v2awsmutation.MetaPatchHandler(mgr),
 		awsmutation.MetaWorkerPatchHandler(mgr),
+		v2awsmutation.MetaWorkerPatchHandler(mgr),
 	}
 }
 

--- a/pkg/handlers/aws/mutation/metapatch_handler.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler.go
@@ -52,7 +52,7 @@ func MetaWorkerPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers = append(patchHandlers, genericmutation.WorkerMetaMutators()...)
 
 	return mutation.NewMetaGeneratePatchesHandler(
-		"awsWorkerConfigPatch",
+		"awsWorkerv3ConfigPatch",
 		mgr.GetClient(),
 		patchHandlers...,
 	)

--- a/pkg/handlers/docker/handlers.go
+++ b/pkg/handlers/docker/handlers.go
@@ -30,6 +30,7 @@ func (h *Handlers) AllHandlers(mgr manager.Manager) []handlers.Named {
 		dockermutation.MetaPatchHandler(mgr),
 		v2dockermutation.MetaPatchHandler(mgr),
 		dockermutation.MetaWorkerPatchHandler(mgr),
+		v2dockermutation.MetaWorkerPatchHandler(mgr),
 	}
 }
 

--- a/pkg/handlers/docker/mutation/metapatch_handler.go
+++ b/pkg/handlers/docker/mutation/metapatch_handler.go
@@ -35,7 +35,7 @@ func MetaWorkerPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers = append(patchHandlers, genericmutation.WorkerMetaMutators()...)
 
 	return mutation.NewMetaGeneratePatchesHandler(
-		"dockerWorkerConfigPatch",
+		"dockerWorkerV3ConfigPatch",
 		mgr.GetClient(),
 		patchHandlers...,
 	)

--- a/pkg/handlers/generic/handlers.go
+++ b/pkg/handlers/generic/handlers.go
@@ -24,5 +24,6 @@ func (h *Handlers) AllHandlers(mgr manager.Manager) []handlers.Named {
 		genericmutation.MetaPatchHandler(mgr),
 		v2genericmutation.MetaPatchHandler(mgr),
 		genericmutation.MetaWorkerPatchHandler(mgr),
+		v2genericmutation.MetaWorkerPatchHandler(mgr),
 	}
 }

--- a/pkg/handlers/generic/mutation/metapatch_handler.go
+++ b/pkg/handlers/generic/mutation/metapatch_handler.go
@@ -15,7 +15,7 @@ func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers := MetaMutators(mgr)
 	patchHandlers = append(patchHandlers, ControlPlaneMetaMutators()...)
 	return mutation.NewMetaGeneratePatchesHandler(
-		"genericClusterV2ConfigPatch",
+		"genericClusterV3ConfigPatch",
 		mgr.GetClient(),
 		patchHandlers...,
 	)
@@ -26,7 +26,7 @@ func MetaWorkerPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers := WorkerMetaMutators()
 
 	return mutation.NewMetaGeneratePatchesHandler(
-		"genericWorkerConfigPatch",
+		"genericWorkerV3ConfigPatch",
 		mgr.GetClient(),
 		patchHandlers...,
 	)

--- a/pkg/handlers/nutanix/handlers.go
+++ b/pkg/handlers/nutanix/handlers.go
@@ -36,6 +36,7 @@ func (h *Handlers) AllHandlers(mgr manager.Manager) []handlers.Named {
 		nutanixmutation.MetaPatchHandler(mgr),
 		v2nutanixmutation.MetaPatchHandler(mgr, h.controlPlaneVirtualIPConfig),
 		nutanixmutation.MetaWorkerPatchHandler(mgr),
+		v2nutanixmutation.MetaWorkerPatchHandler(mgr),
 	}
 }
 

--- a/pkg/handlers/nutanix/mutation/metapatch_handler.go
+++ b/pkg/handlers/nutanix/mutation/metapatch_handler.go
@@ -41,7 +41,7 @@ func MetaWorkerPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers = append(patchHandlers, genericmutation.WorkerMetaMutators()...)
 
 	return mutation.NewMetaGeneratePatchesHandler(
-		"nutanixWorkerConfigPatch",
+		"nutanixWorkerV3ConfigPatch",
 		mgr.GetClient(),
 		patchHandlers...,
 	)

--- a/pkg/handlers/v2/docker/mutation/metapatch_handler.go
+++ b/pkg/handlers/v2/docker/mutation/metapatch_handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/docker/mutation/customimage"
-	genericmutation "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation"
+	genericmutationv2 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/v2/generic/mutation"
 )
 
 // MetaPatchHandler returns a meta patch handler for mutating CAPD clusters.
@@ -17,11 +17,26 @@ func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers := []mutation.MetaMutator{
 		customimage.NewControlPlanePatch(),
 	}
-	patchHandlers = append(patchHandlers, genericmutation.MetaMutators(mgr)...)
-	patchHandlers = append(patchHandlers, genericmutation.ControlPlaneMetaMutators()...)
+	patchHandlers = append(patchHandlers, genericmutationv2.MetaMutators(mgr)...)
+	patchHandlers = append(patchHandlers, genericmutationv2.ControlPlaneMetaMutators()...)
 
 	return mutation.NewMetaGeneratePatchesHandler(
 		"dockerClusterV2ConfigPatch",
+		mgr.GetClient(),
+		patchHandlers...,
+	)
+}
+
+// MetaWorkerPatchHandler returns a meta patch handler for mutating CAPD workers.
+func MetaWorkerPatchHandler(mgr manager.Manager) handlers.Named {
+	patchHandlers := []mutation.MetaMutator{
+		customimage.NewWorkerPatch(),
+	}
+	patchHandlers = append(patchHandlers, genericmutationv2.WorkerMetaMutators()...)
+
+	// The previous handler did not have "v2" in the name.
+	return mutation.NewMetaGeneratePatchesHandler(
+		"dockerWorkerConfigPatch",
 		mgr.GetClient(),
 		patchHandlers...,
 	)

--- a/pkg/handlers/v2/generic/mutation/handlers.go
+++ b/pkg/handlers/v2/generic/mutation/handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/imageregistries/credentials"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/kubernetesimagerepository"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/mirrors"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/taints"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/users"
 )
 
@@ -52,5 +53,23 @@ func MetaMutators(mgr manager.Manager) []mutation.MetaMutator {
 		// We want to keep patch independent of each other and not share any state.
 		// Therefore, We must always apply this patch regardless any other patch modified containerd configuration.
 		containerdapplypatchesandrestart.NewPatch(),
+	}
+}
+
+func ControlPlaneMetaMutators() []mutation.MetaMutator {
+	return []mutation.MetaMutator{
+		taints.NewControlPlanePatch(),
+		// Intentionally not include this patch as it was not available in previous version the hook,
+		// and it uses an API is on by default, which causes a rollout of all Machines in all managed clusters.
+		// noderegistration.NewControlPlanePatch(),
+	}
+}
+
+func WorkerMetaMutators() []mutation.MetaMutator {
+	return []mutation.MetaMutator{
+		taints.NewWorkerPatch(),
+		// Intentionally not include this patch as it was not available in previous version the hook,
+		// and it uses an API is on by default, which causes a rollout of all Machines in all managed clusters.
+		// noderegistration.NewControlPlanePatch(),
 	}
 }

--- a/pkg/handlers/v2/generic/mutation/metapatch_handler.go
+++ b/pkg/handlers/v2/generic/mutation/metapatch_handler.go
@@ -8,15 +8,25 @@ import (
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
-	genericmutation "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation"
 )
 
 // MetaPatchHandler returns a meta patch handler for mutating generic Kubernetes clusters.
 func MetaPatchHandler(mgr manager.Manager) handlers.Named {
 	patchHandlers := MetaMutators(mgr)
-	patchHandlers = append(patchHandlers, genericmutation.ControlPlaneMetaMutators()...)
+	patchHandlers = append(patchHandlers, ControlPlaneMetaMutators()...)
 	return mutation.NewMetaGeneratePatchesHandler(
 		"genericClusterConfigPatch",
+		mgr.GetClient(),
+		patchHandlers...,
+	)
+}
+
+// MetaWorkerPatchHandler returns a meta patch handler for mutating generic workers.
+func MetaWorkerPatchHandler(mgr manager.Manager) handlers.Named {
+	patchHandlers := WorkerMetaMutators()
+
+	return mutation.NewMetaGeneratePatchesHandler(
+		"genericWorkerConfigPatch",
 		mgr.GetClient(),
 		patchHandlers...,
 	)


### PR DESCRIPTION
**What problem does this PR solve?**:
When adding https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/1097, we effectively enabled this handler by default through API defaults. I wrongly assumed that the worker and control-plane handlers were behind a new version of the handlers registration. And because its not, this caused a rollout of all Machines when CAREN is upgraded on the management cluster.

This PR puts the worker and control-plane handlers behind a new version of the hooks and does not include the new `noderegistration` handler in the older version of the hooks.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
Tested locally by upgrading the handler version and observing that Machines were NOT rolled out. We will need some strategy to test this in an e2e test, or possibly think of a different approach for this, e.g. running multiple versions of the controller instead of embedding it in a single handler.

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
