### PR TITLE
test: Return root module root dir when using go.work

### DIFF
--- a/pkg/handlers/generic/lifecycle/ccm/nutanix/handler_test.go
+++ b/pkg/handlers/generic/lifecycle/ccm/nutanix/handler_test.go
@@ -209,7 +209,8 @@ func moduleRootDir() string {
 				out),
 		)
 	}
-	modules := strings.Split(string(out), "\n")
-	rootModule := strings.TrimSpace(modules[0])
-	return rootModule
+	// The first line is the module root directory. When go workspaces are used,
+	// the first line is the "root" module root directory.
+	dir, _, _ := strings.Cut(string(out), "\n")
+	return dir, nil
 }

--- a/pkg/handlers/generic/lifecycle/ccm/nutanix/handler_test.go
+++ b/pkg/handlers/generic/lifecycle/ccm/nutanix/handler_test.go
@@ -209,5 +209,7 @@ func moduleRootDir() string {
 				out),
 		)
 	}
-	return strings.TrimSpace(string(out))
+	modules := strings.Split(string(out), "\n")
+	rootModule := strings.TrimSpace(modules[0])
+	return rootModule
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
Fixes the test helper when `go.work` is used locally.

Previously, the helper returned all the output of `go list -m`, and when using go.work, the output contains multiple lines, with the directory of the root module on the first line. Now, the helper returns only the first line.

The previous behavior caused the test to fail:
```
=== Failed
=== FAIL: pkg/handlers/generic/lifecycle/ccm/nutanix Test_templateValues (0.00s)
    handler_test.go:71:
        	Error Trace:	/home/dlipovetsky/projects/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/lifecycle/ccm/nutanix/handler_test.go:193
        	           				/home/dlipovetsky/projects/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/lifecycle/ccm/nutanix/handler_test.go:71
        	Error:      	Received unexpected error:
        	           	open /home/dlipovetsky/projects/cluster-api-runtime-extensions-nutanix
        	           	/home/dlipovetsky/projects/cluster-api-runtime-extensions-nutanix/api
        	           	/home/dlipovetsky/projects/cluster-api-runtime-extensions-nutanix/common
        	           	/home/dlipovetsky/projects/cluster-api-runtime-extensions-nutanix/docs
        	           	/home/dlipovetsky/projects/cluster-api-runtime-extensions-nutanix/hack/third-party/caaph
        	           	/home/dlipovetsky/projects/cluster-api-runtime-extensions-nutanix/hack/third-party/capa
        	           	/home/dlipovetsky/projects/cluster-api-runtime-extensions-nutanix/hack/third-party/capx
        	           	/home/dlipovetsky/projects/cluster-api-runtime-extensions-nutanix/hack/tools/charts/cluster-api-runtime-extensions-nutanix/addons/ccm/nutanix/values-template.yaml: no such file or directory
        	Test:       	Test_templateValues

DONE 446 tests, 1 failure in 35.288s
make: *** [make/go.mk:49: test.root] Error 1

```
**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
The test passes. My `go.work`:

```
go 1.24.2

use (
	.
	./api
	./common
	./docs
	./hack/third-party/caaph
	./hack/third-party/capa
	./hack/third-party/capx
	./hack/tools
)
```
**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
