### PR TITLE
feat: use registryMirror addon as Containerd mirror

### DIFF
--- a/pkg/handlers/generic/mutation/mirrors/inject.go
+++ b/pkg/handlers/generic/mutation/mirrors/inject.go
@@ -143,11 +143,7 @@ func (h *globalMirrorPatchHandler) Mutate(
 			return err
 		}
 
-		registryConfig, err := containerdConfigFromRegistryMirrorAddon(
-			ctx,
-			h.client,
-			cluster,
-		)
+		registryConfig, err := containerdConfigFromRegistryMirrorAddon(cluster)
 		if err != nil {
 			return err
 		}
@@ -266,11 +262,7 @@ func containerdConfigFromImageRegistry(
 	return configWithOptionalCACert, nil
 }
 
-func containerdConfigFromRegistryMirrorAddon(
-	_ context.Context,
-	_ ctrlclient.Client,
-	cluster *clusterv1.Cluster,
-) (containerdConfig, error) {
+func containerdConfigFromRegistryMirrorAddon(cluster *clusterv1.Cluster) (containerdConfig, error) {
 	serviceIP, err := registrymirrorutils.ServiceIPForCluster(cluster)
 	if err != nil {
 		return containerdConfig{}, fmt.Errorf("error getting service IP for the registry mirror addon: %w", err)

--- a/pkg/handlers/generic/mutation/mirrors/inject_test.go
+++ b/pkg/handlers/generic/mutation/mirrors/inject_test.go
@@ -339,12 +339,12 @@ var _ = Describe("Generate Global mirror patches", func() {
 			},
 		},
 		{
-			Name: "files added in KubeadmControlPlaneTemplate for registry mirror addon",
+			Name: "files added in KubeadmControlPlaneTemplate for registry addon",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
 					v1alpha1.ClusterConfigVariableName,
-					v1alpha1.RegistryMirror{},
-					[]string{"addons", v1alpha1.RegistryMirrorVariableName}...,
+					v1alpha1.RegistryAddon{},
+					[]string{"addons", v1alpha1.RegistryAddonVariableName}...,
 				),
 			},
 			RequestItem: request.NewKubeadmControlPlaneTemplateRequestItem(""),
@@ -364,12 +364,12 @@ var _ = Describe("Generate Global mirror patches", func() {
 			},
 		},
 		{
-			Name: "files added in KubeadmConfigTemplate for registry mirror addon",
+			Name: "files added in KubeadmConfigTemplate for registry addon",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
 					v1alpha1.ClusterConfigVariableName,
-					v1alpha1.RegistryMirror{},
-					[]string{"addons", v1alpha1.RegistryMirrorVariableName}...,
+					v1alpha1.RegistryAddon{},
+					[]string{"addons", v1alpha1.RegistryAddonVariableName}...,
 				),
 				capitest.VariableWithValue(
 					"builtin",
@@ -417,6 +417,13 @@ var _ = Describe("Generate Global mirror patches", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      request.ClusterName,
 					Namespace: request.Namespace,
+				},
+				Spec: clusterv1.ClusterSpec{
+					ClusterNetwork: &clusterv1.ClusterNetwork{
+						Services: &clusterv1.NetworkRanges{
+							CIDRBlocks: []string{"192.168.0.1/16"},
+						},
+					},
 				},
 			},
 		)).To(gomega.BeNil())


### PR DESCRIPTION
**What problem does this PR solve?**:
Depends on https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/1116

Automatically sets the registryMirror as a Containerd mirror. We're not updating the Cluster object because this should not be a user controller configuration and the IP used as the mirror is determined based on the addon handler and the Service CIDRs.

Tested in a Docker cluster:
```
$ kubectl port-forward \
  --address=0.0.0.0 \
  --namespace registry-mirror-system \
  pod/registry-mirror-docker-registry-0 5000:5000
# Push an image tag that doesn't exist in dockerhub  
$ crane copy nginx:latest 0.0.0.0:5000/library/nginx:dkoshkin --insecure
$ kubectl run nginx-working --image=docker.io/library/nginx:dkoshkin
$ kubectl run nginx-should-be-broken --image=docker.io/library/nginx:dne
$ kubectl get pods 
NAME                                                              READY   STATUS              RESTARTS   AGE
cluster-autoscaler-0196931c-cb53-7abf-aa89-49c82c42ced5-86w5j8c   0/1     ContainerCreating   0          19m
nginx-should-be-broken                                            0/1     ErrImagePull        0          11m
nginx-working                                                     1/1     Running             0          11m
```

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
