### PR TITLE
feat(preflight): Add VM Image kubernetes version check

### DIFF
--- a/pkg/webhook/preflight/nutanix/checker.go
+++ b/pkg/webhook/preflight/nutanix/checker.go
@@ -18,10 +18,11 @@ import (
 )
 
 var Checker = &nutanixChecker{
-	configurationCheckFactory:     newConfigurationCheck,
-	credentialsCheckFactory:       newCredentialsCheck,
-	vmImageChecksFactory:          newVMImageChecks,
-	storageContainerChecksFactory: newStorageContainerChecks,
+	configurationCheckFactory:             newConfigurationCheck,
+	credentialsCheckFactory:               newCredentialsCheck,
+	vmImageChecksFactory:                  newVMImageChecks,
+	vmImageKubernetesVersionChecksFactory: newVMImageKubernetesVersionChecks,
+	storageContainerChecksFactory:         newStorageContainerChecks,
 }
 
 type nutanixChecker struct {
@@ -36,6 +37,10 @@ type nutanixChecker struct {
 	) preflight.Check
 
 	vmImageChecksFactory func(
+		cd *checkDependencies,
+	) []preflight.Check
+
+	vmImageKubernetesVersionChecksFactory func(
 		cd *checkDependencies,
 	) []preflight.Check
 
@@ -74,6 +79,7 @@ func (n *nutanixChecker) Init(
 	}
 
 	checks = append(checks, n.vmImageChecksFactory(cd)...)
+	checks = append(checks, n.vmImageKubernetesVersionChecksFactory(cd)...)
 	checks = append(checks, n.storageContainerChecksFactory(cd)...)
 
 	// Add more checks here as needed.

--- a/pkg/webhook/preflight/nutanix/image.go
+++ b/pkg/webhook/preflight/nutanix/image.go
@@ -115,6 +115,10 @@ func getVMImages(
 		if err != nil {
 			return nil, err
 		}
+		if resp == nil {
+			// No images were returned.
+			return []vmmv4.Image{}, nil
+		}
 		image, ok := resp.GetData().(vmmv4.Image)
 		if !ok {
 			return nil, fmt.Errorf("failed to get data returned by GetImageById")

--- a/pkg/webhook/preflight/nutanix/image_test.go
+++ b/pkg/webhook/preflight/nutanix/image_test.go
@@ -417,6 +417,20 @@ func TestGetVMImages(t *testing.T) {
 			errorMsg: "image identifier is missing both name and uuid",
 		},
 		{
+			name: "no image found by uuid",
+			client: &mocknclient{
+				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+					return nil, nil
+				},
+			},
+			id: &capxv1.NutanixResourceIdentifier{
+				Type: capxv1.NutanixIdentifierUUID,
+				UUID: ptr.To("test-uuid"),
+			},
+			wantErr: false,
+			want:    []vmmv4.Image{}, // No images found
+		},
+		{
 			name: "invalid data from GetImageById",
 			client: &mocknclient{
 				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
@@ -55,8 +55,7 @@ func (c *imageKubernetesVersionCheck) Run(ctx context.Context) preflight.CheckRe
 
 		if len(images) == 0 {
 			return preflight.CheckResult{
-				Allowed:  true,
-				Warnings: []string{"expected to find 1 VM Image, found none"},
+				Allowed: true,
 			}
 		}
 

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
@@ -15,8 +15,8 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/webhook/preflight"
 )
 
-// Examples: nkp-ubuntu-22.04-vgpu-1.32.3-20250604180644, nkp-rocky-9.5-release-cis-1.32.3-20250430150550.
 // The regex captures the Kubernetes version in the format of 1.x.y, where x and y are digits.
+// Example: kubedistro-rocky-9.5-vgpu-1.32.3-20250604180644 -> 1.32.3.
 var kubernetesVersionRegex = regexp.MustCompile(`(?i)\b[vV]?(1\.\d+(?:\.\d+)?)\b`)
 
 type imageKubernetesVersionCheck struct {
@@ -107,8 +107,8 @@ func (c *imageKubernetesVersionCheck) checkKubernetesVersion(image *vmmv4.Image)
 }
 
 // extractKubernetesVersionFromImageName extracts the Kubernetes version from the given image name.
-// It expects something that looks like a kubernetes version in the image name i.e. 1.x.y?,
-// Examples: nkp-ubuntu-22.04-vgpu-1.32.3-20250604180644 -> 1.32.3.
+// It expects something that looks like a kubernetes version in the image name i.e. 1.x.y?.
+// Examples: kubedistro-rocky-9.5-vgpu-1.32.3-20250604180644 -> 1.32.3.
 func extractKubernetesVersionFromImageName(imageName string) (string, error) {
 	matches := kubernetesVersionRegex.FindStringSubmatch(imageName)
 	if len(matches) < 2 {

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
@@ -1,0 +1,167 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nutanix
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	vmmv4 "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/content"
+
+	carenv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/webhook/preflight"
+)
+
+// Examples: nkp-ubuntu-22.04-vgpu-1.32.3-20250604180644, nkp-rocky-9.5-release-cis-1.32.3-20250430150550.
+var kubernetesVersionRegex = regexp.MustCompile(`-(\d+\.\d+\.\d+)-\d{14}$`)
+
+type imageKubernetesVersionCheck struct {
+	machineDetails    *carenv1.NutanixMachineDetails
+	field             string
+	nclient           client
+	clusterK8sVersion string
+}
+
+func (c *imageKubernetesVersionCheck) Name() string {
+	return "NutanixVMImageKubernetesVersion"
+}
+
+func (c *imageKubernetesVersionCheck) Run(ctx context.Context) preflight.CheckResult {
+	if c.machineDetails.ImageLookup != nil {
+		return preflight.CheckResult{
+			Allowed:  true,
+			Warnings: []string{fmt.Sprintf("%s uses imageLookup, which is not yet supported by checks", c.field)},
+		}
+	}
+
+	if c.machineDetails.Image != nil {
+		images, err := getVMImages(c.nclient, c.machineDetails.Image)
+		if err != nil {
+			return preflight.CheckResult{
+				Allowed: false,
+				Error:   true,
+				Causes: []preflight.Cause{
+					{
+						Message: fmt.Sprintf("failed to get VM Image: %s", err),
+						Field:   c.field,
+					},
+				},
+			}
+		}
+
+		if len(images) == 0 {
+			return preflight.CheckResult{
+				Allowed:  true,
+				Warnings: []string{"expected to find 1 VM Image, found none"},
+			}
+		}
+
+		if err := c.checkKubernetesVersion(&images[0]); err != nil {
+			return preflight.CheckResult{
+				Allowed: false,
+				Error:   true,
+				Causes: []preflight.Cause{
+					{
+						Message: err.Error(),
+						Field:   c.field,
+					},
+				},
+			}
+		}
+	}
+
+	return preflight.CheckResult{Allowed: true}
+}
+
+func (c *imageKubernetesVersionCheck) checkKubernetesVersion(image *vmmv4.Image) error {
+	imageName := ""
+	if image.Name != nil {
+		imageName = *image.Name
+	}
+
+	if imageName == "" {
+		return fmt.Errorf("VM image name is empty")
+	}
+
+	imageK8sVersion, err := extractKubernetesVersionFromImageName(imageName)
+	if err != nil {
+		return fmt.Errorf("failed to extract Kubernetes version from image name '%s': %s. "+
+			"This check assumes NKP image naming convention. "+
+			"You can opt out of this check if using custom image naming", imageName, err)
+	}
+
+	if imageK8sVersion != c.clusterK8sVersion {
+		return fmt.Errorf(
+			"kubernetes version mismatch: cluster version '%s' does not match image version '%s' (from image name '%s')",
+			c.clusterK8sVersion,
+			imageK8sVersion,
+			imageName,
+		)
+	}
+
+	return nil
+}
+
+// Examples: nkp-ubuntu-22.04-vgpu-1.32.3-20250604180644 -> 1.32.3.
+func extractKubernetesVersionFromImageName(imageName string) (string, error) {
+	matches := kubernetesVersionRegex.FindStringSubmatch(imageName)
+	if len(matches) < 2 {
+		return "", fmt.Errorf(
+			"image name does not match expected NKP naming convention (expected pattern: *-<k8s-version>-<timestamp>)",
+		)
+	}
+	return matches[1], nil
+}
+
+func newVMImageKubernetesVersionChecks(
+	cd *checkDependencies,
+) []preflight.Check {
+	checks := make([]preflight.Check, 0)
+
+	if cd.nclient == nil {
+		return checks
+	}
+
+	// Get cluster Kubernetes version for version matching
+	clusterK8sVersion := ""
+	if cd.cluster != nil && cd.cluster.Spec.Topology != nil && cd.cluster.Spec.Topology.Version != "" {
+		clusterK8sVersion = strings.TrimPrefix(cd.cluster.Spec.Topology.Version, "v")
+	}
+
+	// If cluster Kubernetes version is not specified, skip the check.
+	if clusterK8sVersion == "" {
+		return checks
+	}
+
+	if cd.nutanixClusterConfigSpec != nil && cd.nutanixClusterConfigSpec.ControlPlane != nil &&
+		cd.nutanixClusterConfigSpec.ControlPlane.Nutanix != nil {
+		checks = append(checks,
+			&imageKubernetesVersionCheck{
+				machineDetails: &cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.MachineDetails,
+				field: "cluster.spec.topology.variables[.name=clusterConfig]" +
+					".value.nutanix.controlPlane.machineDetails",
+				nclient:           cd.nclient,
+				clusterK8sVersion: clusterK8sVersion,
+			},
+		)
+	}
+
+	for mdName, nutanixWorkerNodeConfigSpec := range cd.nutanixWorkerNodeConfigSpecByMachineDeploymentName {
+		if nutanixWorkerNodeConfigSpec.Nutanix != nil {
+			checks = append(checks,
+				&imageKubernetesVersionCheck{
+					machineDetails: &nutanixWorkerNodeConfigSpec.Nutanix.MachineDetails,
+					field: fmt.Sprintf("cluster.spec.topology.workers.machineDeployments[.name=%s]"+
+						".variables[.name=workerConfig].value.nutanix.machineDetails", mdName),
+					nclient:           cd.nclient,
+					clusterK8sVersion: clusterK8sVersion,
+				},
+			)
+		}
+	}
+
+	return checks
+}

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
@@ -118,7 +118,7 @@ func newVMImageKubernetesVersionChecks(
 			&imageKubernetesVersionCheck{
 				machineDetails: &cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.MachineDetails,
 				field: "cluster.spec.topology.variables[.name=clusterConfig]" +
-					".value.nutanix.controlPlane.machineDetails",
+					".value.nutanix.controlPlane.machineDetails.image",
 				nclient:           cd.nclient,
 				clusterK8sVersion: clusterK8sVersion,
 			},
@@ -131,7 +131,7 @@ func newVMImageKubernetesVersionChecks(
 				&imageKubernetesVersionCheck{
 					machineDetails: &nutanixWorkerNodeConfigSpec.Nutanix.MachineDetails,
 					field: fmt.Sprintf("cluster.spec.topology.workers.machineDeployments[.name=%s]"+
-						".variables[.name=workerConfig].value.nutanix.machineDetails", mdName),
+						".variables[.name=workerConfig].value.nutanix.machineDetails.image", mdName),
 					nclient:           cd.nclient,
 					clusterK8sVersion: clusterK8sVersion,
 				},

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
@@ -62,7 +62,7 @@ func (c *imageKubernetesVersionCheck) Run(ctx context.Context) preflight.CheckRe
 		if err := c.checkKubernetesVersion(&images[0]); err != nil {
 			return preflight.CheckResult{
 				Allowed: false,
-				Error:   true,
+				Error:   false,
 				Causes: []preflight.Cause{
 					{
 						Message: err.Error(),
@@ -95,7 +95,7 @@ func (c *imageKubernetesVersionCheck) checkKubernetesVersion(image *vmmv4.Image)
 
 	if imageK8sVersion != c.clusterK8sVersion {
 		return fmt.Errorf(
-			"kubernetes version mismatch: cluster version '%s' does not match image version '%s' (from image name '%s')",
+			"kubernetes version mismatch: cluster kubernetes version '%s' does not match image kubernetes version '%s' (from image name '%s')", //nolint:lll // error message is long
 			c.clusterK8sVersion,
 			imageK8sVersion,
 			imageName,

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -57,20 +57,26 @@ func TestExtractKubernetesVersionFromImageName(t *testing.T) {
 			wantErr:   false,
 		},
 		{
+			name:      "custom image name with kubernetes-version at end", // e.g., not following NKP naming convention
+			imageName: "custom-image-v1.23",
+			want:      "1.23",
+			wantErr:   false,
+		},
+		{
+			name:      "custom image name with kubernetes version in middle", // e.g., not following NKP naming convention
+			imageName: "custom-v1.23.1-image",
+			want:      "1.23.1",
+			wantErr:   false,
+		},
+		{
+			name:      "custom image name with kubernetes version in start", // e.g., not following NKP naming convention
+			imageName: "v1.23.1-alpha-custom-image",
+			want:      "1.23.1",
+			wantErr:   false,
+		},
+		{
 			name:      "custom image name - no match", // e.g., not following NKP naming convention
 			imageName: "my-custom-image-name",
-			want:      "",
-			wantErr:   true,
-		},
-		{
-			name:      "missing timestamp",
-			imageName: "nkp-ubuntu-22.04-1.32.3",
-			want:      "",
-			wantErr:   true,
-		},
-		{
-			name:      "invalid version format", // e.g., missing patch version
-			imageName: "nkp-ubuntu-22.04-1.32-20250604180644",
 			want:      "",
 			wantErr:   true,
 		},
@@ -88,7 +94,7 @@ func TestExtractKubernetesVersionFromImageName(t *testing.T) {
 
 			if tc.wantErr {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "image name does not match expected NKP naming convention")
+				assert.Contains(t, err.Error(), "image name does not match expected naming convention")
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tc.want, got)
@@ -188,7 +194,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 				Error:   true,
 				Causes: []preflight.Cause{
 					{
-						Message: "failed to extract Kubernetes version from image name 'my-custom-image-name': image name does not match expected NKP naming convention (expected pattern: *-<k8s-version>-<timestamp>). This check assumes NKP image naming convention. You can opt out of this check if using custom image naming", //nolint:lll // cause is long
+						Message: "failed to extract Kubernetes version from image name 'my-custom-image-name': image name does not match expected naming convention (expected pattern: .*<k8s-version>.*). This check assumes a naming convention that includes kubernetes version in the name. You can opt out of this check if using non-compliant naming", //nolint:lll // cause is long
 						Field:   "test-field",
 					},
 				},

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -202,7 +202,7 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 				},
 			},
 			expectedVersion: "1.32.3",
-			expectedChecks:  1,
+			expectedChecks:  2,
 			nclient:         &mocknclient{},
 		},
 		{
@@ -215,7 +215,7 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 				},
 			},
 			expectedVersion: "1.32.3",
-			expectedChecks:  1,
+			expectedChecks:  2,
 			nclient:         &mocknclient{},
 		},
 		{
@@ -250,6 +250,18 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 				cluster: tc.cluster,
 				nutanixClusterConfigSpec: &carenv1.NutanixClusterConfigSpec{
 					ControlPlane: &carenv1.NutanixControlPlaneSpec{
+						Nutanix: &carenv1.NutanixNodeSpec{
+							MachineDetails: carenv1.NutanixMachineDetails{
+								Image: &capxv1.NutanixResourceIdentifier{
+									Type: capxv1.NutanixIdentifierUUID,
+									UUID: ptr.To("test-uuid"),
+								},
+							},
+						},
+					},
+				},
+				nutanixWorkerNodeConfigSpecByMachineDeploymentName: map[string]*carenv1.NutanixWorkerNodeConfigSpec{
+					"test-md": {
 						Nutanix: &carenv1.NutanixNodeSpec{
 							MachineDetails: carenv1.NutanixMachineDetails{
 								Image: &capxv1.NutanixResourceIdentifier{

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -19,90 +19,6 @@ import (
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/webhook/preflight"
 )
 
-func TestExtractKubernetesVersionFromImageName(t *testing.T) {
-	testCases := []struct {
-		name      string
-		imageName string
-		want      string
-		wantErr   bool
-	}{
-		{
-			name:      "kubedistro ubuntu vgpu image",
-			imageName: "kubedistro-ubuntu-22.04-vgpu-1.32.3-20250604180644",
-			want:      "1.32.3",
-			wantErr:   false,
-		},
-		{
-			name:      "kubedistro rocky release cis image",
-			imageName: "kubedistro-rocky-9.5-release-cis-1.32.3-20250430150550",
-			want:      "1.32.3",
-			wantErr:   false,
-		},
-		{
-			name:      "kubedistro rhel fips image",
-			imageName: "kubedistro-rhel-8.10-fips-1.32.3-20250505212227",
-			want:      "1.32.3",
-			wantErr:   false,
-		},
-		{
-			name:      "kubedistro rocky basic image",
-			imageName: "kubedistro-rocky-9.5-1.32.3-20250514222748",
-			want:      "1.32.3",
-			wantErr:   false,
-		},
-		{
-			name:      "different k8s version",
-			imageName: "kubedistro-ubuntu-22.04-1.31.5-20250101000000",
-			want:      "1.31.5",
-			wantErr:   false,
-		},
-		{
-			name:      "custom image name with kubernetes-version at end", // e.g., not following kubedistro naming convention
-			imageName: "custom-image-v1.23",
-			want:      "1.23",
-			wantErr:   false,
-		},
-		{
-			name:      "custom image name with kubernetes version in middle", // e.g., not following kubedistro naming convention
-			imageName: "custom-v1.23.1-image",
-			want:      "1.23.1",
-			wantErr:   false,
-		},
-		{
-			name:      "custom image name with kubernetes version in start", // e.g., not following kubedistro naming convention
-			imageName: "v1.23.1-alpha-custom-image",
-			want:      "1.23.1",
-			wantErr:   false,
-		},
-		{
-			name:      "custom image name - no match", // e.g., not following kubedistro naming convention
-			imageName: "my-custom-image-name",
-			want:      "",
-			wantErr:   true,
-		},
-		{
-			name:      "empty image name",
-			imageName: "",
-			want:      "",
-			wantErr:   true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := extractKubernetesVersionFromImageName(tc.imageName)
-
-			if tc.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "image name does not match expected naming convention")
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tc.want, got)
-			}
-		})
-	}
-}
-
 func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 	testCases := []struct {
 		name              string
@@ -162,7 +78,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 				Error:   false,
 				Causes: []preflight.Cause{
 					{
-						Message: "kubernetes version mismatch: cluster kubernetes version '1.32.3' does not match image kubernetes version '1.31.5' (from image name 'kubedistro-ubuntu-22.04-vgpu-1.31.5-20250604180644')", //nolint:lll // cause is long
+						Message: "cluster kubernetes version '1.32.3' is not part of image name 'kubedistro-ubuntu-22.04-vgpu-1.31.5-20250604180644'", //nolint:lll // cause message is long
 						Field:   "test-field",
 					},
 				},
@@ -194,7 +110,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 				Error:   false,
 				Causes: []preflight.Cause{
 					{
-						Message: "failed to extract Kubernetes version from image name 'my-custom-image-name': image name does not match expected naming convention (expected pattern: .*<k8s-version>.*). This check assumes a naming convention that includes kubernetes version in the name. You can opt out of this check if using non-compliant naming", //nolint:lll // cause is long
+						Message: "cluster kubernetes version '1.32.3' is not part of image name 'my-custom-image-name'",
 						Field:   "test-field",
 					},
 				},

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -27,55 +27,55 @@ func TestExtractKubernetesVersionFromImageName(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:      "nkp ubuntu vgpu image",
-			imageName: "nkp-ubuntu-22.04-vgpu-1.32.3-20250604180644",
+			name:      "kubedistro ubuntu vgpu image",
+			imageName: "kubedistro-ubuntu-22.04-vgpu-1.32.3-20250604180644",
 			want:      "1.32.3",
 			wantErr:   false,
 		},
 		{
-			name:      "nkp rocky release cis image",
-			imageName: "nkp-rocky-9.5-release-cis-1.32.3-20250430150550",
+			name:      "kubedistro rocky release cis image",
+			imageName: "kubedistro-rocky-9.5-release-cis-1.32.3-20250430150550",
 			want:      "1.32.3",
 			wantErr:   false,
 		},
 		{
-			name:      "nkp rhel fips image",
-			imageName: "nkp-rhel-8.10-fips-1.32.3-20250505212227",
+			name:      "kubedistro rhel fips image",
+			imageName: "kubedistro-rhel-8.10-fips-1.32.3-20250505212227",
 			want:      "1.32.3",
 			wantErr:   false,
 		},
 		{
-			name:      "nkp rocky basic image",
-			imageName: "nkp-rocky-9.5-1.32.3-20250514222748",
+			name:      "kubedistro rocky basic image",
+			imageName: "kubedistro-rocky-9.5-1.32.3-20250514222748",
 			want:      "1.32.3",
 			wantErr:   false,
 		},
 		{
 			name:      "different k8s version",
-			imageName: "nkp-ubuntu-22.04-1.31.5-20250101000000",
+			imageName: "kubedistro-ubuntu-22.04-1.31.5-20250101000000",
 			want:      "1.31.5",
 			wantErr:   false,
 		},
 		{
-			name:      "custom image name with kubernetes-version at end", // e.g., not following NKP naming convention
+			name:      "custom image name with kubernetes-version at end", // e.g., not following kubedistro naming convention
 			imageName: "custom-image-v1.23",
 			want:      "1.23",
 			wantErr:   false,
 		},
 		{
-			name:      "custom image name with kubernetes version in middle", // e.g., not following NKP naming convention
+			name:      "custom image name with kubernetes version in middle", // e.g., not following kubedistro naming convention
 			imageName: "custom-v1.23.1-image",
 			want:      "1.23.1",
 			wantErr:   false,
 		},
 		{
-			name:      "custom image name with kubernetes version in start", // e.g., not following NKP naming convention
+			name:      "custom image name with kubernetes version in start", // e.g., not following kubedistro naming convention
 			imageName: "v1.23.1-alpha-custom-image",
 			want:      "1.23.1",
 			wantErr:   false,
 		},
 		{
-			name:      "custom image name - no match", // e.g., not following NKP naming convention
+			name:      "custom image name - no match", // e.g., not following kubedistro naming convention
 			imageName: "my-custom-image-name",
 			want:      "",
 			wantErr:   true,
@@ -119,7 +119,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 					err := resp.SetData(vmmv4.Image{
 						ObjectType_: ptr.To("vmm.v4.content.Image"),
 						ExtId:       ptr.To("test-uuid"),
-						Name:        ptr.To("nkp-ubuntu-22.04-vgpu-1.32.3-20250604180644"),
+						Name:        ptr.To("kubedistro-ubuntu-22.04-vgpu-1.32.3-20250604180644"),
 					})
 					require.NoError(t, err)
 					return resp, nil
@@ -144,7 +144,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 					err := resp.SetData(vmmv4.Image{
 						ObjectType_: ptr.To("vmm.v4.content.Image"),
 						ExtId:       ptr.To("test-uuid"),
-						Name:        ptr.To("nkp-ubuntu-22.04-vgpu-1.31.5-20250604180644"),
+						Name:        ptr.To("kubedistro-ubuntu-22.04-vgpu-1.31.5-20250604180644"),
 					})
 					require.NoError(t, err)
 					return resp, nil
@@ -162,7 +162,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 				Error:   true,
 				Causes: []preflight.Cause{
 					{
-						Message: "kubernetes version mismatch: cluster version '1.32.3' does not match image version '1.31.5' (from image name 'nkp-ubuntu-22.04-vgpu-1.31.5-20250604180644')", //nolint:lll // cause is long
+						Message: "kubernetes version mismatch: cluster version '1.32.3' does not match image version '1.31.5' (from image name 'kubedistro-ubuntu-22.04-vgpu-1.31.5-20250604180644')", //nolint:lll // cause is long
 						Field:   "test-field",
 					},
 				},

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -190,6 +190,7 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 		cluster         *clusterv1.Cluster
 		expectedVersion string
 		expectedChecks  int
+		nclient         client
 	}{
 		{
 			name: "cluster with topology version",
@@ -202,6 +203,7 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 			},
 			expectedVersion: "1.32.3",
 			expectedChecks:  1,
+			nclient:         &mocknclient{},
 		},
 		{
 			name: "cluster with topology version without v prefix",
@@ -214,6 +216,7 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 			},
 			expectedVersion: "1.32.3",
 			expectedChecks:  1,
+			nclient:         &mocknclient{},
 		},
 		{
 			name: "cluster without topology",
@@ -224,6 +227,20 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 			},
 			expectedVersion: "",
 			expectedChecks:  0,
+			nclient:         &mocknclient{},
+		},
+		{
+			name: "client not initialized",
+			cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Version: "v1.32.3",
+					},
+				},
+			},
+			expectedVersion: "1.32.3",
+			expectedChecks:  0,
+			nclient:         nil,
 		},
 	}
 
@@ -243,7 +260,7 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 						},
 					},
 				},
