### PR TITLE
test: Add update test helpers

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -19,6 +19,7 @@ require (
 	k8s.io/api v0.32.5
 	k8s.io/apiextensions-apiserver v0.32.5
 	k8s.io/apimachinery v0.32.5
+	k8s.io/apiserver v0.32.5
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/cluster-api v1.10.2
 	sigs.k8s.io/cluster-api/test v1.10.2
@@ -85,7 +86,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiserver v0.32.5 // indirect
 	k8s.io/client-go v0.32.5 // indirect
 	k8s.io/cluster-bootstrap v0.32.3 // indirect
 	k8s.io/component-base v0.32.5 // indirect

--- a/common/pkg/testutils/openapi/convert.go
+++ b/common/pkg/testutils/openapi/convert.go
@@ -208,5 +208,22 @@ func ConvertJSONSchemaPropsToAPIExtensions(
 		}
 	}
 
+	if schema.XValidations != nil {
+		props.XValidations = make([]apiextensions.ValidationRule, 0, len(schema.XValidations))
+		for _, v := range schema.XValidations {
+			var reason *apiextensions.FieldValueErrorReason
+			if v.Reason != "" {
+				reason = ptr.To(apiextensions.FieldValueErrorReason(v.Reason))
+			}
+			props.XValidations = append(props.XValidations, apiextensions.ValidationRule{
+				Rule:              v.Rule,
+				Message:           v.Message,
+				MessageExpression: v.MessageExpression,
+				Reason:            reason,
+				FieldPath:         v.FieldPath,
+			})
+		}
+	}
+
 	return props, allErrs
 }


### PR DESCRIPTION
Previously there was no way to test transitions that would be
enforced via CEL. This commit fixes that and allows the testing
of CEL transition rules on update, which will be necessary for
some future handlers.
