### PR TITLE
feat: Enforce MD replicas within cluster autoscaler bounds

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -30,6 +30,7 @@ A Helm chart for cluster-api-runtime-extensions-nutanix
 | certificates.issuer.selfSigned | bool | `true` |  |
 | deployDefaultClusterClasses | bool | `true` |  |
 | deployment.replicas | int | `1` |  |
+| enforceClusterAutoscalerLimits.enabled | bool | `true` |  |
 | env | object | `{}` |  |
 | helmAddonsConfigMap | string | `"default-helm-addons-config"` |  |
 | helmRepository.enabled | bool | `true` |  |

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         - --namespacesync-enabled={{ .Values.namespaceSync.enabled }}
         - --namespacesync-source-namespace={{ default .Release.Namespace .Values.namespaceSync.sourceNamespace }}
         - --namespacesync-target-namespace-label-key={{ .Values.namespaceSync.targetNamespaceLabelKey }}
+        - --enforce-clusterautoscaler-limits-enabled={{ .Values.enforceClusterAutoscalerLimits.enabled }}
         - --helm-addons-configmap={{ .Values.helmAddonsConfigMap }}
         - --cni.cilium.helm-addon.default-values-template-configmap-name={{ .Values.hooks.cni.cilium.helmAddonStrategy.defaultValueTemplateConfigMap.name }}
         - --nfd.helm-addon.default-values-template-configmap-name={{ .Values.hooks.nfd.helmAddonStrategy.defaultValueTemplateConfigMap.name }}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/role.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/role.yaml
@@ -80,6 +80,16 @@ rules:
       - list
       - watch
   - apiGroups:
+      - cluster.x-k8s.io
+    resources:
+      - machinedeployments
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - storage.k8s.io
     resources:
       - storageclasses

--- a/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
@@ -31,6 +31,14 @@
             },
             "type": "object"
         },