-				nclient: &mocknclient{},
+				nclient: tc.nclient,
 				log:     testr.New(t),
 			}
 

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -148,6 +148,22 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "imageLookup not yet supported",
+			nclient: &mocknclient{},
+			machineDetails: &carenv1.NutanixMachineDetails{
+				ImageLookup: &capxv1.NutanixImageLookup{
+					Format: ptr.To("test-format"),
+					BaseOS: "test-baseos",
+				},
+			},
+			want: preflight.CheckResult{
+				Allowed: true,
+				Warnings: []string{
+					"test-field uses imageLookup, which is not yet supported by checks",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -159,7 +159,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 			clusterK8sVersion: "1.32.3",
 			want: preflight.CheckResult{
 				Allowed: false,
-				Error:   true,
+				Error:   false,
 				Causes: []preflight.Cause{
 					{
 						Message: "kubernetes version mismatch: cluster kubernetes version '1.32.3' does not match image kubernetes version '1.31.5' (from image name 'kubedistro-ubuntu-22.04-vgpu-1.31.5-20250604180644')", //nolint:lll // cause is long
@@ -191,7 +191,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 			clusterK8sVersion: "1.32.3",
 			want: preflight.CheckResult{
 				Allowed: false,
-				Error:   true,
+				Error:   false,
 				Causes: []preflight.Cause{
 					{
 						Message: "failed to extract Kubernetes version from image name 'my-custom-image-name': image name does not match expected naming convention (expected pattern: .*<k8s-version>.*). This check assumes a naming convention that includes kubernetes version in the name. You can opt out of this check if using non-compliant naming", //nolint:lll // cause is long
@@ -223,7 +223,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 			clusterK8sVersion: "1.32.3",
 			want: preflight.CheckResult{
 				Allowed: false,
-				Error:   true,
+				Error:   false,
 				Causes: []preflight.Cause{
 					{
 						Message: "VM image name is empty",

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -1,0 +1,321 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nutanix
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	vmmv4 "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/content"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	capxv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
+	carenv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/webhook/preflight"
+)
+
+func TestExtractKubernetesVersionFromImageName(t *testing.T) {
+	testCases := []struct {
+		name      string
+		imageName string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "nkp ubuntu vgpu image",
+			imageName: "nkp-ubuntu-22.04-vgpu-1.32.3-20250604180644",
+			want:      "1.32.3",
+			wantErr:   false,
+		},
+		{
+			name:      "nkp rocky release cis image",
+			imageName: "nkp-rocky-9.5-release-cis-1.32.3-20250430150550",
+			want:      "1.32.3",
+			wantErr:   false,
+		},
+		{
+			name:      "nkp rhel fips image",
+			imageName: "nkp-rhel-8.10-fips-1.32.3-20250505212227",
+			want:      "1.32.3",
+			wantErr:   false,
+		},
+		{
+			name:      "nkp rocky basic image",
+			imageName: "nkp-rocky-9.5-1.32.3-20250514222748",
+			want:      "1.32.3",
+			wantErr:   false,
+		},
+		{
+			name:      "different k8s version",
+			imageName: "nkp-ubuntu-22.04-1.31.5-20250101000000",
+			want:      "1.31.5",
+			wantErr:   false,
+		},
+		{
+			name:      "custom image name - no match", // e.g., not following NKP naming convention
+			imageName: "my-custom-image-name",
+			want:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "missing timestamp",
+			imageName: "nkp-ubuntu-22.04-1.32.3",
+			want:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid version format", // e.g., missing patch version
+			imageName: "nkp-ubuntu-22.04-1.32-20250604180644",
+			want:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "empty image name",
+			imageName: "",
+			want:      "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractKubernetesVersionFromImageName(tc.imageName)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "image name does not match expected NKP naming convention")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
+	testCases := []struct {
+		name              string
+		nclient           client
+		machineDetails    *carenv1.NutanixMachineDetails
+		clusterK8sVersion string
+		want              preflight.CheckResult
+	}{
+		{
+			name: "kubernetes version matches",
+			nclient: &mocknclient{
+				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+					resp := &vmmv4.GetImageApiResponse{}
+					err := resp.SetData(vmmv4.Image{
+						ObjectType_: ptr.To("vmm.v4.content.Image"),
+						ExtId:       ptr.To("test-uuid"),
+						Name:        ptr.To("nkp-ubuntu-22.04-vgpu-1.32.3-20250604180644"),
+					})
+					require.NoError(t, err)
+					return resp, nil
+				},
+			},
+			machineDetails: &carenv1.NutanixMachineDetails{
+				Image: &capxv1.NutanixResourceIdentifier{
+					Type: capxv1.NutanixIdentifierUUID,
+					UUID: ptr.To("test-uuid"),
+				},
+			},
+			clusterK8sVersion: "1.32.3",
+			want: preflight.CheckResult{
+				Allowed: true,
+			},
+		},
+		{
+			name: "kubernetes version mismatch",
+			nclient: &mocknclient{
+				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+					resp := &vmmv4.GetImageApiResponse{}
+					err := resp.SetData(vmmv4.Image{
+						ObjectType_: ptr.To("vmm.v4.content.Image"),
+						ExtId:       ptr.To("test-uuid"),
+						Name:        ptr.To("nkp-ubuntu-22.04-vgpu-1.31.5-20250604180644"),
+					})
+					require.NoError(t, err)
+					return resp, nil
+				},
+			},
+			machineDetails: &carenv1.NutanixMachineDetails{
+				Image: &capxv1.NutanixResourceIdentifier{
+					Type: capxv1.NutanixIdentifierUUID,
+					UUID: ptr.To("test-uuid"),
+				},
+			},
+			clusterK8sVersion: "1.32.3",
+			want: preflight.CheckResult{
+				Allowed: false,
+				Error:   true,
+				Causes: []preflight.Cause{
+					{
+						Message: "kubernetes version mismatch: cluster version '1.32.3' does not match image version '1.31.5' (from image name 'nkp-ubuntu-22.04-vgpu-1.31.5-20250604180644')", //nolint:lll // cause is long
+						Field:   "test-field",
+					},
+				},
+			},
+		},
+		{
+			name: "custom image name - extraction fails",
+			nclient: &mocknclient{
+				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+					resp := &vmmv4.GetImageApiResponse{}
+					err := resp.SetData(vmmv4.Image{
+						ObjectType_: ptr.To("vmm.v4.content.Image"),
+						ExtId:       ptr.To("test-uuid"),
+						Name:        ptr.To("my-custom-image-name"),
+					})
+					require.NoError(t, err)
+					return resp, nil
+				},
+			},
+			machineDetails: &carenv1.NutanixMachineDetails{
+				Image: &capxv1.NutanixResourceIdentifier{
+					Type: capxv1.NutanixIdentifierUUID,
+					UUID: ptr.To("test-uuid"),
+				},
+			},
+			clusterK8sVersion: "1.32.3",
+			want: preflight.CheckResult{
+				Allowed: false,
+				Error:   true,
+				Causes: []preflight.Cause{
+					{
+						Message: "failed to extract Kubernetes version from image name 'my-custom-image-name': image name does not match expected NKP naming convention (expected pattern: *-<k8s-version>-<timestamp>). This check assumes NKP image naming convention. You can opt out of this check if using custom image naming", //nolint:lll // cause is long
+						Field:   "test-field",
+					},
+				},
+			},
+		},
+		{
+			name: "empty image name",
+			nclient: &mocknclient{
+				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+					resp := &vmmv4.GetImageApiResponse{}
+					err := resp.SetData(vmmv4.Image{
+						ObjectType_: ptr.To("vmm.v4.content.Image"),
+						ExtId:       ptr.To("test-uuid"),
+						Name:        nil, // empty name
+					})
+					require.NoError(t, err)
+					return resp, nil
+				},
+			},
+			machineDetails: &carenv1.NutanixMachineDetails{
+				Image: &capxv1.NutanixResourceIdentifier{
+					Type: capxv1.NutanixIdentifierUUID,
+					UUID: ptr.To("test-uuid"),
+				},
+			},
+			clusterK8sVersion: "1.32.3",
+			want: preflight.CheckResult{
+				Allowed: false,
+				Error:   true,
+				Causes: []preflight.Cause{
+					{
+						Message: "VM image name is empty",
+						Field:   "test-field",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			check := &imageKubernetesVersionCheck{
+				machineDetails:    tc.machineDetails,
+				field:             "test-field",
+				nclient:           tc.nclient,
+				clusterK8sVersion: tc.clusterK8sVersion,
+			}
+
+			got := check.Run(context.Background())
+
+			assert.Equal(t, tc.want.Allowed, got.Allowed)
+			assert.Equal(t, tc.want.Error, got.Error)
+			assert.Equal(t, tc.want.Causes, got.Causes)
+		})
+	}
+}
+
+func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
+	testCases := []struct {
+		name            string
+		cluster         *clusterv1.Cluster
+		expectedVersion string
+		expectedChecks  int
+	}{
+		{
+			name: "cluster with topology version",
+			cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Version: "v1.32.3",
+					},
+				},
+			},
+			expectedVersion: "1.32.3",
+			expectedChecks:  1,
+		},
+		{
+			name: "cluster with topology version without v prefix",
+			cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Version: "1.32.3",
+					},
+				},
+			},
+			expectedVersion: "1.32.3",
+			expectedChecks:  1,
+		},
+		{
+			name: "cluster without topology",
+			cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: nil,
+				},
+			},
+			expectedVersion: "",
+			expectedChecks:  0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cd := &checkDependencies{
+				cluster: tc.cluster,
+				nutanixClusterConfigSpec: &carenv1.NutanixClusterConfigSpec{
+					ControlPlane: &carenv1.NutanixControlPlaneSpec{
+						Nutanix: &carenv1.NutanixNodeSpec{
+							MachineDetails: carenv1.NutanixMachineDetails{
+								Image: &capxv1.NutanixResourceIdentifier{
+									Type: capxv1.NutanixIdentifierUUID,
+									UUID: ptr.To("test-uuid"),
+								},
+							},
+						},
+					},
+				},
+				nclient: &mocknclient{},
+				log:     testr.New(t),
+			}
+
+			checks := newVMImageKubernetesVersionChecks(cd)
+
+			require.Len(t, checks, tc.expectedChecks, "unexpected number of checks created")
+			if tc.expectedChecks != 0 {
+				check := checks[0].(*imageKubernetesVersionCheck)
+				assert.Equal(t, tc.expectedVersion, check.clusterK8sVersion)
+			}
+		})
+	}
+}

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -162,7 +162,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 				Error:   true,
 				Causes: []preflight.Cause{
 					{
-						Message: "kubernetes version mismatch: cluster version '1.32.3' does not match image version '1.31.5' (from image name 'kubedistro-ubuntu-22.04-vgpu-1.31.5-20250604180644')", //nolint:lll // cause is long
+						Message: "kubernetes version mismatch: cluster kubernetes version '1.32.3' does not match image kubernetes version '1.31.5' (from image name 'kubedistro-ubuntu-22.04-vgpu-1.31.5-20250604180644')", //nolint:lll // cause is long
 						Field:   "test-field",
 					},
 				},


