### PR TITLE
fix: Do not run preflight checks if Cluster is paused

### DIFF
--- a/pkg/webhook/preflight/preflight.go
+++ b/pkg/webhook/preflight/preflight.go
@@ -95,6 +95,12 @@ func (h *WebhookHandler) Handle(ctx context.Context, req admission.Request) admi
 		return admission.Allowed("")
 	}
 
+	if cluster.Spec.Paused {
+		// If the cluster is paused, skip all checks.
+		// This allows the cluster to be moved to another API server without running checks.
+		return admission.Allowed("")
+	}
+
 	skipEvaluator := skip.New(cluster)
 
 	if skipEvaluator.ForAll() {

--- a/pkg/webhook/preflight/preflight_test.go
+++ b/pkg/webhook/preflight/preflight_test.go
@@ -998,3 +998,39 @@ func TestRun_ZeroChecksFromChecker(t *testing.T) {
 
 	assert.Equal(t, "check1", normalResults[0].Name, "expected result name to be 'check1'")
 }
+
+func TestHandle_ClusterPaused(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := clusterv1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	decoder := admission.NewDecoder(scheme)
+
+	// Create a paused cluster
+	cluster := topologyCluster()
+	cluster.Spec.Paused = true
+
+	handler := New(fake.NewClientBuilder().Build(), decoder)
+
+	ctx := context.Background()
+
+	// Create admission request
+	jsonCluster, err := json.Marshal(cluster)
+	require.NoError(t, err)
+
+	admissionReq := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Object: runtime.RawExtension{
+				Raw: jsonCluster,
+			},
+		},
+	}
+
+	// Handle the request
+	got := handler.Handle(ctx, admissionReq)
+
+	// Check response - should be allowed without warnings for paused cluster
+	assert.True(t, got.Allowed, "expected response to be allowed for paused cluster")
+	assert.Empty(t, got.Warnings, "expected no warnings for paused cluster")
+}


### PR DESCRIPTION
**What problem does this PR solve?**:
When clusterctl moves the Cluster, clusterctl first creates a paused Cluster object, then the referenced Secrets. That order might be a bug. However, to allow move to work, we want to skip preflight checks.  

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
