### PR TITLE
ci: include correct kube-vip version when listing images

### DIFF
--- a/make/addons.mk
+++ b/make/addons.mk
@@ -91,4 +91,4 @@ list-images:
 	  -chart-directory=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/ \
 	  -helm-chart-configmap=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml \
 	  -caren-version=$(CAREN_VERSION) \
-	  -additional-yaml-files=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/templates/virtual-ip/kube-vip/manifests/kube-vip-configmap.yaml
+	  -additional-yaml-files=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
Noticed after the release we're still using the kube-vip image `v0.8.9` from the old handler.
With this change:
```
➜  cluster-api-runtime-extensions-nutanix git:(dkoshkin/ci-include-correct-kube-vip-version) ✗ make list-images | grep kube-vip
ghcr.io/kube-vip/kube-vip:v0.8.10
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
