### PR TITLE
fix: Fix typo in field name; use one-line strings to prevent future typos

### DIFF
--- a/pkg/webhook/preflight/generic/registry_test.go
+++ b/pkg/webhook/preflight/generic/registry_test.go
@@ -300,8 +300,10 @@ func TestRegistryCheck(t *testing.T) {
 				InternalError: false,
 				Causes: []preflight.Cause{
 					{
-						Message: fmt.Sprintf("Failed to parse registry URL %q with error: "+
-							"parse \"invalid-url\": invalid URI for request", "invalid-url"),
+						Message: fmt.Sprintf(
+							"Failed to parse registry URL %q with error: parse \"invalid-url\": invalid URI for request",
+							"invalid-url",
+						),
 						Field: "cluster.spec.topology.variables[.name=clusterConfig].value.imageRegistries[0].url",
 					},
 				},

--- a/pkg/webhook/preflight/generic/spec_test.go
+++ b/pkg/webhook/preflight/generic/spec_test.go
@@ -106,9 +106,9 @@ func TestNewConfigurationCheck(t *testing.T) {
 				InternalError: true,
 				Causes: []preflight.Cause{
 					{
-						Message: "Failed to unmarshal cluster variable clusterConfig: failed to unmarshal json:" +
-							" invalid character 'i' looking for beginning of object key string",
-						Field: "cluster.spec.topology.variables[.name=clusterConfig].genericClusterConfigSpec",
+						///nolint:lll // The message is long.
+						Message: "Failed to unmarshal cluster variable clusterConfig: failed to unmarshal json: invalid character 'i' looking for beginning of object key string",
+						Field:   "cluster.spec.topology.variables[.name=clusterConfig].genericClusterConfigSpec",
 					},
 				},
 			},

--- a/pkg/webhook/preflight/nutanix/credentials.go
+++ b/pkg/webhook/preflight/nutanix/credentials.go
@@ -73,8 +73,7 @@ func newCredentialsCheck(
 		credentialsCheck.result.Causes = append(credentialsCheck.result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("Failed to parse Prism Central endpoint URL: %s", err),
-				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"]" +
-					".value.nutanix.prismCentralEndpoint.url",
+				Field:   "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.prismCentralEndpoint.url", ///nolint:lll // Field is long.
 			},
 		)
 		return credentialsCheck
@@ -96,8 +95,7 @@ func newCredentialsCheck(
 			preflight.Cause{
 				Message: fmt.Sprintf("Prism Central credentials Secret %q not found",
 					prismCentralEndpointSpec.Credentials.SecretRef.Name),
-				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"]" +
-					".value.nutanix.prismCentralEndpoint.credentials.secretRef",
+				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.prismCentralEndpoint.credentials.secretRef", ///nolint:lll // Field is long.
 			},
 		)
 		return credentialsCheck
@@ -111,8 +109,7 @@ func newCredentialsCheck(
 					prismCentralEndpointSpec.Credentials.SecretRef.Name,
 					err,
 				),
-				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"]" +
-					".value.nutanix.prismCentralEndpoint.credentials.secretRef",
+				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.prismCentralEndpoint.credentials.secretRef", ///nolint:lll // Field is long.
 			},
 		)
 		return credentialsCheck
@@ -126,8 +123,7 @@ func newCredentialsCheck(
 					"Credentials Secret %q is empty",
 					prismCentralEndpointSpec.Credentials.SecretRef.Name,
 				),
-				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"]" +
-					".value.nutanix.prismCentralEndpoint.credentials.secretRef",
+				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.prismCentralEndpoint.credentials.secretRef", ///nolint:lll // Field is long.
 			},
 		)
 		return credentialsCheck
@@ -143,8 +139,7 @@ func newCredentialsCheck(
 					prismCentralEndpointSpec.Credentials.SecretRef.Name,
 					credentialsSecretDataKey,
 				),
-				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"]" +
-					".value.nutanix.prismCentralEndpoint.credentials.secretRef",
+				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.prismCentralEndpoint.credentials.secretRef", ///nolint:lll // Field is long.
 			},
 		)
 		return credentialsCheck
@@ -156,8 +151,7 @@ func newCredentialsCheck(
 		credentialsCheck.result.Causes = append(credentialsCheck.result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("Failed to parse Prism Central credentials: %s", err),
-				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"]" +
-					".value.nutanix.prismCentralEndpoint.credentials.secretRef",
+				Field:   "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.prismCentralEndpoint.credentials.secretRef", ///nolint:lll // Field is long.
 			},
 		)
 		return credentialsCheck
