### PR TITLE
fix: registry addon headless service port

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
@@ -25,7 +25,7 @@ data:
     RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://kubernetes.github.io/autoscaler{{ end }}'
   cncf-distribution-registry: |
     ChartName: docker-registry
-    ChartVersion: 2.3.4
+    ChartVersion: 2.3.5
     RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://mesosphere.github.io/charts/staging/{{ end }}'
   cosi-controller: |
     ChartName: cosi

--- a/hack/addons/helm-chart-bundler/repos.yaml
+++ b/hack/addons/helm-chart-bundler/repos.yaml
@@ -35,7 +35,7 @@ repositories:
     repoURL: https://mesosphere.github.io/charts/staging/
     charts:
       docker-registry:
-      - 2.3.4
+      - 2.3.5
   local-path-provisioner:
     repoURL: https://charts.containeroo.ch
     charts:

--- a/hack/addons/kustomize/cncf-distribution-registry/kustomization.yaml.tmpl
+++ b/hack/addons/kustomize/cncf-distribution-registry/kustomization.yaml.tmpl
@@ -18,7 +18,7 @@ helmCharts:
 - name: docker-registry
   repo: https://mesosphere.github.io/charts/staging/
   releaseName: cncf-distribution-registry
-  version: 2.3.4
+  version: 2.3.5
   valuesFile: helm-values.yaml
   includeCRDs: true
   skipTests: true


### PR DESCRIPTION
**What problem does this PR solve?**:
Updates chart version that has a fix that correctly sets headless service port equal to pod's port.
Usually clients would explicitly set the port directly when connecting to the headless service, but this does fix using `kubectl port-forward`

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
```
$ kubectl port-forward --address=127.0.0.1 --namespace registry-system service/cncf-distribution-registry-docker-registry-headless https
Forwarding from 127.0.0.1:5000 -> 5000
Handling connection for 5000

$ crane copy nginx:stable 127.0.0.1:5000/library/nginx:dkoshkin --insecure                                                                      
2025/06/13 13:51:08 Copying from nginx:stable to 127.0.0.1:5000/library/nginx:dkoshkin
2025/06/13 13:51:11 pushed blob: sha256:6b8146f9616cc4005c1b785be80e6c75d2fc745cdf9d7f12e1aacf0449faada7
...
```

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
