### PR TITLE
feat: add requests and limits to registry containers

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/registry/cncf-distribution/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/registry/cncf-distribution/values-template.yaml
@@ -6,8 +6,22 @@ service:
   type: ClusterIP
   clusterIP: {{ .ServiceIP }}
   port: 443
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 250m
+    memory: 384Mi
 statefulSet:
   enabled: true
   syncer:
     interval: 2m
+    resources:
+      requests:
+        cpu: 25m
+        memory: 50Mi
+      limits:
+        cpu: 100m
+        memory: 75Mi
 tlsSecretName: {{ .TLSSecretName }}


### PR DESCRIPTION
**What problem does this PR solve?**:
Set requests and limits for the registry containers. The addon can be enabled in every cluster so we want to have control over the resources.
These numbers were collected by pushing a 12GB bundle to the registry.
<img width="831" alt="image" src="https://github.com/user-attachments/assets/11a84a43-1caa-4e26-8fbe-492a1cd0b5d6" />


**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