@@ -180,8 +174,7 @@ func newCredentialsCheck(
 		credentialsCheck.result.Causes = append(credentialsCheck.result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("Failed to initialize Nutanix client: %s", err),
-				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"]" +
-					".value.nutanix.prismCentralEndpoint.credentials.secretRef",
+				Field:   "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.prismCentralEndpoint.credentials.secretRef", ///nolint:lll // Field is long.
 			},
 		)
 		return credentialsCheck
@@ -200,8 +193,7 @@ func newCredentialsCheck(
 		credentialsCheck.result.Causes = append(credentialsCheck.result.Causes,
 			preflight.Cause{
 				Message: fmt.Sprintf("Failed to validate credentials using the v3 API client: %s", err),
-				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"]" +
-					".value.nutanix.prismCentralEndpoint.credentials.secretRef",
+				Field:   "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.prismCentralEndpoint.credentials.secretRef", ///nolint:lll // Field is long.
 			},
 		)
 		return credentialsCheck

--- a/pkg/webhook/preflight/nutanix/image.go
+++ b/pkg/webhook/preflight/nutanix/image.go
@@ -82,9 +82,8 @@ func newVMImageChecks(
 		checks = append(checks,
 			&imageCheck{
 				machineDetails: &cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.MachineDetails,
-				field: "$.spec.topology.variables[?@.name==\"clusterConfig\"]." +
-					".value.nutanix.controlPlane.machineDetails",
-				nclient: cd.nclient,
+				field:          "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.controlPlane.machineDetails", ///nolint:lll // Field is long.
+				nclient:        cd.nclient,
 			},
 		)
 	}
@@ -94,8 +93,11 @@ func newVMImageChecks(
 			checks = append(checks,
 				&imageCheck{
 					machineDetails: &nutanixWorkerNodeConfigSpec.Nutanix.MachineDetails,
-					field: fmt.Sprintf("$.spec.topology.workers.machineDeployments[?@.name==%q]"+
-						".variables[?@.name=workerConfig].value.nutanix.machineDetails", mdName),
+					///nolint:lll // The field is long.
+					field: fmt.Sprintf(
+						"$.spec.topology.workers.machineDeployments[?@.name==%q].variables[?@.name=workerConfig].value.nutanix.machineDetails",
+						mdName,
+					),
 					nclient: cd.nclient,
 				},
 			)

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
@@ -125,9 +125,8 @@ func newVMImageKubernetesVersionChecks(
 		cd.nutanixClusterConfigSpec.ControlPlane.Nutanix != nil {
 		checks = append(checks,
 			&imageKubernetesVersionCheck{
-				machineDetails: &cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.MachineDetails,
-				field: "$.spec.topology.variables[?@.name==\"clusterConfig\"]." +
-					".value.nutanix.controlPlane.machineDetails",
+				machineDetails:    &cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.MachineDetails,
+				field:             "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.controlPlane.machineDetails", ///nolint:lll // Field is long.
 				nclient:           cd.nclient,
 				clusterK8sVersion: clusterK8sVersion,
 			},
@@ -139,8 +138,11 @@ func newVMImageKubernetesVersionChecks(
 			checks = append(checks,
 				&imageKubernetesVersionCheck{
 					machineDetails: &nutanixWorkerNodeConfigSpec.Nutanix.MachineDetails,
-					field: fmt.Sprintf("$.spec.topology.workers.machineDeployments[?@.name==%q]"+
-						".variables[?@.name=workerConfig].value.nutanix.machineDetails", mdName),
+					//nolint:lll // The field is long.
+					field: fmt.Sprintf(
+						"$.spec.topology.workers.machineDeployments[?@.name==%q].variables[?@.name=workerConfig].value.nutanix.machineDetails",
+						mdName,
+					),
 					nclient:           cd.nclient,
 					clusterK8sVersion: clusterK8sVersion,
 				},

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -79,9 +79,9 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 				InternalError: false,
 				Causes: []preflight.Cause{
 					{
-						Message: "Kubernetes version check failed: kubernetes version \"1.32.3\" is not part " +
-							"of image name \"kubedistro-ubuntu-22.04-vgpu-1.31.5-20250604180644\"",
-						Field: "machineDetails.image",
+						///nolint:lll // The message is long.
+						Message: "Kubernetes version check failed: kubernetes version \"1.32.3\" is not part of image name \"kubedistro-ubuntu-22.04-vgpu-1.31.5-20250604180644\"",
+						Field:   "machineDetails.image",
 					},
 				},
 			},
@@ -137,9 +137,9 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 				InternalError: false,
 				Causes: []preflight.Cause{
 					{
-						Message: "Kubernetes version check failed: kubernetes version \"1.32.3\" is not part of " +
-							"image name \"my-custom-image-name\"",
-						Field: "machineDetails.image",
+						///nolint:lll // The message is long.
+						Message: "Kubernetes version check failed: kubernetes version \"1.32.3\" is not part of image name \"my-custom-image-name\"",
+						Field:   "machineDetails.image",
 					},
 				},
 			},
@@ -170,9 +170,9 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 				InternalError: false,
 				Causes: []preflight.Cause{
 					{
-						Message: "Kubernetes version check failed: failed to parse kubernetes version " +
-							"\"invalid.version\": No Major.Minor.Patch elements found",
-						Field: "machineDetails.image",
+						//nolint:lll // The message is long.
+						Message: "Kubernetes version check failed: failed to parse kubernetes version \"invalid.version\": No Major.Minor.Patch elements found",
+						Field:   "machineDetails.image",
 					},
 				},
 			},

--- a/pkg/webhook/preflight/nutanix/specs.go
+++ b/pkg/webhook/preflight/nutanix/specs.go
@@ -86,9 +86,9 @@ func newConfigurationCheck(
 							carenv1.WorkerConfigVariableName,
 							err,
 						),
+						//nolint:lll // The field is long.
 						Field: fmt.Sprintf(
-							"$.spec.topology.workers.machineDeployments[?@.name==%q]"+
-								".variables[?@.name=workerConfig].value.nutanix.machineDetails",
+							"$.spec.topology.workers.machineDeployments[?@.name==%q].variables[?@.name=workerConfig].value.nutanix.machineDetails",
 							md.Name,
 						),
 					},

--- a/pkg/webhook/preflight/nutanix/specs_test.go
+++ b/pkg/webhook/preflight/nutanix/specs_test.go
@@ -136,9 +136,9 @@ func TestNewConfigurationCheck(t *testing.T) {
 				InternalError: true,
 				Causes: []preflight.Cause{
 					{
-						Message: "Failed to unmarshal cluster variable clusterConfig: failed to unmarshal json:" +
-							" invalid character 'i' looking for beginning of object key string",
-						Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix",
+						//nolint:lll // The message is long.
+						Message: "Failed to unmarshal cluster variable clusterConfig: failed to unmarshal json: invalid character 'i' looking for beginning of object key string",
+						Field:   "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix",
 					},
 				},
 			},
@@ -184,10 +184,10 @@ func TestNewConfigurationCheck(t *testing.T) {
 				InternalError: true,
 				Causes: []preflight.Cause{
 					{
-						Message: "Failed to unmarshal topology machineDeployment variable workerConfig:" +
-							" failed to unmarshal json: invalid character 'i' looking for beginning of object key string",
-						Field: "$.spec.topology.workers.machineDeployments[?@.name==\"md-0\"]" +
-							".variables[?@.name=workerConfig].value.nutanix.machineDetails",
+						//nolint:lll // The message is long.
+						Message: "Failed to unmarshal topology machineDeployment variable workerConfig: failed to unmarshal json: invalid character 'i' looking for beginning of object key string",
+						//nolint:lll // The field is long.
+						Field: "$.spec.topology.workers.machineDeployments[?@.name==\"md-0\"].variables[?@.name=workerConfig].value.nutanix.machineDetails",
 					},
 				},
 			},

--- a/pkg/webhook/preflight/nutanix/storagecontainer.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer.go
@@ -162,9 +162,9 @@ func newStorageContainerChecks(cd *checkDependencies) []preflight.Check {
 			checks = append(checks,
 				&storageContainerCheck{
 					machineSpec: &nutanixWorkerNodeConfigSpec.Nutanix.MachineDetails,
+					//nolint:lll // The field is long.
 					field: fmt.Sprintf(
-						"$.spec.topology.workers.machineDeployments[?@.name==%q]"+
-							".variables[?@.name=workerConfig].value.nutanix.machineDetails",
+						"$.spec.topology.workers.machineDeployments[?@.name==%q].variables[?@.name=workerConfig].value.nutanix.machineDetails",
 						mdName,
 					),
 					csiSpec: &cd.nutanixClusterConfigSpec.Addons.CSI.Providers.NutanixCSI,
@@ -193,7 +193,7 @@ func getStorageContainers(
 	}
 	containers, ok := resp.GetData().([]clustermgmtv4.StorageContainer)
 	if !ok {
-		return nil, fmt.Errorf("failed to get data returned by ListStorageContainers(filter=%q)", fltr)
+		return nil, fmt.Errorf("failed to get data returned by ListStorageContainers (filter=%q)", fltr)
 	}
 	return containers, nil
 }

--- a/pkg/webhook/preflight/nutanix/storagecontainer_test.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer_test.go
@@ -384,8 +384,8 @@ func TestStorageContainerCheck(t *testing.T) {
 			},
 			expectedAllowed: false,
 			expectedError:   false,
-			expectedCauseMessage: "Expected to find 1 storage container named \"missing-container\" " +
-				"on cluster \"test-cluster\", found 0",
+			//nolint:lll // The message is long.
+			expectedCauseMessage: "Expected to find 1 storage container named \"missing-container\" on cluster \"test-cluster\", found 0",
 		},
 		{
 			name: "multiple storage containers found",
@@ -460,8 +460,8 @@ func TestStorageContainerCheck(t *testing.T) {
 			},
 			expectedAllowed: false,
 			expectedError:   false,
-			expectedCauseMessage: "Expected to find 1 storage container named \"duplicate-container\" " +
-				"on cluster \"test-cluster\", found 2",
+			//nolint:lll // The message is long.
+			expectedCauseMessage: "Expected to find 1 storage container named \"duplicate-container\" on cluster \"test-cluster\", found 2",
 		},
 		{
 			name: "successful storage container check",
@@ -623,8 +623,8 @@ func TestStorageContainerCheck(t *testing.T) {
 			},
 			expectedAllowed: false,
 			expectedError:   true,
-			expectedCauseMessage: "Failed to check if storage container \"valid-container\" exists: " +
-				"failed to get cluster \"test-cluster\": API error",
+			//nolint:lll // The message is long.
+			expectedCauseMessage: "Failed to check if storage container \"valid-container\" exists: failed to get cluster \"test-cluster\": API error",
 		},
 		{
 			name: "error listing storage containers",
@@ -687,8 +687,8 @@ func TestStorageContainerCheck(t *testing.T) {
 			},
 			expectedAllowed: false,
 			expectedError:   true,
-			expectedCauseMessage: "Failed to check if storage container \"valid-container\" exists in cluster " +
-				"\"test-cluster\": API error listing containers",
+			//nolint:lll // The message is long.
+			expectedCauseMessage: "Failed to check if storage container \"valid-container\" exists in cluster \"test-cluster\": API error listing containers",
 		},
 		{
 			name: "error response from ListStorageContainers",
@@ -754,9 +754,8 @@ func TestStorageContainerCheck(t *testing.T) {
 			},
 			expectedAllowed: false,
 			expectedError:   true,
-			expectedCauseMessage: "Failed to check if storage container \"valid-container\" exists in cluster " +
-				"\"test-cluster\": failed to get data returned by ListStorageContainers" +
-				"(filter=\"name eq 'valid-container' and clusterExtId eq 'cluster-uuid-123'\")",
+			//nolint:lll // The message is long.
+			expectedCauseMessage: "Failed to check if storage container \"valid-container\" exists in cluster \"test-cluster\": failed to get data returned by ListStorageContainers (filter=\"name eq 'valid-container' and clusterExtId eq 'cluster-uuid-123'\")",
 		},
 		{
 			name: "nil data from ListStorageContainers",
@@ -819,8 +818,8 @@ func TestStorageContainerCheck(t *testing.T) {
 			},
 			expectedAllowed: false,
 			expectedError:   false,
-			expectedCauseMessage: "Expected to find 1 storage container named \"valid-container\" " +
-				"on cluster \"test-cluster\", found 0",
+			//nolint:lll // The message is long.
+			expectedCauseMessage: "Expected to find 1 storage container named \"valid-container\" on cluster \"test-cluster\", found 0",
 		},
 		{
 			name: "multiple storage class configs with success",


### PR DESCRIPTION
**What problem does this PR solve?**:
There was an extra period in a field, introduced when I manually split the field across two lines, to appease the linter. Fields are long strings, and easier to read and maintain if we don't split them up.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
