### PR TITLE
fix: Do not treat expected preflight check failures as internal errors

### DIFF
--- a/pkg/webhook/preflight/generic/registry.go
+++ b/pkg/webhook/preflight/generic/registry.go
@@ -77,7 +77,7 @@ func (r *registryCheck) checkRegistry(
 	registryURLParsed, err := url.ParseRequestURI(registryURL)
 	if err != nil {
 		result.Allowed = false
-		result.Error = false
+		result.InternalError = false
 		result.Causes = append(result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("failed to parse registry url %s with error: %s", registryURL, err),
@@ -101,7 +101,7 @@ func (r *registryCheck) checkRegistry(
 		)
 		if apierrors.IsNotFound(err) {
 			result.Allowed = false
-			result.Error = false
+			result.InternalError = false
 			result.Causes = append(result.Causes,
 				preflight.Cause{
 					Message: fmt.Sprintf("Registry credentials Secret %q not found", credentials.SecretRef.Name),
@@ -112,7 +112,7 @@ func (r *registryCheck) checkRegistry(
 		}
 		if err != nil {
 			result.Allowed = false
-			result.Error = true
+			result.InternalError = true
 			result.Causes = append(result.Causes,
 				preflight.Cause{
 					Message: fmt.Sprintf("failed to get Registry credentials Secret: %s", err),
@@ -157,7 +157,7 @@ func (r *registryCheck) checkRegistry(
 		return result
 	}
 	result.Allowed = true
-	result.Error = false
+	result.InternalError = false
 	return result
 }
 

--- a/pkg/webhook/preflight/generic/registry_test.go
+++ b/pkg/webhook/preflight/generic/registry_test.go
@@ -131,8 +131,8 @@ func TestRegistryCheck(t *testing.T) {
 				},
 			},
 			want: preflight.CheckResult{
-				Allowed: false,
-				Error:   true,
+				Allowed:       false,
+				InternalError: true,
 				Causes: []preflight.Cause{
 					{
 						Message: "failed to get Registry credentials Secret: fake error",
@@ -163,8 +163,8 @@ func TestRegistryCheck(t *testing.T) {
 				},
 			},
 			want: preflight.CheckResult{
-				Allowed: false,
-				Error:   false,
+				Allowed:       false,
+				InternalError: false,
 				Causes: []preflight.Cause{
 					{
 						Message: "Registry credentials Secret \"test-secret\" not found",
@@ -264,8 +264,8 @@ func TestRegistryCheck(t *testing.T) {
 				}
 			},
 			want: preflight.CheckResult{
-				Allowed: false,
-				Error:   false,
+				Allowed:       false,
+				InternalError: false,
 				Causes: []preflight.Cause{
 					{
 						Message: fmt.Sprintf("failed to parse registry url %s with error: "+
@@ -311,7 +311,7 @@ func TestRegistryCheck(t *testing.T) {
 
 			// Verify the result
 			assert.Equal(t, tc.want.Allowed, got.Allowed, "(allowed) mismatch for test "+tc.name)
-			assert.Equal(t, tc.want.Error, got.Error, "(error) mismatch test "+tc.name)
+			assert.Equal(t, tc.want.InternalError, got.InternalError, "(error) mismatch test "+tc.name)
 			assert.Equal(t, tc.want.Causes, got.Causes, "(causes) mismatch test "+tc.name)
 		})
 	}

--- a/pkg/webhook/preflight/generic/spec.go
+++ b/pkg/webhook/preflight/generic/spec.go
@@ -42,7 +42,7 @@ func newConfigurationCheck(
 	)
 	if err != nil {
 		configurationCheck.result.Allowed = false
-		configurationCheck.result.Error = true
+		configurationCheck.result.InternalError = true
 		configurationCheck.result.Causes = append(configurationCheck.result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("Failed to unmarshal cluster variable %s: %s",

--- a/pkg/webhook/preflight/generic/spec_test.go
+++ b/pkg/webhook/preflight/generic/spec_test.go
@@ -102,8 +102,8 @@ func TestNewConfigurationCheck(t *testing.T) {
 				},
 			},
 			expectedResult: preflight.CheckResult{
-				Allowed: false,
-				Error:   true,
+				Allowed:       false,
+				InternalError: true,
 				Causes: []preflight.Cause{
 					{
 						Message: "Failed to unmarshal cluster variable clusterConfig: failed to unmarshal json:" +

--- a/pkg/webhook/preflight/nutanix/credentials.go
+++ b/pkg/webhook/preflight/nutanix/credentials.go
@@ -89,7 +89,7 @@ func newCredentialsCheck(
 	)
 	if apierrors.IsNotFound(err) {
 		credentialsCheck.result.Allowed = false
-		credentialsCheck.result.Error = false
+		credentialsCheck.result.InternalError = false
 		credentialsCheck.result.Causes = append(credentialsCheck.result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("Prism Central credentials Secret %q not found",
@@ -101,7 +101,7 @@ func newCredentialsCheck(
 	}
 	if err != nil {
 		credentialsCheck.result.Allowed = false
-		credentialsCheck.result.Error = true
+		credentialsCheck.result.InternalError = true
 		credentialsCheck.result.Causes = append(credentialsCheck.result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("Failed to get Prism Central credentials Secret %q: %s",
@@ -169,7 +169,7 @@ func newCredentialsCheck(
 	nclient, err := nclientFactory(credentials)
 	if err != nil {
 		credentialsCheck.result.Allowed = false
-		credentialsCheck.result.Error = true
+		credentialsCheck.result.InternalError = true
 		credentialsCheck.result.Causes = append(credentialsCheck.result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("Failed to initialize Nutanix client: %s", err),
@@ -183,7 +183,7 @@ func newCredentialsCheck(
 	_, err = nclient.GetCurrentLoggedInUser(ctx)
 	if err != nil {
 		credentialsCheck.result.Allowed = false
-		credentialsCheck.result.Error = true
+		credentialsCheck.result.InternalError = true
 		credentialsCheck.result.Causes = append(credentialsCheck.result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("Failed to validate credentials using the v3 API client. "+

--- a/pkg/webhook/preflight/nutanix/credentials_test.go
+++ b/pkg/webhook/preflight/nutanix/credentials_test.go
@@ -5,12 +5,15 @@ package nutanix
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
@@ -52,7 +55,7 @@ func TestNewCredentialsCheck_MissingNutanixField(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.True(t, result.Error)
+	assert.False(t, result.Error)
 	assert.NotEmpty(t, result.Causes)
 	assert.Contains(t, result.Causes[0].Message, "Nutanix cluster configuration is not defined")
 }
@@ -66,7 +69,7 @@ func TestNewCredentialsCheck_InvalidURL(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.True(t, result.Error)
+	assert.False(t, result.Error)
 	assert.Contains(t, result.Causes[0].Message, "failed to parse Prism Central endpoint URL")
 }
 
@@ -79,8 +82,46 @@ func TestNewCredentialsCheck_SecretNotFound(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
+	assert.False(t, result.Error)
+	assert.Contains(t, result.Causes[0].Message, "Prism Central credentials Secret \"ntnx-creds\" not found")
+}
+
+type fakeK8sSecretClient struct {
+	ctrlclient.Client
+	getSecretFunc func(context.Context, types.NamespacedName, ctrlclient.Object, ...ctrlclient.GetOption) error
+}
+
+func (m *fakeK8sSecretClient) Get(
+	ctx context.Context,
+	key types.NamespacedName,
+	obj ctrlclient.Object,
+	opts ...ctrlclient.GetOption,
+) error {
+	if m.getSecretFunc != nil {
+		return m.getSecretFunc(ctx, key, obj, opts...)
+	}
+	return nil
+}
+
+func TestNewCredentialsCheck_SecretGetError(t *testing.T) {
+	cd := validCheckDependencies()
+	cd.kclient = &fakeK8sSecretClient{
+		getSecretFunc: func(ctx context.Context,
+			key types.NamespacedName,
+			obj ctrlclient.Object,
+			opts ...ctrlclient.GetOption,
+		) error {
+			return fmt.Errorf("fake error")
+		},
+	}
+	nclientFactory := func(_ prismgoclient.Credentials) (client, error) {
+		return &mocknclient{}, nil
+	}
+	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
+	result := check.Run(context.Background())
+	assert.False(t, result.Allowed)
 	assert.True(t, result.Error)
-	assert.Contains(t, result.Causes[0].Message, "failed to get Prism Central credentials Secret")
+	assert.Contains(t, result.Causes[0].Message, "Failed to get Prism Central credentials Secret \"ntnx-creds\": fake error")
 }
 
 func TestNewCredentialsCheck_SecretEmpty(t *testing.T) {
@@ -99,8 +140,8 @@ func TestNewCredentialsCheck_SecretEmpty(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.True(t, result.Error)
-	assert.Contains(t, result.Causes[0].Message, "credentials Secret 'ntnx-creds' is empty")
+	assert.False(t, result.Error)
+	assert.Contains(t, result.Causes[0].Message, "credentials Secret \"ntnx-creds\" is empty")
 }
 
 func TestNewCredentialsCheck_SecretMissingKey(t *testing.T) {
@@ -118,8 +159,8 @@ func TestNewCredentialsCheck_SecretMissingKey(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nil, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.True(t, result.Error)
-	assert.Contains(t, result.Causes[0].Message, "does not contain key 'credentials'")
+	assert.False(t, result.Error)
+	assert.Contains(t, result.Causes[0].Message, "does not contain key \"credentials\"")
 }
 
 func TestNewCredentialsCheck_InvalidCredentialsFormat(t *testing.T) {
@@ -140,7 +181,7 @@ func TestNewCredentialsCheck_InvalidCredentialsFormat(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.True(t, result.Error)
+	assert.False(t, result.Error)
 	assert.Contains(t, result.Causes[0].Message, "failed to parse Prism Central credentials")
 }
 

--- a/pkg/webhook/preflight/nutanix/credentials_test.go
+++ b/pkg/webhook/preflight/nutanix/credentials_test.go
@@ -29,7 +29,7 @@ func TestNewCredentialsCheck_Success(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.True(t, result.Allowed)
-	assert.False(t, result.Error)
+	assert.False(t, result.InternalError)
 	assert.Empty(t, result.Causes)
 }
 
@@ -42,7 +42,7 @@ func TestNewCredentialsCheck_NoNutanixConfig(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.True(t, result.Allowed)
-	assert.False(t, result.Error)
+	assert.False(t, result.InternalError)
 	assert.Empty(t, result.Causes)
 }
 
@@ -55,7 +55,7 @@ func TestNewCredentialsCheck_MissingNutanixField(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.False(t, result.Error)
+	assert.False(t, result.InternalError)
 	assert.NotEmpty(t, result.Causes)
 	assert.Contains(t, result.Causes[0].Message, "Nutanix cluster configuration is not defined")
 }
@@ -69,7 +69,7 @@ func TestNewCredentialsCheck_InvalidURL(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.False(t, result.Error)
+	assert.False(t, result.InternalError)
 	assert.Contains(t, result.Causes[0].Message, "failed to parse Prism Central endpoint URL")
 }
 
@@ -82,7 +82,7 @@ func TestNewCredentialsCheck_SecretNotFound(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.False(t, result.Error)
+	assert.False(t, result.InternalError)
 	assert.Contains(t, result.Causes[0].Message, "Prism Central credentials Secret \"ntnx-creds\" not found")
 }
 
@@ -120,7 +120,7 @@ func TestNewCredentialsCheck_SecretGetError(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.True(t, result.Error)
+	assert.True(t, result.InternalError)
 	assert.Contains(t, result.Causes[0].Message, "Failed to get Prism Central credentials Secret \"ntnx-creds\": fake error")
 }
 
@@ -140,7 +140,7 @@ func TestNewCredentialsCheck_SecretEmpty(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.False(t, result.Error)
+	assert.False(t, result.InternalError)
 	assert.Contains(t, result.Causes[0].Message, "credentials Secret \"ntnx-creds\" is empty")
 }
 
@@ -159,7 +159,7 @@ func TestNewCredentialsCheck_SecretMissingKey(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nil, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.False(t, result.Error)
+	assert.False(t, result.InternalError)
 	assert.Contains(t, result.Causes[0].Message, "does not contain key \"credentials\"")
 }
 
@@ -181,7 +181,7 @@ func TestNewCredentialsCheck_InvalidCredentialsFormat(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.False(t, result.Error)
+	assert.False(t, result.InternalError)
 	assert.Contains(t, result.Causes[0].Message, "failed to parse Prism Central credentials")
 }
 
@@ -194,7 +194,7 @@ func TestNewCredentialsCheck_FailedToCreateClient(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.True(t, result.Error)
+	assert.True(t, result.InternalError)
 	assert.Contains(t, result.Causes[0].Message, "Failed to initialize Nutanix client")
 }
 
@@ -207,7 +207,7 @@ func TestNewCredentialsCheck_FailedToGetCurrentLoggedInUser(t *testing.T) {
 	check := newCredentialsCheck(context.Background(), nclientFactory, cd)
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
-	assert.True(t, result.Error)
+	assert.True(t, result.InternalError)
 	assert.Contains(t, result.Causes[0].Message, "Failed to validate credentials using the v3 API client.")
 }
 

--- a/pkg/webhook/preflight/nutanix/credentials_test.go
+++ b/pkg/webhook/preflight/nutanix/credentials_test.go
@@ -121,7 +121,11 @@ func TestNewCredentialsCheck_SecretGetError(t *testing.T) {
 	result := check.Run(context.Background())
 	assert.False(t, result.Allowed)
 	assert.True(t, result.InternalError)
-	assert.Contains(t, result.Causes[0].Message, "Failed to get Prism Central credentials Secret \"ntnx-creds\": fake error")
+	assert.Contains(
+		t,
+		result.Causes[0].Message,
+		"Failed to get Prism Central credentials Secret \"ntnx-creds\": fake error",
+	)
 }
 
 func TestNewCredentialsCheck_SecretEmpty(t *testing.T) {

--- a/pkg/webhook/preflight/nutanix/image.go
+++ b/pkg/webhook/preflight/nutanix/image.go
@@ -42,7 +42,7 @@ func (c *imageCheck) Run(ctx context.Context) preflight.CheckResult {
 		images, err := getVMImages(c.nclient, c.machineDetails.Image)
 		if err != nil {
 			result.Allowed = false
-			result.Error = true
+			result.InternalError = true
 			result.Causes = append(result.Causes, preflight.Cause{
 				Message: fmt.Sprintf("failed to get VM Image: %s", err),
 				Field:   c.field,

--- a/pkg/webhook/preflight/nutanix/image_test.go
+++ b/pkg/webhook/preflight/nutanix/image_test.go
@@ -188,8 +188,8 @@ func TestVMImageCheck(t *testing.T) {
 				},
 			},
 			want: preflight.CheckResult{
-				Allowed: false,
-				Error:   true,
+				Allowed:       false,
+				InternalError: true,
 				Causes: []preflight.Cause{
 					{
 						Message: "failed to get VM Image: api error",
@@ -221,8 +221,8 @@ func TestVMImageCheck(t *testing.T) {
 				},
 			},
 			want: preflight.CheckResult{
-				Allowed: false,
-				Error:   true,
+				Allowed:       false,
+				InternalError: true,
 				Causes: []preflight.Cause{
 					{
 						Message: "failed to get VM Image: api error",
@@ -257,8 +257,8 @@ func TestVMImageCheck(t *testing.T) {
 				},
 			},
 			want: preflight.CheckResult{
-				Allowed: false,
-				Error:   true,
+				Allowed:       false,
+				InternalError: true,
 				Causes: []preflight.Cause{
 					{
 						Message: "failed to get VM Image: failed to get data returned by ListImages",
@@ -293,7 +293,7 @@ func TestVMImageCheck(t *testing.T) {
 
 			// Verify the result
 			assert.Equal(t, tc.want.Allowed, got.Allowed)
-			assert.Equal(t, tc.want.Error, got.Error)
+			assert.Equal(t, tc.want.InternalError, got.InternalError)
 			assert.Equal(t, tc.want.Causes, got.Causes)
 		})
 	}

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
@@ -37,8 +37,8 @@ func (c *imageKubernetesVersionCheck) Run(ctx context.Context) preflight.CheckRe
 		images, err := getVMImages(c.nclient, c.machineDetails.Image)
 		if err != nil {
 			return preflight.CheckResult{
-				Allowed: false,
-				Error:   true,
+				Allowed:       false,
+				InternalError: true,
 				Causes: []preflight.Cause{
 					{
 						Message: fmt.Sprintf("failed to get VM Image: %s", err),
@@ -56,8 +56,8 @@ func (c *imageKubernetesVersionCheck) Run(ctx context.Context) preflight.CheckRe
 
 		if err := c.checkKubernetesVersion(&images[0]); err != nil {
 			return preflight.CheckResult{
-				Allowed: false,
-				Error:   false,
+				Allowed:       false,
+				InternalError: false,
 				Causes: []preflight.Cause{
 					{
 						Message: err.Error(),

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -75,8 +75,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 			},
 			clusterK8sVersion: "1.32.3",
 			want: preflight.CheckResult{
-				Allowed: false,
-				Error:   false,
+				Allowed:       false,
+				InternalError: false,
 				Causes: []preflight.Cause{
 					{
 						Message: "cluster kubernetes version '1.32.3' is not part of image name 'kubedistro-ubuntu-22.04-vgpu-1.31.5-20250604180644'", //nolint:lll // cause message is long
@@ -107,8 +107,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 			},
 			clusterK8sVersion: "1.32.3",
 			want: preflight.CheckResult{
-				Allowed: false,
-				Error:   false,
+				Allowed:       false,
+				InternalError: false,
 				Causes: []preflight.Cause{
 					{
 						Message: "cluster kubernetes version '1.32.3' is not part of image name 'my-custom-image-name'",
@@ -139,8 +139,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 			},
 			clusterK8sVersion: "1.32.3",
 			want: preflight.CheckResult{
-				Allowed: false,
-				Error:   false,
+				Allowed:       false,
+				InternalError: false,
 				Causes: []preflight.Cause{
 					{
 						Message: "VM image name is empty",
@@ -196,8 +196,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 				},
 			},
 			want: preflight.CheckResult{
-				Allowed: false,
-				Error:   true,
+				Allowed:       false,
+				InternalError: true,
 				Causes: []preflight.Cause{
 					{
 						Message: "failed to get VM Image: some error",
@@ -220,7 +220,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 			got := check.Run(context.Background())
 
 			assert.Equal(t, tc.want.Allowed, got.Allowed)
-			assert.Equal(t, tc.want.Error, got.Error)
+			assert.Equal(t, tc.want.InternalError, got.InternalError)
 			assert.Equal(t, tc.want.Causes, got.Causes)
 		})
 	}

--- a/pkg/webhook/preflight/nutanix/specs.go
+++ b/pkg/webhook/preflight/nutanix/specs.go
@@ -46,7 +46,7 @@ func newConfigurationCheck(
 	if err != nil {
 		// Should not happen if the cluster passed CEL validation rules.
 		configurationCheck.result.Allowed = false
-		configurationCheck.result.Error = true
+		configurationCheck.result.InternalError = true
 		configurationCheck.result.Causes = append(configurationCheck.result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("Failed to unmarshal cluster variable %s: %s",
@@ -79,7 +79,7 @@ func newConfigurationCheck(
 			if err != nil {
 				// Should not happen if the cluster passed CEL validation rules.
 				configurationCheck.result.Allowed = false
-				configurationCheck.result.Error = true
+				configurationCheck.result.InternalError = true
 				configurationCheck.result.Causes = append(configurationCheck.result.Causes,
 					preflight.Cause{
 						Message: fmt.Sprintf("Failed to unmarshal topology machineDeployment variable %s: %s",

--- a/pkg/webhook/preflight/nutanix/specs_test.go
+++ b/pkg/webhook/preflight/nutanix/specs_test.go
@@ -132,8 +132,8 @@ func TestNewConfigurationCheck(t *testing.T) {
 				},
 			},
 			expectedResult: preflight.CheckResult{
-				Allowed: false,
-				Error:   true,
+				Allowed:       false,
+				InternalError: true,
 				Causes: []preflight.Cause{
 					{
 						Message: "Failed to unmarshal cluster variable clusterConfig: failed to unmarshal json:" +
@@ -180,8 +180,8 @@ func TestNewConfigurationCheck(t *testing.T) {
 				},
 			},
 			expectedResult: preflight.CheckResult{
-				Allowed: false,
-				Error:   true,
+				Allowed:       false,
+				InternalError: true,
 				Causes: []preflight.Cause{
 					{
 						Message: "Failed to unmarshal topology machineDeployment variable workerConfig:" +

--- a/pkg/webhook/preflight/nutanix/storagecontainer.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer.go
@@ -37,7 +37,7 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 
 	if c.csiSpec == nil {
 		result.Allowed = false
-		result.Error = true
+		result.InternalError = true
 		result.Causes = append(result.Causes, preflight.Cause{
 			Message: fmt.Sprintf(
 				"no storage container found for cluster %q",
@@ -83,7 +83,7 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 		cluster, err := getClusterOnce()
 		if err != nil {
 			result.Allowed = false
-			result.Error = true
+			result.InternalError = true
 			result.Causes = append(result.Causes, preflight.Cause{
 				Message: fmt.Sprintf(
 					"failed to check if storage container %q exists: failed to get cluster %q: %s",
@@ -99,7 +99,7 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 		containers, err := getStorageContainers(c.nclient, *cluster.ExtId, storageContainer)
 		if err != nil {
 			result.Allowed = false
-			result.Error = true
+			result.InternalError = true
 			result.Causes = append(result.Causes, preflight.Cause{
 				Message: fmt.Sprintf(
 					"failed to check if storage container %q exists in cluster %q: %s",

--- a/pkg/webhook/preflight/nutanix/storagecontainer.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer.go
@@ -39,11 +39,8 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 		result.Allowed = false
 		result.InternalError = true
 		result.Causes = append(result.Causes, preflight.Cause{
-			Message: fmt.Sprintf(
-				"no storage container found for cluster %q",
-				*c.machineSpec.Cluster.Name,
-			),
-			Field: c.field,
+			Message: "Nutanix CSI Provider configuration is missing",
+			Field:   c.field,
 		})
 
 		return result
@@ -52,11 +49,8 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 	if c.csiSpec.StorageClassConfigs == nil {
 		result.Allowed = false
 		result.Causes = append(result.Causes, preflight.Cause{
-			Message: fmt.Sprintf(
-				"no storage class configs found for cluster %q",
-				*c.machineSpec.Cluster.Name,
-			),
-			Field: c.field,
+			Message: "Nutanix CSI Provider configuration is missing storage class configurations",
+			Field:   c.field,
 		})
 
 		return result

--- a/pkg/webhook/preflight/nutanix/storagecontainer.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer.go
@@ -64,10 +64,13 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 
 	clusterIdentifier := &c.machineSpec.Cluster
 
-	// We wait to get the cluster until we know we need to.
-	// We should only get the cluster once.
-	getClusterOnce := sync.OnceValues(func() (*clustermgmtv4.Cluster, error) {
-		return getCluster(c.nclient, clusterIdentifier)
+	// To avoid unnecessary API calls, we delay the retrieval of clusters until we actually
+	// need to check for storage containers.
+	// There is only one cluster referenced in MachineDetails, so we can use sync.OnceValues
+	// to ensure that we only call getClusters once, even if there are multiple storage
+	// class configs.
+	getClustersOnce := sync.OnceValues(func() ([]clustermgmtv4.Cluster, error) {
+		return getClusters(c.nclient, clusterIdentifier)
 	})
 
 	for _, storageClassConfig := range c.csiSpec.StorageClassConfigs {
@@ -80,7 +83,7 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 			continue
 		}
 
-		cluster, err := getClusterOnce()
+		clusters, err := getClustersOnce()
 		if err != nil {
 			result.Allowed = false
 			result.InternalError = true
@@ -95,6 +98,21 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 			})
 			continue
 		}
+
+		if len(clusters) != 1 {
+			result.Allowed = false
+			result.Causes = append(result.Causes, preflight.Cause{
+				Message: fmt.Sprintf(
+					"expected to find 1 cluster matching the reference, found %d",
+					len(clusters),
+				),
+				Field: c.field,
+			})
+			continue
+		}
+
+		// Found exactly one cluster.
+		cluster := &clusters[0]
 
 		containers, err := getStorageContainers(c.nclient, *cluster.ExtId, storageContainer)
 		if err != nil {
@@ -112,26 +130,14 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 			continue
 		}
 
-		if len(containers) == 0 {
+		if len(containers) != 1 {
 			result.Allowed = false
 			result.Causes = append(result.Causes, preflight.Cause{
 				Message: fmt.Sprintf(
-					"storage container %q not found on cluster %q",
+					"expected to find 1 storage container named %q on cluster %q, found %d",
 					storageContainer,
 					clusterIdentifier,
-				),
-				Field: c.field,
-			})
-			continue
-		}
-
-		if len(containers) > 1 {
-			result.Allowed = false
-			result.Causes = append(result.Causes, preflight.Cause{
-				Message: fmt.Sprintf(
-					"multiple storage containers named %q found on cluster %q",
-					storageContainer,
-					clusterIdentifier,
+					len(containers),
 				),
 				Field: c.field,
 			})
@@ -209,48 +215,37 @@ func getStorageContainers(
 	return containers, nil
 }
 
-func getCluster(
+func getClusters(
 	client client,
 	clusterIdentifier *v1beta1.NutanixResourceIdentifier,
-) (*clustermgmtv4.Cluster, error) {
+) ([]clustermgmtv4.Cluster, error) {
 	switch {
 	case clusterIdentifier.IsUUID():
 		resp, err := client.GetClusterById(clusterIdentifier.UUID)
 		if err != nil {
 			return nil, err
 		}
-
 		cluster, ok := resp.GetData().(clustermgmtv4.Cluster)
 		if !ok {
 			return nil, fmt.Errorf("failed to get data returned by GetClusterById")
 		}
-
-		return &cluster, nil
+		return []clustermgmtv4.Cluster{cluster}, nil
 	case clusterIdentifier.IsName():
 		filter := fmt.Sprintf("name eq '%s'", *clusterIdentifier.Name)
 		resp, err := client.ListClusters(nil, nil, &filter, nil, nil, nil)
 		if err != nil {
 			return nil, err
 		}
-
 		if resp == nil || resp.GetData() == nil {
-			return nil, fmt.Errorf("no clusters were returned")
+			// No clusters were returned.
+			return []clustermgmtv4.Cluster{}, nil
 		}
 
 		clusters, ok := resp.GetData().([]clustermgmtv4.Cluster)
 		if !ok {
 			return nil, fmt.Errorf("failed to get data returned by ListClusters")
 		}
-
-		if len(clusters) == 0 {
-			return nil, fmt.Errorf("no clusters found with name %q", *clusterIdentifier.Name)
-		}
-
-		if len(clusters) > 1 {
-			return nil, fmt.Errorf("multiple clusters found with name %q", *clusterIdentifier.Name)
-		}
-
-		return &clusters[0], nil
+		return clusters, nil
 	default:
 		return nil, fmt.Errorf("cluster identifier is missing both name and uuid")
 	}

--- a/pkg/webhook/preflight/nutanix/storagecontainer_test.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer_test.go
@@ -550,12 +550,10 @@ func TestStorageContainerCheck(t *testing.T) {
 		},
 		{
 			name: "multiple clusters found",
-			nodeSpec: &carenv1.NutanixNodeSpec{
-				MachineDetails: carenv1.NutanixMachineDetails{
-					Cluster: capxv1.NutanixResourceIdentifier{
-						Type: capxv1.NutanixIdentifierName,
-						Name: ptr.To(clusterName),
-					},
+			machineSpec: &carenv1.NutanixMachineDetails{
+				Cluster: capxv1.NutanixResourceIdentifier{
+					Type: capxv1.NutanixIdentifierName,
+					Name: ptr.To(clusterName),
 				},
 			},
 			csiSpec: &carenv1.CSIProvider{

--- a/pkg/webhook/preflight/nutanix/storagecontainer_test.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer_test.go
@@ -276,7 +276,7 @@ func TestStorageContainerCheck(t *testing.T) {
 			nclient:              nil,
 			expectedAllowed:      false,
 			expectedError:        true,
-			expectedCauseMessage: fmt.Sprintf("no storage container found for cluster %q", clusterName),
+			expectedCauseMessage: "Nutanix CSI Provider configuration is missing",
 		},
 		{
 			name: "nil storage class configs",
@@ -290,7 +290,7 @@ func TestStorageContainerCheck(t *testing.T) {
 			nclient:              nil,
 			expectedAllowed:      false,
 			expectedError:        false,
-			expectedCauseMessage: fmt.Sprintf("no storage class configs found for cluster %q", clusterName),
+			expectedCauseMessage: "Nutanix CSI Provider configuration is missing storage class configurations",
 		},
 		{
 			name: "storage class config without parameters",

--- a/pkg/webhook/preflight/nutanix/storagecontainer_test.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer_test.go
@@ -893,7 +893,7 @@ func TestStorageContainerCheck(t *testing.T) {
 
 			// Verify the result
 			assert.Equal(t, tc.expectedAllowed, result.Allowed)
-			assert.Equal(t, tc.expectedError, result.Error)
+			assert.Equal(t, tc.expectedError, result.InternalError)
 
 			if tc.expectedCauseMessage != "" {
 				require.NotEmpty(t, result.Causes)

--- a/pkg/webhook/preflight/nutanix/storagecontainer_test.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer_test.go
@@ -396,9 +396,10 @@ func TestStorageContainerCheck(t *testing.T) {
 					return resp, nil
 				},
 			},
-			expectedAllowed:      false,
-			expectedError:        false,
-			expectedCauseMessage: "storage container \"missing-container\" not found on cluster \"test-cluster\"",
+			expectedAllowed: false,
+			expectedError:   false,
+			expectedCauseMessage: "expected to find 1 storage container named \"missing-container\" " +
+				"on cluster \"test-cluster\", found 0",
 		},
 		{
 			name: "multiple storage containers found",
@@ -471,9 +472,10 @@ func TestStorageContainerCheck(t *testing.T) {
 					return resp, nil
 				},
 			},
-			expectedAllowed:      false,
-			expectedError:        false,
-			expectedCauseMessage: "multiple storage containers named \"duplicate-container\" found on cluster \"test-cluster\"",
+			expectedAllowed: false,
+			expectedError:   false,
+			expectedCauseMessage: "expected to find 1 storage container named \"duplicate-container\" " +
+				"on cluster \"test-cluster\", found 2",
 		},
 		{
 			name: "successful storage container check",
@@ -545,6 +547,59 @@ func TestStorageContainerCheck(t *testing.T) {
 			},
 			expectedAllowed: true,
 			expectedError:   false,
+		},
+		{
+			name: "multiple clusters found",
+			nodeSpec: &carenv1.NutanixNodeSpec{
+				MachineDetails: carenv1.NutanixMachineDetails{
+					Cluster: capxv1.NutanixResourceIdentifier{
+						Type: capxv1.NutanixIdentifierName,
+						Name: ptr.To(clusterName),
+					},
+				},
+			},
+			csiSpec: &carenv1.CSIProvider{
+				StorageClassConfigs: map[string]carenv1.StorageClassConfig{
+					"test-sc": {
+						Parameters: map[string]string{
+							"storageContainer": "valid-container",
+						},
+					},
+				},
+			},
+			nclient: &mocknclient{
+				listClustersFunc: func(
+					page,
+					limit *int,
+					filter,
+					orderby,
+					apply,
+					select_ *string,
+					args ...map[string]interface{},
+				) (
+					*clustermgmtv4.ListClustersApiResponse,
+					error,
+				) {
+					resp := &clustermgmtv4.ListClustersApiResponse{
+						ObjectType_: ptr.To("clustermgmt.v4.config.ListClustersApiResponse"),
+					}
+					err := resp.SetData([]clustermgmtv4.Cluster{
+						{
+							Name:  ptr.To(clusterName),
+							ExtId: ptr.To("cluster-uuid-123"),
+						},
+						{
+							Name:  ptr.To(clusterName),
+							ExtId: ptr.To("cluster-uuid-456"),
+						},
+					})
+					require.NoError(t, err)
+					return resp, nil
+				},
+			},
+			expectedAllowed:      false,
+			expectedError:        false,
+			expectedCauseMessage: "expected to find 1 cluster matching the reference, found 2",
 		},
 		{
 			name: "error getting cluster",
@@ -778,9 +833,10 @@ func TestStorageContainerCheck(t *testing.T) {
 					return &clustermgmtv4.ListStorageContainersApiResponse{}, nil
 				},
 			},
-			expectedAllowed:      false,
-			expectedError:        false,
-			expectedCauseMessage: "storage container \"valid-container\" not found on cluster \"test-cluster\"",
+			expectedAllowed: false,
+			expectedError:   false,
+			expectedCauseMessage: "expected to find 1 storage container named \"valid-container\" " +
+				"on cluster \"test-cluster\", found 0",
 		},
 		{
 			name: "multiple storage class configs with success",
@@ -906,14 +962,14 @@ func TestStorageContainerCheck(t *testing.T) {
 	}
 }
 
-func TestGetCluster(t *testing.T) {
+func TestGetClusters(t *testing.T) {
 	testCases := []struct {
-		name              string
-		clusterIdentifier *capxv1.NutanixResourceIdentifier
-		client            client
-		expectError       bool
-		errorContains     string
-		expectedClusterID string
+		name               string
+		clusterIdentifier  *capxv1.NutanixResourceIdentifier
+		client             client
+		expectError        bool
+		errorContains      string
+		expectedClusterIDs []string
 	}{
 		{
 			name: "get cluster by UUID - success",
@@ -938,8 +994,8 @@ func TestGetCluster(t *testing.T) {
 					return resp, nil
 				},
 			},
-			expectError:       false,
-			expectedClusterID: "test-uuid-123",
+			expectError:        false,
+			expectedClusterIDs: []string{"test-uuid-123"},
 		},
 		{
 			name: "get cluster by UUID - API error",
@@ -1005,8 +1061,8 @@ func TestGetCluster(t *testing.T) {
 					return resp, nil
 				},
 			},
-			expectError:       false,
-			expectedClusterID: "test-uuid-123",
+			expectError:        false,
+			expectedClusterIDs: []string{"test-uuid-123"},
 		},
 		{
 			name: "get cluster by name - API error",
@@ -1053,7 +1109,7 @@ func TestGetCluster(t *testing.T) {
 					return nil, nil
 				},
 			},
-			expectError:   true,
+			expectError:   false,
 			errorContains: "no clusters were returned",
 		},
 		{
@@ -1106,7 +1162,7 @@ func TestGetCluster(t *testing.T) {
 					}, nil
 				},
 			},
-			expectError:   true,
+			expectError:   false,
 			errorContains: "no clusters were returned",
 		},
 		{
@@ -1135,7 +1191,7 @@ func TestGetCluster(t *testing.T) {
 					return resp, nil
 				},
 			},
-			expectError:   true,
+			expectError:   false,
 			errorContains: "no clusters found with name",
 		},
 		{
@@ -1173,8 +1229,8 @@ func TestGetCluster(t *testing.T) {
 					return resp, nil
 				},
 			},
-			expectError:   true,
-			errorContains: "multiple clusters found with name",
+			expectError:        false,
+			expectedClusterIDs: []string{"test-uuid-1", "test-uuid-2"},
 		},
 		{
 			name: "invalid identifier type",
@@ -1227,16 +1283,19 @@ func TestGetCluster(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cluster, err := getCluster(tc.client, tc.clusterIdentifier)
+			clusters, err := getClusters(tc.client, tc.clusterIdentifier)
 
 			if tc.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errorContains)
-				assert.Nil(t, cluster)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, cluster)
-				assert.Equal(t, tc.expectedClusterID, *cluster.ExtId)
+				assert.Nil(t, clusters)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, tc.expectedClusterIDs, len(clusters))
+			for i, cluster := range clusters {
+				assert.Equal(t, tc.expectedClusterIDs[i], *cluster.ExtId)
 			}
 		})
 	}

--- a/pkg/webhook/preflight/preflight.go
+++ b/pkg/webhook/preflight/preflight.go
@@ -43,8 +43,8 @@ type (
 	// list of causes for the failure. It also contains a list of warnings that were
 	// generated during the check.
 	CheckResult struct {
-		Allowed bool
-		Error   bool
+		Allowed       bool
+		InternalError bool
 
 		Causes   []Cause
 		Warnings []string
@@ -128,7 +128,7 @@ func (h *WebhookHandler) Handle(ctx context.Context, req admission.Request) admi
 	internalError := false
 	for _, results := range resultsOrderedByCheckerAndCheck {
 		for _, result := range results {
-			if result.Error {
+			if result.InternalError {
 				internalError = true
 			}
 			if !result.Allowed {
@@ -201,9 +201,9 @@ func run(ctx context.Context,
 					resultsOrderedByCheck[j] = namedResult{
 						Name: check.Name(),
 						CheckResult: CheckResult{
-							Allowed: true,
-							Error:   false,
-							Causes:  nil,
+							Allowed:       true,
+							InternalError: false,
+							Causes:        nil,
 							Warnings: []string{
 								fmt.Sprintf("Cluster has skipped preflight check %q", check.Name()),
 							},
@@ -223,7 +223,7 @@ func run(ctx context.Context,
 							resultsOrderedByCheck[j] = namedResult{
 								Name: check.Name(),
 								CheckResult: CheckResult{
-									Error: true,
+									InternalError: true,
 									Causes: []Cause{
 										{
 											Message: fmt.Sprintf("internal error (panic): %s", r),

--- a/pkg/webhook/preflight/preflight_test.go
+++ b/pkg/webhook/preflight/preflight_test.go
@@ -296,8 +296,8 @@ func TestHandle(t *testing.T) {
 						&mockCheck{
 							name: "Test1",
 							result: CheckResult{
-								Allowed: false,
-								Error:   true,
+								Allowed:       false,
+								InternalError: true,
 								Causes: []Cause{
 									{
 										Message: "internal error",
@@ -426,8 +426,8 @@ func (c *cancellableCheck) Run(ctx context.Context) CheckResult {
 	case <-ctx.Done():
 		c.cancelled = true
 		return CheckResult{
-			Allowed: false,
-			Error:   true,
+			Allowed:       false,
+			InternalError: true,
 			Causes: []Cause{
 				{
 					Message: "context cancelled",
@@ -585,7 +585,7 @@ func TestRun_MultipleCheckersMultipleChecks(t *testing.T) {
 			&mockCheck{
 				name: "c2-check1",
 				result: CheckResult{
-					Error: true,
+					InternalError: true,
 				},
 			},
 		},
@@ -733,7 +733,7 @@ func TestRun_ContextCancellation(t *testing.T) {
 	check := &contextAwareCheck{
 		name: "cancellable-check",
 		onCancel: func() CheckResult {
-			return CheckResult{Error: true}
+			return CheckResult{InternalError: true}
 		},
 		onTimeout: func() CheckResult {
 			close(completed)
@@ -766,7 +766,7 @@ func TestRun_ContextCancellation(t *testing.T) {
 
 	results := resultsOrderedByCheckerAndCheck[0]
 	assert.Len(t, results, 1, "expected 1 result from the checker")
-	assert.True(t, results[0].Error, "expected result to be an error after cancellation")
+	assert.True(t, results[0].InternalError, "expected result to be an error after cancellation")
 }
 
 func TestRun_OrderOfResults(t *testing.T) {
@@ -865,7 +865,7 @@ func TestRun_ErrorHandlingInChecks(t *testing.T) {
 	errorCheck := &mockCheck{
 		name: "error-check",
 		result: CheckResult{
-			Error: true,
+			InternalError: true,
 			Causes: []Cause{
 				{
 					Message: "simulated error in check",
@@ -886,7 +886,7 @@ func TestRun_ErrorHandlingInChecks(t *testing.T) {
 	wantErrorCheckResult := namedResult{
 		Name: "error-check",
 		CheckResult: CheckResult{
-			Error: true,
+			InternalError: true,
 			Causes: []Cause{
 				{
 					Message: "simulated error in check",
@@ -947,7 +947,7 @@ func TestRun_PanicHandlingInChecks(t *testing.T) {
 	wantPanicCheckResult := namedResult{
 		Name: "panicking-check",
 		CheckResult: CheckResult{
-			Error: true,
+			InternalError: true,
 			Causes: []Cause{
 				{
 					Message: "internal error (panic): simulated panic in check",


### PR DESCRIPTION
**What problem does this PR solve?**:
Internal errors are meant to signal some unexpected failure. We have been treating a number of expected failures as internal errors, and this PR fixes these.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