+        "enforceClusterAutoscalerLimits": {
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "env": {
             "properties": {},
             "type": "object"

--- a/charts/cluster-api-runtime-extensions-nutanix/values.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.yaml
@@ -132,6 +132,16 @@ namespaceSync:
   # By default, sourceNamespace is the helm release namespace.
   sourceNamespace: ""
 
+# Enable the Cluster Autoscaler limits enforcement controller.
+# This controller ensures that the number of replicas in a MachineDeployment
+# does not exceed the limits set by the Cluster Autoscaler annotations.
+# It will also ensure that the number of replicas is at least the minimum
+# number of replicas set by the Cluster Autoscaler annotations.
+# The controller will not enforce the limits if the Cluster Autoscaler annotations
+# are not present on the MachineDeployment.
+enforceClusterAutoscalerLimits:
+  enabled: true
+
 deployment:
   replicas: 1
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,6 +32,7 @@ import (
 	caaphv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/server"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/controllers/enforceclusterautoscalerlimits"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/controllers/namespacesync"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/features"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws"
@@ -118,6 +119,7 @@ func main() {
 	genericMetaHandlers := generic.New()
 
 	namespacesyncOptions := namespacesync.Options{}
+	enforceClusterAutoscalerLimitsOptions := enforceclusterautoscalerlimits.Options{}
 
 	// Initialize and parse command line flags.
 	logs.AddFlags(pflag.CommandLine, logs.SkipLoggingConfigurationFlags())
@@ -129,6 +131,7 @@ func main() {
 	dockerMetaHandlers.AddFlags(pflag.CommandLine)
 	nutanixMetaHandlers.AddFlags(pflag.CommandLine)
 	namespacesyncOptions.AddFlags(pflag.CommandLine)
+	enforceClusterAutoscalerLimitsOptions.AddFlags(pflag.CommandLine)
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
@@ -200,7 +203,6 @@ func main() {
 			SourceClusterClassNamespace: namespacesyncOptions.SourceNamespace,
 			IsTargetNamespace:           namespacesync.NamespaceHasLabelKey(namespacesyncOptions.TargetNamespaceLabelKey),
 		}).SetupWithManager(
-			signalCtx,
 			mgr,
 			&controller.Options{MaxConcurrentReconciles: namespacesyncOptions.Concurrency},
 		); err != nil {
@@ -209,6 +211,23 @@ func main() {
 				"unable to create controller",
 				"controller",
 				"namespacesync.Reconciler",
+			)
+			os.Exit(1)
+		}
+	}
+
+	if enforceClusterAutoscalerLimitsOptions.Enabled {
+		if err := (&enforceclusterautoscalerlimits.Reconciler{
+			Client: mgr.GetClient(),
+		}).SetupWithManager(
+			mgr,
+			&controller.Options{MaxConcurrentReconciles: enforceClusterAutoscalerLimitsOptions.Concurrency},
+		); err != nil {
+			setupLog.Error(
+				err,
+				"unable to create controller",
+				"controller",
+				"enforceclusterautoscalerlimits.Reconciler",
 			)
 			os.Exit(1)
 		}

--- a/pkg/controllers/enforceclusterautoscalerlimits/controller.go
+++ b/pkg/controllers/enforceclusterautoscalerlimits/controller.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package enforceclusterautoscalerlimits
+
+import (
+	context "context"
+	fmt "fmt"
+	"strconv"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+type Reconciler struct {
+	client.Client
+}
+
+func (r *Reconciler) SetupWithManager(
+	mgr ctrl.Manager,
+	options *controller.Options,
+) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.MachineDeployment{}).
+		WithOptions(*options).
+		Complete(r)
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx).WithValues("machineDeployment", req.NamespacedName)
+
+	var md clusterv1.MachineDeployment
+	if err := r.Get(ctx, req.NamespacedName, &md); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(5).Info("MachineDeployment not found, skipping reconciliation")
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, fmt.Errorf("failed to get MachineDeployment %s: %w", req.NamespacedName, err)
+	}
+
+	// If replicas is not set, we don't need to do anything.
+	if md.Spec.Replicas == nil {
+		logger.V(5).Info("MachineDeployment has no replicas set, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
+	minReplicas, err := minReplicasFromAnnotations(md.Annotations)
+	if err != nil {
+		// Do nothing if the minSize annotation is missing.
+		if errors.Is(err, errMissingMinAnnotation) {
+			logger.V(5).Info("MachineDeployment has no min size annotation, skipping reconciliation")
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, fmt.Errorf("failed to get min size: %w", err)
+	}
+
+	maxReplicas, err := maxReplicasFromAnnotations(md.Annotations)
+	if err != nil {
+		// Do nothing if the maxSize annotation is missing.
+		if errors.Is(err, errMissingMaxAnnotation) {
+			logger.V(5).Info("MachineDeployment has no max size annotation, skipping reconciliation")
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, fmt.Errorf("failed to get max size: %w", err)
+	}
+
+	if minReplicas > maxReplicas {
+		logger.WithValues("minReplicas", minReplicas, "maxReplicas", maxReplicas).
+			Info("Min replicas is greater than max replicas - skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
+	// If the current replicas are within the bounds, do nothing.
+	if int(*md.Spec.Replicas) >= minReplicas && int(*md.Spec.Replicas) <= maxReplicas {
+		return ctrl.Result{}, nil
+	}
+
+	// Otherwise set replicas to nil and depend on CAPI MachineDeployment defaulting to handle
+	// the scaling correctly.
+	// See https://github.com/kubernetes-sigs/cluster-api/blob/v1.10.3/internal/webhooks/machinedeployment.go#L365
+	// for more details.
+	md.Spec.Replicas = nil
+
+	if err := r.Update(ctx, &md); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update MachineDeployment %s: %w", req.NamespacedName, err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+var (
+	// errMissingMinAnnotation is the error returned when a
+	// machine set does not have an annotation keyed by
+	// nodeGroupMinSizeAnnotationKey.
+	errMissingMinAnnotation = errors.New("missing min annotation")
+
+	// errMissingMaxAnnotation is the error returned when a
+	// machine set does not have an annotation keyed by
+	// nodeGroupMaxSizeAnnotationKey.
+	errMissingMaxAnnotation = errors.New("missing max annotation")
+
+	// errInvalidMinAnnotationValue is the error returned when a
+	// machine set has a non-integral min annotation value.
+	errInvalidMinAnnotation = errors.New("invalid min annotation")
+
+	// errInvalidMaxAnnotationValue is the error returned when a
+	// machine set has a non-integral max annotation value.
+	errInvalidMaxAnnotation = errors.New("invalid max annotation")
+)
+
+// minReplicasFromAnnotations returns the minimum value encoded in the annotations keyed
+// by "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size".
+// Returns errMissingMinAnnotation if the annotation doesn't exist or
+// errInvalidMinAnnotation if the value is not of type int.
+func minReplicasFromAnnotations(annotations map[string]string) (int, error) {
+	val, found := annotations[clusterv1.AutoscalerMinSizeAnnotation]
+	if !found {
+		return 0, errMissingMinAnnotation
+	}
+	i, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %v", errInvalidMinAnnotation, err)
+	}
+	return i, nil
+}
+
+// maxReplicasFromAnnotations returns the maximum value encoded in the annotations keyed
+// by "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size".
+// Returns errMissingMaxAnnotation if the annotation doesn't exist or
+// errInvalidMaxAnnotation if the value is not of type int.
+func maxReplicasFromAnnotations(annotations map[string]string) (int, error) {
+	val, found := annotations[clusterv1.AutoscalerMaxSizeAnnotation]
+	if !found {
+		return 0, errMissingMaxAnnotation
+	}
+	i, err := strconv.Atoi(val)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %v", errInvalidMaxAnnotation, err)
+	}
+	return i, nil
+}

--- a/pkg/controllers/enforceclusterautoscalerlimits/controller_test.go
+++ b/pkg/controllers/enforceclusterautoscalerlimits/controller_test.go
@@ -1,0 +1,294 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package enforceclusterautoscalerlimits
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/internal/test/builder"
+)
+
+func TestReconcileMachineDeploymentWithNoReplicasOrClusterAutoscalerAnnotations(t *testing.T) {
+	g := NewWithT(t)
+	timeout := 5 * time.Second
+
+	sourceMachineDeployment := builder.MachineDeployment(
+		metav1.NamespaceDefault,
+		"test-md",
+	).WithClusterName("test").Build()
+
+	g.Expect(env.Client.Create(ctx, sourceMachineDeployment)).To(Succeed())
+	defer func() {
+		g.Expect(env.CleanupAndWait(ctx, sourceMachineDeployment)).To(Succeed())
+	}()
+
+	g.Eventually(func() error {
+		return env.Client.Get(ctx, client.ObjectKeyFromObject(sourceMachineDeployment), &clusterv1.MachineDeployment{})
+	}, timeout).To(Succeed())
+
+	g.Consistently(func() error {
+		return verifyMachineDeploymentReplicas(
+			env.Client,
+			client.ObjectKeyFromObject(sourceMachineDeployment),
+			nil,
+		)
+	},
+		timeout,
+	).Should(Succeed())
+}
+
+func TestReconcileMachineDeploymentWithReplicasOnly(t *testing.T) {
+	g := NewWithT(t)
+	timeout := 5 * time.Second
+
+	sourceMachineDeployment := builder.MachineDeployment(
+		metav1.NamespaceDefault,
+		"test-md",
+	).WithClusterName("test").WithReplicas(5).Build()
+
+	g.Expect(env.Client.Create(ctx, sourceMachineDeployment)).To(Succeed())
+	defer func() {
+		g.Expect(env.CleanupAndWait(ctx, sourceMachineDeployment)).To(Succeed())
+	}()
+
+	g.Eventually(func() error {
+		return env.Client.Get(ctx, client.ObjectKeyFromObject(sourceMachineDeployment), &clusterv1.MachineDeployment{})
+	}).To(Succeed())
+
+	g.Consistently(func() error {
+		return verifyMachineDeploymentReplicas(
+			env.Client,
+			client.ObjectKeyFromObject(sourceMachineDeployment),
+			ptr.To[int32](5),
+		)
+	},
+		timeout,
+	).Should(Succeed())
+}
+
+func TestReconcileMachineDeploymentWithReplicasAndMinAnnotationOnly(t *testing.T) {
+	g := NewWithT(t)
+	timeout := 5 * time.Second
+
+	sourceMachineDeployment := builder.MachineDeployment(
+		metav1.NamespaceDefault,
+		"test-md",
+	).
+		WithClusterName("test").
+		WithReplicas(5).
+		WithMinClusterAutoscalerAnnotation(12).
+		Build()
+
+	g.Expect(env.Client.Create(ctx, sourceMachineDeployment)).To(Succeed())
+	defer func() {
+		g.Expect(env.CleanupAndWait(ctx, sourceMachineDeployment)).To(Succeed())
+	}()
+
+	g.Eventually(func() error {
+		return env.Client.Get(ctx, client.ObjectKeyFromObject(sourceMachineDeployment), &clusterv1.MachineDeployment{})
+	}, timeout).To(Succeed())
+
+	g.Consistently(func() error {
+		return verifyMachineDeploymentReplicas(
+			env.Client,
+			client.ObjectKeyFromObject(sourceMachineDeployment),
+			ptr.To[int32](5),
+		)
+	},
+		timeout,
+	).Should(Succeed())
+}
+
+func TestReconcileMachineDeploymentWithReplicasAndMaxAnnotationOnly(t *testing.T) {
+	g := NewWithT(t)
+	timeout := 5 * time.Second
+
+	sourceMachineDeployment := builder.MachineDeployment(
+		metav1.NamespaceDefault,
+		"test-md",
+	).
+		WithClusterName("test").
+		WithReplicas(5).
+		WithMaxClusterAutoscalerAnnotation(3).
+		Build()
+
+	g.Expect(env.Client.Create(ctx, sourceMachineDeployment)).To(Succeed())
+	defer func() {
+		g.Expect(env.CleanupAndWait(ctx, sourceMachineDeployment)).To(Succeed())
+	}()
+
+	g.Eventually(func() error {
+		return env.Client.Get(ctx, client.ObjectKeyFromObject(sourceMachineDeployment), &clusterv1.MachineDeployment{})
+	}, timeout).To(Succeed())
+
+	g.Consistently(func() error {
+		return verifyMachineDeploymentReplicas(
+			env.Client,
+			client.ObjectKeyFromObject(sourceMachineDeployment),
+			ptr.To[int32](5),
+		)
+	},
+		timeout,
+	).Should(Succeed())
+}
+
+func TestReconcileMachineDeploymentWithReplicasWithinMinMaxBounds(t *testing.T) {
+	g := NewWithT(t)
+	timeout := 5 * time.Second
+
+	sourceMachineDeployment := builder.MachineDeployment(
+		metav1.NamespaceDefault,
+		"test-md",
+	).
+		WithClusterName("test").
+		WithReplicas(5).
+		WithMinClusterAutoscalerAnnotation(3).
+		WithMaxClusterAutoscalerAnnotation(12).
+		Build()
+
+	g.Expect(env.Client.Create(ctx, sourceMachineDeployment)).To(Succeed())
+	defer func() {
+		g.Expect(env.CleanupAndWait(ctx, sourceMachineDeployment)).To(Succeed())
+	}()
+
+	g.Eventually(func() error {
+		return env.Client.Get(ctx, client.ObjectKeyFromObject(sourceMachineDeployment), &clusterv1.MachineDeployment{})
+	}, timeout).To(Succeed())
+
+	g.Consistently(func() error {
+		return verifyMachineDeploymentReplicas(
+			env.Client,
+			client.ObjectKeyFromObject(sourceMachineDeployment),
+			ptr.To[int32](5),
+		)
+	},
+		timeout,
+	).Should(Succeed())
+}
+
+func TestReconcileMachineDeploymentWithReplicasLessThanMinBound(t *testing.T) {
+	g := NewWithT(t)
+	timeout := 5 * time.Second
+
+	sourceMachineDeployment := builder.MachineDeployment(
+		metav1.NamespaceDefault,
+		"test-md",
+	).
+		WithClusterName("test").
+		WithReplicas(5).
+		WithMinClusterAutoscalerAnnotation(7).
+		WithMaxClusterAutoscalerAnnotation(12).
+		Build()
+
+	g.Expect(env.Client.Create(ctx, sourceMachineDeployment)).To(Succeed())
+	defer func() {
+		g.Expect(env.CleanupAndWait(ctx, sourceMachineDeployment)).To(Succeed())
+	}()
+
+	g.Eventually(func() error {
+		return verifyMachineDeploymentReplicas(
+			env.Client,
+			client.ObjectKeyFromObject(sourceMachineDeployment),
+			nil,
+		)
+	},
+		timeout,
+	).Should(Succeed())
+}
+
+func TestReconcileMachineDeploymentWithReplicasMoreThanMaxBound(t *testing.T) {
+	g := NewWithT(t)
+	timeout := 5 * time.Second
+
+	sourceMachineDeployment := builder.MachineDeployment(
+		metav1.NamespaceDefault,
+		"test-md",
+	).
+		WithClusterName("test").
+		WithReplicas(15).
+		WithMinClusterAutoscalerAnnotation(7).
+		WithMaxClusterAutoscalerAnnotation(12).
+		Build()
+
+	g.Expect(env.Client.Create(ctx, sourceMachineDeployment)).To(Succeed())
+	defer func() {
+		g.Expect(env.CleanupAndWait(ctx, sourceMachineDeployment)).To(Succeed())
+	}()
+
+	g.Eventually(func() error {
+		return verifyMachineDeploymentReplicas(
+			env.Client,
+			client.ObjectKeyFromObject(sourceMachineDeployment),
+			nil,
+		)
+	},
+		timeout,
+	).Should(Succeed())
+}
+
+func TestReconcileMachineDeploymentWithInvalidClusterAutoscalerAnnotations(t *testing.T) {
+	g := NewWithT(t)
+	timeout := 5 * time.Second
+
+	sourceMachineDeployment := builder.MachineDeployment(
+		metav1.NamespaceDefault,
+		"test-md",
+	).WithClusterName("test").
+		WithReplicas(1).
+		WithMaxClusterAutoscalerAnnotation(3).
+		WithMinClusterAutoscalerAnnotation(7).
+		Build()
+
+	g.Expect(env.Client.Create(ctx, sourceMachineDeployment)).To(Succeed())
+	defer func() {
+		g.Expect(env.CleanupAndWait(ctx, sourceMachineDeployment)).To(Succeed())
+	}()
+
+	g.Eventually(func() error {
+		return env.Client.Get(ctx, client.ObjectKeyFromObject(sourceMachineDeployment), &clusterv1.MachineDeployment{})
+	}).To(Succeed())
+
+	g.Consistently(func() error {
+		return verifyMachineDeploymentReplicas(
+			env.Client,
+			client.ObjectKeyFromObject(sourceMachineDeployment),
+			ptr.To[int32](1),
+		)
+	},
+		timeout,
+	).Should(Succeed())
+}
+
+func verifyMachineDeploymentReplicas(
+	c client.Client,
+	key client.ObjectKey,
+	expectedReplicas *int32,
+) error {
+	var md clusterv1.MachineDeployment
+	if err := c.Get(ctx, key, &md); err != nil {
+		return fmt.Errorf("failed to get MachineDeployment %s: %w", key, err)
+	}
+
+	if expectedReplicas == nil && md.Spec.Replicas != nil {
+		return fmt.Errorf("expected replicas to be nil, but got %d", *md.Spec.Replicas)
+	}
+
+	if expectedReplicas != nil && md.Spec.Replicas == nil {
+		return fmt.Errorf("expected %d replicas, but got nil", *expectedReplicas)
+	}
+
+	if expectedReplicas != nil && *md.Spec.Replicas != *expectedReplicas {
+		return fmt.Errorf("expected %d replicas, but got %d", *expectedReplicas, *md.Spec.Replicas)
+	}
+
+	return nil
+}

--- a/pkg/controllers/enforceclusterautoscalerlimits/doc.go
+++ b/pkg/controllers/enforceclusterautoscalerlimits/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package enforceclusterautoscalerlimits provides a controller that enforces Cluster Autoscaler
+// limits on MachineDeployments.
+//
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch;update;patch
+package enforceclusterautoscalerlimits

--- a/pkg/controllers/enforceclusterautoscalerlimits/flags.go
+++ b/pkg/controllers/enforceclusterautoscalerlimits/flags.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package enforceclusterautoscalerlimits
+
+import (
+	"github.com/spf13/pflag"
+)
+
+type Options struct {
+	Enabled     bool
+	Concurrency int
+}
+
+func (o *Options) AddFlags(flags *pflag.FlagSet) {
+	pflag.CommandLine.BoolVar(
+		&o.Enabled,
+		"enforce-clusterautoscaler-limits-enabled",
+		false,
+		"Enable enforcing cluster-autoscaler limits on MachineDeployments.",
+	)
+
+	pflag.CommandLine.IntVar(
+		&o.Concurrency,
+		"enforce-clusterautoscaler-limits-concurrency",
+		10,
+		"Number of MachineDeployments to handle concurrently.",
+	)
+}

--- a/pkg/controllers/enforceclusterautoscalerlimits/suite_test.go
+++ b/pkg/controllers/enforceclusterautoscalerlimits/suite_test.go
@@ -1,7 +1,7 @@
-// Copyright 2024 Nutanix. All rights reserved.
+// Copyright 2025 Nutanix. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package namespacesync
+package enforceclusterautoscalerlimits
 
 import (
 	"context"
@@ -13,28 +13,20 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/internal/test/envtest"
-)
-
-const (
-	targetNamespaceLabelKey = "test"
 )
 
 var (
 	ctx        = ctrl.SetupSignalHandler()
 	fakeScheme = runtime.NewScheme()
 	env        *envtest.Environment
-
-	sourceClusterClassNamespace = "source"
 )
 
 func TestMain(m *testing.M) {
@@ -45,20 +37,8 @@ func TestMain(m *testing.M) {
 	_ = corev1.AddToScheme(fakeScheme)
 
 	setupReconcilers := func(ctx context.Context, mgr ctrl.Manager) {
-		unstructuredCachingClient, err := client.New(mgr.GetConfig(), client.Options{
-			Cache: &client.CacheOptions{
-				Reader:       mgr.GetCache(),
-				Unstructured: true,
-			},
-		})
-		if err != nil {
-			panic(fmt.Sprintf("unable to create unstructuredCachineClient: %v", err))
-		}
 		if err := (&Reconciler{
-			Client:                      mgr.GetClient(),
-			UnstructuredCachingClient:   unstructuredCachingClient,
-			SourceClusterClassNamespace: sourceClusterClassNamespace,
-			IsTargetNamespace:           NamespaceHasLabelKey(targetNamespaceLabelKey),
+			Client: mgr.GetClient(),
 		}).SetupWithManager(mgr, &controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("unable to create reconciler: %v", err))
 		}
@@ -68,15 +48,6 @@ func TestMain(m *testing.M) {
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
 		M: m,
 		SetupEnv: func(e *envtest.Environment) {
-			err := e.Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: sourceClusterClassNamespace,
-				},
-			})
-			if err != nil {
-				panic(fmt.Sprintf("unable to create source namespace: %s", err))
-			}
-
 			env = e
 		},
 		SetupReconcilers: setupReconcilers,

--- a/pkg/controllers/namespacesync/controller.go
+++ b/pkg/controllers/namespacesync/controller.go
@@ -33,7 +33,6 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) SetupWithManager(
-	ctx context.Context,
 	mgr ctrl.Manager,
 	options *controller.Options,
 ) error {


### PR DESCRIPTION
When the current MD `.spec.replicas` is outside of the bounds of the cluster autoscaler min/max annotations, cluster autoscaler will not scale the MD up or down. This can occur when either the annotations are edited or `spec.replicas` is updated.

In a topology-based cluster, CAPI propagates the cluster autoscaler annotations from `cluster.spec.topology.workers.machineDeployments[].metadata.annotations` to the templated `MachineDeployment` resources. If these annotations are changed so that the range they define does not contain the current number of replicas, then no scaling up or down will happen to the MachineDeployment by the cluster autoscaler.

This commit adds a controller that does the following to MachineDeployments:

- if `spec.replicas` is nil do nothing
- if cluster autoscaler annotations for min or max are missing do nothing
- if `spec.replicas` is within cluster autoscaler annotations bounds do nothing
- if `spec.replicas` is not within CA annotations bounds then set `spec.replicas`
  to nil (CAPI MD defaulting webhook will correctly set MD replicas as per
https://github.com/kubernetes-sigs/cluster-api/blob/v1.10.3/internal/webhooks/machinedeployment.go#L353-L376.

This ensures that scaling up and down by specifying cluster autoscaler annotations on the machine deployments in `cluster.spec.topology.workers.machineDeployments[].metadata.annotations` will always be respected, even if the current number of replicas is outside the autoscaling specified bounds.