### PR TITLE
test(e2e): Disable Calico tests

### DIFF
--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Quick start", func() {
 
 		Context(provider, Label("provider:"+provider), providerSpecificDecorators, func() {
 			lowercaseProvider := strings.ToLower(provider)
-			for _, cniProvider := range []string{"Cilium", "Calico"} {
+			for _, cniProvider := range []string{"Cilium"} { // TODO: Reenable Calico tests later once we fix flakiness.
 				Context(cniProvider, Label("cni:"+cniProvider), func() {
 					for _, addonStrategy := range []string{"HelmAddon", "ClusterResourceSet"} {
 						Context(addonStrategy, Label("addonStrategy:"+addonStrategy), func() {

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Self-hosted", Serial, func() {
 		}
 		Context(provider, Label("provider:"+provider), providerSpecificDecorators, func() {
 			lowercaseProvider := strings.ToLower(provider)
-			for _, cniProvider := range []string{"Cilium", "Calico"} {
+			for _, cniProvider := range []string{"Cilium"} { // TODO: Reenable Calico tests later once we fix flakiness.
 				Context(cniProvider, Label("cni:"+cniProvider), func() {
 					for _, addonStrategy := range []string{"HelmAddon", "ClusterResourceSet"} {
 						Context(addonStrategy, Label("addonStrategy:"+addonStrategy), func() {


### PR DESCRIPTION
These are currently unused and causing numerous flakes. Disabling until
we get time to properly investigate and fix.
