### PR TITLE
fix: Misc fixes to the preflight framework

### DIFF
--- a/pkg/webhook/preflight/preflight.go
+++ b/pkg/webhook/preflight/preflight.go
@@ -131,11 +131,13 @@ func (h *WebhookHandler) Handle(ctx context.Context, req admission.Request) admi
 				resp.Allowed = false
 			}
 			for _, cause := range result.Causes {
-				resp.Result.Details.Causes = append(resp.Result.Details.Causes, metav1.StatusCause{
-					Type:    metav1.CauseType(fmt.Sprintf("FailedPreflight%s", result.Name)),
-					Message: cause.Message,
-					Field:   cause.Field,
-				})
+				resp.Result.Details.Causes = append(resp.Result.Details.Causes,
+					metav1.StatusCause{
+						Type:    metav1.CauseType(result.Name),
+						Message: cause.Message,
+						Field:   cause.Field,
+					},
+				)
 			}
 			resp.Warnings = append(resp.Warnings, result.Warnings...)
 		}

--- a/pkg/webhook/preflight/preflight.go
+++ b/pkg/webhook/preflight/preflight.go
@@ -84,6 +84,10 @@ func (h *WebhookHandler) Handle(ctx context.Context, req admission.Request) admi
 		return admission.Allowed("")
 	}
 
+	if req.Operation == admissionv1.Update {
+		return admission.Allowed("")
+	}
+
 	cluster := &clusterv1.Cluster{}
 	err := h.decoder.Decode(req, cluster)
 	if err != nil {

--- a/pkg/webhook/preflight/preflight.go
+++ b/pkg/webhook/preflight/preflight.go
@@ -185,6 +185,12 @@ func run(ctx context.Context,
 
 			checksWG := sync.WaitGroup{}
 			for j, check := range checks {
+				ctrl.LoggerFrom(ctx).V(5).Info(
+					"running preflight check",
+					"checkName", check.Name(),
+					"clusterName", cluster.Name,
+					"clusterNamespace", cluster.Namespace,
+				)
 				if skipEvaluator.For(check.Name()) {
 					resultsOrderedByCheck[j] = namedResult{
 						Name: check.Name(),

--- a/pkg/webhook/preflight/preflight_test.go
+++ b/pkg/webhook/preflight/preflight_test.go
@@ -248,7 +248,7 @@ func TestHandle(t *testing.T) {
 						Details: &metav1.StatusDetails{
 							Causes: []metav1.StatusCause{
 								{
-									Type:    "FailedPreflightTest1",
+									Type:    "Test1",
 									Field:   "spec.test",
 									Message: "test failed",
 								},
@@ -342,11 +342,11 @@ func TestHandle(t *testing.T) {
 						Details: &metav1.StatusDetails{
 							Causes: []metav1.StatusCause{
 								{
-									Type:    "FailedPreflightTest2",
+									Type:    "Test2",
 									Message: "check failed",
 								},
 								{
-									Type:    "FailedPreflightTest1",
+									Type:    "Test1",
 									Message: "internal error",
 								},
 							},
@@ -475,11 +475,11 @@ func TestHandleCancelledContext(t *testing.T) {
 				Details: &metav1.StatusDetails{
 					Causes: []metav1.StatusCause{
 						{
-							Type:    "FailedPreflightTest1",
+							Type:    "Test1",
 							Message: "context cancelled",
 						},
 						{
-							Type:    "FailedPreflightTest2",
+							Type:    "Test2",
 							Message: "context cancelled",
 						},
 					},


### PR DESCRIPTION
**What problem does this PR solve?**:
- Skip preflight on Cluster update. This is defensive programming. The webhook is already configured to only run on create. When we support for update, we will remove this, and reconfigure the webhook.
- Use preflight check name as cause type. Previously, the "FailedPreflight" prefix was present, but it makes it more difficult to identify the name of the check that failed, and the prefix is not necessary, because the top-level Message explains that preflight checks failed.
- Debug log message when preflight check runs.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
