### PR TITLE
feat: Preflight check opt-out

### DIFF
--- a/pkg/webhook/preflight/skip/skip.go
+++ b/pkg/webhook/preflight/skip/skip.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package skip
+
+import (
+	"strings"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+const (
+	// AnnotationKey is the key of the annotation on the Cluster used to skip preflight checks.
+	AnnotationKey = "preflight.cluster.caren.nutanix.com/skip"
+
+	// SkipAllChecksAnnotationValue is the value used in the cluster's annotations to indicate
+	// that all checks are skipped.
+	SkipAllChecksAnnotationValue = "all"
+)
+
+// Evaluator is used to determine which checks should be skipped, based on the cluster's annotations.
+type Evaluator struct {
+	normalizedCheckNames map[string]struct{}
+	all                  bool
+}
+
+// New creates a new Evaluator from the cluster's annotations.
+func New(cluster *clusterv1.Cluster) *Evaluator {
+	o := &Evaluator{
+		normalizedCheckNames: make(map[string]struct{}),
+	}
+
+	annotations := cluster.GetAnnotations()
+	if annotations == nil {
+		// If there are no annotations, return an Evaluator with no prefixes.
+		return o
+	}
+
+	value, exists := annotations[AnnotationKey]
+	if !exists {
+		// If the annotation does not exist, return an Evaluator with no prefixes.
+		return o
+	}
+
+	for _, checkName := range strings.Split(value, ",") {
+		if checkName == "" {
+			// Ignore whitespace between commas.
+			continue
+		}
+		normalizedCheckName := strings.TrimSpace(strings.ToLower(checkName))
+		o.normalizedCheckNames[normalizedCheckName] = struct{}{}
+	}
+	if _, exists := o.normalizedCheckNames[SkipAllChecksAnnotationValue]; exists && len(o.normalizedCheckNames) == 1 {
+		o.all = true
+	}
+	return o
+}
+
+// For checks if the specific check should be skipped.
+// It returns true if the cluster skip annotation contains the check name.
+// The check name is case-insensitive, so "CheckName1" and "checkname1" will both match.
+// If the cluster has skipped all checks, For will return true for any check name.
+//
+// For example, if the cluster has skipped "CheckName1", then calling
+// For("CheckName1") or For("checkname1") will return true, but For("CheckName2") will
+// return false.
+func (o *Evaluator) For(checkName string) bool {
+	if o.all {
+		// If the cluster has skipped all checks, return true for any check name.
+		return true
+	}
+	normalizedCheckName := strings.TrimSpace(strings.ToLower(checkName))
+	_, exists := o.normalizedCheckNames[normalizedCheckName]
+	return exists
+}
+
+// ForAll checks if all checks should be skipped.
+// It returns true if the cluster skip annotation contains "all".
+// The check is case-insensitive, so "all", "ALL", and "All" will all match.
+func (o *Evaluator) ForAll() bool {
+	return o.all
+}

--- a/pkg/webhook/preflight/skip/skip_test.go
+++ b/pkg/webhook/preflight/skip/skip_test.go
@@ -1,0 +1,255 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package skip
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestNew(t *testing.T) {
+	testCases := []struct {
+		name             string
+		annotations      map[string]string
+		expectCheckNames map[string]struct{}
+	}{
+		{
+			name:             "ignores nil annotations",
+			annotations:      nil,
+			expectCheckNames: map[string]struct{}{},
+		},
+		{
+			name:             "ignores empty annotations",
+			annotations:      map[string]string{},
+			expectCheckNames: map[string]struct{}{},
+		},
+		{
+			name: "ignores missing annotation key",
+			annotations: map[string]string{
+				"some-other-key": "value",
+			},
+			expectCheckNames: map[string]struct{}{},
+		},
+		{
+			name: "ignores empty skip annotation value",
+			annotations: map[string]string{
+				AnnotationKey: "",
+			},
+			expectCheckNames: map[string]struct{}{},
+		},
+		{
+			name: "ignores empty check names",
+			annotations: map[string]string{
+				AnnotationKey: "InfraVMImage,,InfraCredentials,",
+			},
+			expectCheckNames: map[string]struct{}{
+				"infravmimage":     {},
+				"infracredentials": {},
+			},
+		},
+		{
+			name: "ignores value of only commas",
+			annotations: map[string]string{
+				AnnotationKey: ",,,",
+			},
+			expectCheckNames: map[string]struct{}{},
+		},
+		{
+			name: "accepts single check name",
+			annotations: map[string]string{
+				AnnotationKey: "InfraVMImage",
+			},
+			expectCheckNames: map[string]struct{}{
+				"infravmimage": {},
+			},
+		},
+		{
+			name: "accepts multiple check names",
+			annotations: map[string]string{
+				AnnotationKey: "InfraVMImage,InfraCredentials",
+			},
+			expectCheckNames: map[string]struct{}{
+				"infravmimage":     {},
+				"infracredentials": {},
+			},
+		},
+		{
+			name: "trims spaces from check names",
+			annotations: map[string]string{
+				AnnotationKey: " InfraVMImage , InfraCredentials ",
+			},
+			expectCheckNames: map[string]struct{}{
+				"infravmimage":     {},
+				"infracredentials": {},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.annotations,
+				},
+			}
+
+			evaluator := New(cluster)
+			assert.Equal(t, tc.expectCheckNames, evaluator.normalizedCheckNames)
+		})
+	}
+}
+
+func TestEvaluator_For(t *testing.T) {
+	testCases := []struct {
+		name        string
+		annotations map[string]string
+		checkName   string
+		expectMatch bool
+	}{
+		{
+			name:        "no annotations",
+			annotations: nil,
+			checkName:   "InfraVMImage",
+			expectMatch: false,
+		},
+		{
+			name:        "no skip annotation",
+			annotations: map[string]string{},
+			checkName:   "InfraVMImage",
+			expectMatch: false,
+		},
+		{
+			name: "empty annotation value",
+			annotations: map[string]string{
+				AnnotationKey: "",
+			},
+			checkName:   "InfraVMImage",
+			expectMatch: false,
+		},
+		{
+			name: "skip InfraVMImage check",
+			annotations: map[string]string{
+				AnnotationKey: "InfraVMImage,InfraCredentials",
+			},
+			checkName:   "InfraVMImage",
+			expectMatch: true,
+		},
+		{
+			name: "skip credentials, but not image",
+			annotations: map[string]string{
+				AnnotationKey: "InfraCredentials",
+			},
+			checkName:   "InfraVMImage",
+			expectMatch: false,
+		},
+		{
+			name: "skip with spaces and case mixing",
+			annotations: map[string]string{
+				AnnotationKey: " infraVMImage , InfraCredentials ",
+			},
+			checkName:   "InfraVMImage",
+			expectMatch: true,
+		},
+		{
+			name: "extra commas do not affect matching",
+			annotations: map[string]string{
+				AnnotationKey: "InfraVMImage,,InfraCredentials,",
+			},
+			checkName:   "InfraVMImage",
+			expectMatch: true,
+		},
+		{
+			name: "skip all checks",
+			annotations: map[string]string{
+				AnnotationKey: "all",
+			},
+			checkName:   "InfraVMImage",
+			expectMatch: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.annotations,
+				},
+			}
+
+			evaluator := New(cluster)
+			result := evaluator.For(tc.checkName)
+			assert.Equal(t, tc.expectMatch, result)
+		})
+	}
+}
+
+func TestEvaluator_ForAll(t *testing.T) {
+	testCases := []struct {
+		name        string
+		annotations map[string]string
+		expectMatch bool
+	}{
+		{
+			name:        "no annotations",
+			annotations: nil,
+			expectMatch: false,
+		},
+		{
+			name:        "no skip annotation",
+			annotations: map[string]string{},
+			expectMatch: false,
+		},
+		{
+			name: "empty annotation value",
+			annotations: map[string]string{
+				AnnotationKey: "",
+			},
+		},
+		{
+			name: "skip all checks with spaces and case mixing",
+			annotations: map[string]string{
+				AnnotationKey: " aLL ",
+			},
+			expectMatch: true,
+		},
+		{
+			name: "skip all checks with extra commas",
+			annotations: map[string]string{
+				AnnotationKey: ",all,,",
+			},
+			expectMatch: true,
+		},
+		{
+			name: "skip all checks",
+			annotations: map[string]string{
+				AnnotationKey: "all",
+			},
+			expectMatch: true,
+		},
+		{
+			name: "skip some checks, but not all",
+			annotations: map[string]string{
+				AnnotationKey: "OneCheck,AnotherCheck",
+			},
+			expectMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.annotations,
+				},
+			}
+
+			evaluator := New(cluster)
+			result := evaluator.ForAll()
+			assert.Equal(t, tc.expectMatch, result)
+		})
+	}
+}


### PR DESCRIPTION
**What problem does this PR solve?**:
Provides a way for the client to opt out of preflight checks for a specific Cluster by using an annotation:

Examples

Opt out of two specific checks:
```
preflight.cluster.caren.nutanix.com/opt-out: "CheckOne, checktwo"
```

(Note that both case and whitespace is ignored)

Opt out of all checks:

```
preflight.cluster.caren.nutanix.com/opt-out: all
```

When a pre-flight check returns a false negative due to a bug, an issue in some external API, or some unforseen circumstance, the client needs a way to opt out. 

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