### PR DESCRIPTION
This check ensures images that have the standard NKP naming scheme have the image with the same kubernetes version as the cluster version.

**How has this been tested?**
create a cluster using `nkp create cluster nutanix --dry-run` and tweak the image kubernetes version to be different from cluster kubernetes version.
```
$ cat cluster.yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  ...
  name: nkp-sid
  namespace: default
spec:
  ...
  topology:
    ...
    variables:
    - name: clusterConfig
      value:
        ...
        controlPlane:
          nutanix:
            machineDetails:
              ...
              image:
                name: nkp-rocky-9.5-release-1.31.4-20250214003015.qcow2
                type: name
    version: v1.32.3
    workers:
      machineDeployments:
      - class: default-worker
        ...
        name: md-0
        variables:
          overrides:
          - name: workerConfig
            value:
              nutanix:
                machineDetails:
                  ...
                  image:
                    name: nkp-rocky-9.5-release-1.31.4-20250214003015.qcow2
                    type: name
```
create the cluster
```
$ k apply -f cluster.yaml -v4
The request is invalid: 
* cluster.spec.topology.variables[.name=clusterConfig].value.nutanix.controlPlane.machineDetails: kubernetes version mismatch: cluster kubernetes version '1.32.3' does not match image kubernetes version '1.31.4' (from image name 'nkp-rocky-9.5-release-1.31.4-20250214003015.qcow2')
* cluster.spec.topology.workers.machineDeployments[.name=md-0].variables[.name=workerConfig].value.nutanix.machineDetails: kubernetes version mismatch: cluster kubernetes version '1.32.3' does not match image kubernetes version '1.31.4' (from image name 'nkp-rocky-9.5-release-1.31.4-20250214003015.qcow2')
```