### PR TITLE
ci: Remove Docker k8s v1.30 e2e test in GHA

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -67,7 +67,6 @@ jobs:
           - {"provider": "Nutanix", "kubernetesMinor": "v1.30", "kubernetesVersion": "v1.30.10", "osImage": "nkp-rocky-9.5-release-1.30.10-20250417212833"}
           - {"provider": "Nutanix", "kubernetesMinor": "v1.31", "kubernetesVersion": "v1.31.4", "osImage": "nkp-rocky-9.5-release-1.31.4-20250409153435"}
           - {"provider": "Nutanix", "kubernetesMinor": "v1.32", "kubernetesVersion": "v1.32.3", "osImage": "nkp-rocky-9.5-release-1.32.3-20250430150550"}
-          - {"provider": "Docker", "kubernetesMinor": "v1.30", "kubernetesVersion": "v1.30.12"}
           - {"provider": "Docker", "kubernetesMinor": "v1.31", "kubernetesVersion": "v1.31.8"}
           - {"provider": "Docker", "kubernetesMinor": "v1.32", "kubernetesVersion": "v1.32.4"}
           - {"provider": "Docker", "kubernetesMinor": "v1.33", "kubernetesVersion": "v1.33.0"}
@@ -97,7 +96,6 @@ jobs:
     strategy:
       matrix:
         config:
-          - {"provider": "Docker", "kubernetesMinor": "v1.30", "kubernetesVersion": "v1.30.12"}
           - {"provider": "Docker", "kubernetesMinor": "v1.31", "kubernetesVersion": "v1.31.8"}
           - {"provider": "Docker", "kubernetesMinor": "v1.32", "kubernetesVersion": "v1.32.4"}
           - {"provider": "Docker", "kubernetesMinor": "v1.33", "kubernetesVersion": "v1.33.0"}


### PR DESCRIPTION
No need to run this any more, just keeping on top of number of
checks we run.

Requires #1121.