### PR TITLE
feat(failuredomains): add failure domain rollout controller

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/role.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/role.yaml
@@ -75,6 +75,7 @@ rules:
       - cluster.x-k8s.io
     resources:
       - clusters
+      - machines
     verbs:
       - get
       - list
@@ -82,7 +83,23 @@ rules:
   - apiGroups:
       - cluster.x-k8s.io
     resources:
+      - clusters/status
+    verbs:
+      - get
+  - apiGroups:
+      - cluster.x-k8s.io
+    resources:
       - machinedeployments
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - controlplane.cluster.x-k8s.io
+    resources:
+      - kubeadmcontrolplanes
     verbs:
       - get
       - list

--- a/pkg/controllers/failuredomainrollout/controller.go
+++ b/pkg/controllers/failuredomainrollout/controller.go
@@ -1,0 +1,346 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package failuredomainrollout
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type Reconciler struct {
+	client.Client
+}
+
+func (r *Reconciler) SetupWithManager(
+	mgr ctrl.Manager,
+	options *controller.Options,
+) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.Cluster{}).
+		Watches(
+			&controlplanev1.KubeadmControlPlane{},
+			handler.EnqueueRequestsFromMapFunc(r.kubeadmControlPlaneToCluster),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		).
+		WithOptions(*options).
+		Complete(r)
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx).WithValues("cluster", req.NamespacedName)
+	logger.V(5).Info("Starting failure domain rollout reconciliation")
+
+	var cluster clusterv1.Cluster
+	if err := r.Get(ctx, req.NamespacedName, &cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(5).Info("Cluster not found, skipping reconciliation")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get Cluster %s: %w", req.NamespacedName, err)
+	}
+
+	// Early validation checks
+	if cluster.Spec.Topology == nil {
+		logger.V(5).Info("Cluster is not using topology, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
+	if cluster.Spec.ControlPlaneRef == nil {
+		logger.V(5).Info("Cluster has no control plane reference, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
+	if len(cluster.Status.FailureDomains) == 0 {
+		logger.V(5).Info("Cluster has no failure domains, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
+	// Get the KubeAdmControlPlane
+	kcpKey := types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      cluster.Spec.ControlPlaneRef.Name,
+	}
+
+	var kcp controlplanev1.KubeadmControlPlane
+	if err := r.Get(ctx, kcpKey, &kcp); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(5).Info("KubeAdmControlPlane not found, skipping reconciliation")
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, fmt.Errorf("failed to get KubeAdmControlPlane %s: %w", kcpKey, err)
+	}
+
+	// Check if we need to trigger a rollout
+	needsRollout, reason, err := r.shouldTriggerRollout(ctx, &cluster, &kcp)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to determine if rollout is needed: %w", err)
+	}
+
+	if needsRollout {
+		logger.Info("Rollout needed due to failure domain changes", "reason", reason)
+
+		// Check if we should skip the rollout due to recent or ongoing rollout activities
+		if shouldSkip, requeueAfter := r.shouldSkipRollout(&kcp); shouldSkip {
+			logger.Info("Skipping rollout due to recent or ongoing rollout activity",
+				"reason", reason, "requeueAfter", requeueAfter)
+			return ctrl.Result{RequeueAfter: requeueAfter}, nil
+		}
+
+		logger.Info("Attempting to trigger KCP rollout due to failure domain changes", "reason", reason)
+
+		// Set rolloutAfter to trigger immediate rollout
+		now := metav1.Now()
+		kcpCopy := kcp.DeepCopy()
+		kcpCopy.Spec.RolloutAfter = &now
+
+		if err := r.Update(ctx, kcpCopy); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update KubeAdmControlPlane %s: %w", kcpKey, err)
+		}
+
+		logger.Info(
+			"Successfully triggered KCP rollout due to failure domain changes",
+			"rolloutAfter",
+			now.Format(time.RFC3339),
+		)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// getMachineDistribution returns the current distribution of machines across failure domains.
+func (r *Reconciler) getMachineDistribution(ctx context.Context, cluster *clusterv1.Cluster) (map[string]int, error) {
+	var machines clusterv1.MachineList
+	if err := r.List(ctx, &machines, client.InNamespace(cluster.Namespace), client.MatchingLabels{
+		clusterv1.ClusterNameLabel:         cluster.Name,
+		clusterv1.MachineControlPlaneLabel: "",
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list control plane machines: %w", err)
+	}
+
+	distribution := make(map[string]int)
+	for i := range machines.Items {
+		if machines.Items[i].Spec.FailureDomain != nil {
+			distribution[*machines.Items[i].Spec.FailureDomain]++
+		}
+	}
+
+	return distribution, nil
+}
+
+// shouldTriggerRollout determines if a rollout should be triggered based on current failure domain state.
+func (r *Reconciler) shouldTriggerRollout(
+	ctx context.Context,
+	cluster *clusterv1.Cluster,
+	kcp *controlplanev1.KubeadmControlPlane,
+) (shouldTrigger bool, reason string, err error) {
+	logger := ctrl.LoggerFrom(ctx).WithValues("cluster", client.ObjectKeyFromObject(cluster))
+
+	// Get the current machine distribution
+	currentDistribution, err := r.getMachineDistribution(ctx, cluster)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to get current machine distribution: %w", err)
+	}
+
+	// Check if any currently used failure domain is disabled or removed
+	for usedFD := range currentDistribution {
+		if fd, exists := cluster.Status.FailureDomains[usedFD]; !exists {
+			logger.V(5).Info("Found removed failure domain in use", "failureDomain", usedFD)
+			return true, fmt.Sprintf("failure domain %s is removed", usedFD), nil
+		} else if !fd.ControlPlane {
+			logger.V(5).Info("Found disabled failure domain in use", "failureDomain", usedFD)
+			return true, fmt.Sprintf("failure domain %s is disabled for control plane", usedFD), nil
+		}
+	}
+
+	// Check if the distribution could be improved
+	availableFDs := getAvailableFailureDomains(cluster.Status.FailureDomains)
+	if shouldImprove := r.shouldImproveDistribution(kcp, currentDistribution, availableFDs); shouldImprove {
+		return true, "failure domain distribution could be improved for better fault tolerance", nil
+	}
+
+	return false, "", nil
+}
+
+// shouldSkipRollout determines if a rollout should be skipped due to recent or ongoing rollout activities.
+// Returns true if rollout should be skipped and the duration to wait before checking again.
+func (r *Reconciler) shouldSkipRollout(kcp *controlplanev1.KubeadmControlPlane) (bool, time.Duration) {
+	// Check if rollout was triggered recently
+	if kcp.Spec.RolloutAfter != nil {
+		timeSinceRollout := time.Since(kcp.Spec.RolloutAfter.Time)
+		if timeSinceRollout < 15*time.Minute {
+			return true, 5 * time.Minute
+		}
+	}
+
+	// Check if KCP is currently rolling out by comparing updated vs total replicas
+	if kcp.Status.UpdatedReplicas < kcp.Status.Replicas {
+		return true, 2 * time.Minute
+	}
+
+	// Check conditions for ongoing updates
+	for _, condition := range kcp.Status.Conditions {
+		if condition.Type == controlplanev1.MachinesSpecUpToDateCondition &&
+			condition.Status == corev1.ConditionFalse {
+			return true, 2 * time.Minute
+		}
+	}
+
+	return false, 0
+}
+
+// shouldImproveDistribution determines if the current failure domain distribution could be improved.
+func (r *Reconciler) shouldImproveDistribution(
+	kcp *controlplanev1.KubeadmControlPlane,
+	currentDistribution map[string]int,
+	availableFDs []string,
+) bool {
+	// Skip if no replicas specified
+	if kcp.Spec.Replicas == nil {
+		return false
+	}
+
+	replicas := int(*kcp.Spec.Replicas)
+	availableCount := len(availableFDs)
+
+	// Check if current distribution violates ideal distribution
+	if r.hasSuboptimalDistribution(currentDistribution, replicas, availableCount) {
+		return true
+	}
+
+	// Check if using more failure domains would improve fault tolerance
+	currentUsedCount := len(currentDistribution)
+	if availableCount > currentUsedCount {
+		return r.canImproveWithMoreFDs(currentDistribution, replicas, availableCount)
+	}
+
+	return false
+}
+
+// hasSuboptimalDistribution checks if any failure domain has more machines than the ideal maximum.
+func (r *Reconciler) hasSuboptimalDistribution(distribution map[string]int, replicas, availableCount int) bool {
+	maxIdealPerFD := r.calculateMaxIdealPerFD(replicas, availableCount)
+
+	for _, count := range distribution {
+		if count > maxIdealPerFD {
+			return true
+		}
+	}
+
+	return false
+}
+
+// canImproveWithMoreFDs checks if using additional failure domains would improve fault tolerance by comparing
+// current max concentration vs ideal max with optimal distribution.
+// Also checks if we can reduce the number of FDs at maximum concentration.
+func (r *Reconciler) canImproveWithMoreFDs(currentDistribution map[string]int, replicas, availableCount int) bool {
+	if len(currentDistribution) == 0 {
+		return false
+	}
+
+	// Find current min and max counts to understand current concentration
+	minCount, maxCount := replicas, 0
+	for _, count := range currentDistribution {
+		if count < minCount {
+			minCount = count
+		}
+		if count > maxCount {
+			maxCount = count
+		}
+	}
+
+	// When this function is called, we know hasSuboptimalDistribution was false,
+	// which means maxCount <= calculateMaxIdealPerFD(replicas, availableCount).
+	// Therefore, we only need to check if we can improve concentration.
+
+	currentFDsAtMax := 0
+	for _, count := range currentDistribution {
+		if count == maxCount {
+			currentFDsAtMax++
+		}
+	}
+
+	// Calculate optimal number of FDs that should have the maximum
+	// In optimal distribution, (replicas % availableCount) FDs get the extra replica
+	optimalFDsAtMax := replicas % availableCount
+	if optimalFDsAtMax == 0 && replicas > 0 {
+		// If evenly divisible and we have replicas, all FDs get the same amount
+		// This means no FDs are "at max" in the sense of having extras
+		optimalFDsAtMax = availableCount
+	}
+
+	// Improvement if we can reduce the number of FDs at maximum concentration
+	return optimalFDsAtMax < currentFDsAtMax
+}
+
+// calculateMaxIdealPerFD calculates the maximum number of machines per failure domain in ideal distribution.
+func (r *Reconciler) calculateMaxIdealPerFD(replicas, availableCount int) int {
+	if availableCount == 0 {
+		return replicas
+	}
+
+	baseReplicasPerFD := replicas / availableCount
+	extraReplicas := replicas % availableCount
+
+	if extraReplicas > 0 {
+		return baseReplicasPerFD + 1
+	}
+
+	return baseReplicasPerFD
+}
+
+// getAvailableFailureDomains returns the names of available failure domains for control plane.
+func getAvailableFailureDomains(failureDomains clusterv1.FailureDomains) []string {
+	var available []string
+	for name, fd := range failureDomains {
+		if fd.ControlPlane {
+			available = append(available, name)
+		}
+	}
+	return available
+}
+
+// kubeadmControlPlaneToCluster maps KubeAdmControlPlane changes to cluster reconcile requests.
+func (r *Reconciler) kubeadmControlPlaneToCluster(ctx context.Context, obj client.Object) []reconcile.Request {
+	kcp, ok := obj.(*controlplanev1.KubeadmControlPlane)
+	if !ok {
+		return nil
+	}
+
+	// Find the cluster that owns this KCP
+	var clusters clusterv1.ClusterList
+	if err := r.List(ctx, &clusters, client.InNamespace(kcp.Namespace)); err != nil {
+		return nil
+	}
+
+	for i := range clusters.Items {
+		if clusters.Items[i].Spec.ControlPlaneRef != nil && clusters.Items[i].Spec.ControlPlaneRef.Name == kcp.Name {
+			return []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Namespace: clusters.Items[i].Namespace,
+						Name:      clusters.Items[i].Name,
+					},
+				},
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controllers/failuredomainrollout/controller_test.go
+++ b/pkg/controllers/failuredomainrollout/controller_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -200,6 +200,77 @@ func TestReconciler_shouldTriggerRollout(t *testing.T) {
 				},
 			},
 			expectedRollout: false,
+		},
+		{
+			name: "new failure domain improves distribution - should trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{
+							ControlPlane: true,
+						},
+						"fd2": clusterv1.FailureDomainSpec{
+							ControlPlane: true,
+						},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+			},
+			machines: []clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-machine-1",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							clusterv1.ClusterNameLabel:         "test-cluster",
+							clusterv1.MachineControlPlaneLabel: "",
+						},
+					},
+					Spec: clusterv1.MachineSpec{
+						FailureDomain: ptr.To("fd1"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-machine-2",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							clusterv1.ClusterNameLabel:         "test-cluster",
+							clusterv1.MachineControlPlaneLabel: "",
+						},
+					},
+					Spec: clusterv1.MachineSpec{
+						FailureDomain: ptr.To("fd1"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-machine-3",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							clusterv1.ClusterNameLabel:         "test-cluster",
+							clusterv1.MachineControlPlaneLabel: "",
+						},
+					},
+					Spec: clusterv1.MachineSpec{
+						FailureDomain: ptr.To("fd1"),
+					},
+				},
+			},
+			expectedRollout: true,
+			expectedReason:  "failure domain distribution could be improved for better fault tolerance",
 		},
 	}
 
@@ -409,6 +480,15 @@ func TestReconciler_shouldImproveDistribution(t *testing.T) {
 			expectedImprove:         false,
 			description:             "0 replicas should not trigger improvement",
 		},
+
+		{
+			name:                    "no available failure domains",
+			replicas:                0,
+			machines:                []clusterv1.Machine{},
+			availableFailureDomains: []string{},
+			expectedImprove:         false,
+			description:             "0 replicas should not trigger improvement",
+		},
 	}
 
 	for _, tt := range tests {
@@ -454,6 +534,256 @@ func TestReconciler_shouldImproveDistribution(t *testing.T) {
 				tt.availableFailureDomains,
 			)
 			require.Equal(t, tt.expectedImprove, shouldImprove, "Test case: %s", tt.description)
+		})
+	}
+}
+
+func TestReconciler_canImproveWithMoreFDs(t *testing.T) {
+	r := &Reconciler{}
+
+	tests := []struct {
+		name                string
+		currentDistribution map[string]int
+		replicas            int
+		availableCount      int
+		expectedImprove     bool
+		description         string
+	}{
+		{
+			name:                "empty distribution",
+			currentDistribution: map[string]int{},
+			replicas:            3,
+			availableCount:      3,
+			expectedImprove:     false,
+			description:         "empty distribution should not improve",
+		},
+		{
+			name: "zero replicas",
+			currentDistribution: map[string]int{
+				"fd1": 0,
+			},
+			replicas:        0,
+			availableCount:  2,
+			expectedImprove: false,
+			description:     "zero replicas cannot improve",
+		},
+		{
+			name: "no additional FDs available",
+			currentDistribution: map[string]int{
+				"fd1": 2,
+				"fd2": 1,
+			},
+			replicas:        3,
+			availableCount:  2,
+			expectedImprove: false,
+			description:     "cannot improve if no additional FDs available",
+		},
+		{
+			name: "1 replica on 1 FD, cannot improve with more FDs",
+			currentDistribution: map[string]int{
+				"fd1": 1,
+			},
+			replicas:        1,
+			availableCount:  3,
+			expectedImprove: false,
+			description:     "single replica already optimal - currentMax=1, optimalMax=1",
+		},
+		{
+			name: "3 replicas concentrated on 1 FD, can spread across 2 FDs",
+			currentDistribution: map[string]int{
+				"fd1": 3,
+			},
+			replicas:        3,
+			availableCount:  2,
+			expectedImprove: true,
+			description:     "can improve [3] → [2,1] - currentMax=3, optimalMax=2",
+		},
+		{
+			name: "3 replicas suboptimal [2,1], can spread across 3 FDs",
+			currentDistribution: map[string]int{
+				"fd1": 2,
+				"fd2": 1,
+			},
+			replicas:        3,
+			availableCount:  3,
+			expectedImprove: true,
+			description:     "can improve [2,1] → [1,1,1] - currentMax=2, optimalMax=1",
+		},
+		{
+			name: "3 replicas optimally distributed across 3 FDs",
+			currentDistribution: map[string]int{
+				"fd1": 1,
+				"fd2": 1,
+				"fd3": 1,
+			},
+			replicas:        3,
+			availableCount:  3,
+			expectedImprove: false,
+			description:     "already optimal - currentMax=1, optimalMax=1",
+		},
+		{
+			name: "3 replicas optimal, extra FDs available",
+			currentDistribution: map[string]int{
+				"fd1": 1,
+				"fd2": 1,
+				"fd3": 1,
+			},
+			replicas:        3,
+			availableCount:  5,
+			expectedImprove: false,
+			description:     "no improvement possible - currentMax=1, optimalMax=1",
+		},
+		{
+			name: "5 replicas concentrated, can spread across more FDs",
+			currentDistribution: map[string]int{
+				"fd1": 3,
+				"fd2": 2,
+			},
+			replicas:        5,
+			availableCount:  5,
+			expectedImprove: true,
+			description:     "can improve [3,2] → [1,1,1,1,1] - currentMax=3, optimalMax=1",
+		},
+		{
+			name: "5 replicas optimally distributed across 3 FDs",
+			currentDistribution: map[string]int{
+				"fd1": 2,
+				"fd2": 2,
+				"fd3": 1,
+			},
+			replicas:        5,
+			availableCount:  3,
+			expectedImprove: false,
+			description:     "already optimal for 3 FDs - currentMax=2, optimalMax=2",
+		},
+		{
+			name: "5 replicas can improve distribution quality",
+			currentDistribution: map[string]int{
+				"fd1": 2,
+				"fd2": 2,
+				"fd3": 1,
+			},
+			replicas:        5,
+			availableCount:  5,
+			expectedImprove: true,
+			description:     "can improve [2,2,1] → [1,1,1,1,1] - currentMax=2, optimalMax=1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := r.canImproveWithMoreFDs(tt.currentDistribution, tt.replicas, tt.availableCount)
+			require.Equal(t, tt.expectedImprove, result, "Test case: %s", tt.description)
+		})
+	}
+}
+
+func TestReconciler_shouldSkipClusterReconciliation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, controlplanev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name         string
+		cluster      *clusterv1.Cluster
+		expectedSkip bool
+		description  string
+	}{
+		{
+			name: "cluster without topology - should skip",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					// No Topology set
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			expectedSkip: true,
+			description:  "should skip when cluster has no topology",
+		},
+		{
+			name: "cluster without control plane ref - should skip",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					// No ControlPlaneRef set
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			expectedSkip: true,
+			description:  "should skip when cluster has no control plane reference",
+		},
+		{
+			name: "cluster without failure domains - should skip",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					// No FailureDomains set
+				},
+			},
+			expectedSkip: true,
+			description:  "should skip when cluster has no failure domains",
+		},
+		{
+			name: "cluster with all required fields - should not skip",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+						"fd2": clusterv1.FailureDomainSpec{ControlPlane: false},
+					},
+				},
+			},
+			expectedSkip: false,
+			description:  "should not skip when cluster has all required fields",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{}
+			logger := logr.Discard()
+
+			shouldSkip := r.shouldSkipClusterReconciliation(tt.cluster, logger)
+
+			require.Equal(t, tt.expectedSkip, shouldSkip, "Test case: %s", tt.description)
 		})
 	}
 }
@@ -809,56 +1139,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 			description:            "fd4 was added but distribution [1,1,1] is already optimal, no improvement possible",
 		},
 		{
-			name: "cluster not reconciled - should requeue",
-			cluster: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-cluster",
-					Namespace:  "test-namespace",
-					Generation: 5, // Higher than observedGeneration
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{},
-					ControlPlaneRef: &corev1.ObjectReference{
-						Name: "test-kcp",
-					},
-				},
-				Status: clusterv1.ClusterStatus{
-					ObservedGeneration: 3, // Lower than generation
-					FailureDomains: clusterv1.FailureDomains{
-						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
-						"fd2": clusterv1.FailureDomainSpec{ControlPlane: true},
-					},
-				},
-			},
-			kcp: &controlplanev1.KubeadmControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-kcp",
-					Namespace:  "test-namespace",
-					Generation: 2,
-				},
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: ptr.To[int32](3),
-				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					ObservedGeneration: 2, // Matches generation
-				},
-			},
-			machines: []clusterv1.Machine{
-				createMachine("m1", "fd1"),
-				createMachine("m2", "fd2"),
-			},
-			expectRolloutTriggered: false,
-			expectRequeue:          true,
-			expectedRequeueAfter:   2 * time.Minute,
-			description:            "cluster observedGeneration < generation, should requeue",
-		},
-		{
 			name: "kubeadmcontrolplane not reconciled - should requeue",
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "test-cluster",
-					Namespace:  "test-namespace",
-					Generation: 3,
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
 				},
 				Spec: clusterv1.ClusterSpec{
 					Topology: &clusterv1.Topology{},
@@ -867,7 +1152,6 @@ func TestReconciler_Reconcile(t *testing.T) {
 					},
 				},
 				Status: clusterv1.ClusterStatus{
-					ObservedGeneration: 3, // Matches generation
 					FailureDomains: clusterv1.FailureDomains{
 						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
 						"fd2": clusterv1.FailureDomainSpec{ControlPlane: true},
@@ -895,6 +1179,252 @@ func TestReconciler_Reconcile(t *testing.T) {
 			expectRequeue:          true,
 			expectedRequeueAfter:   2 * time.Minute,
 			description:            "kcp observedGeneration < generation, should requeue",
+		},
+		{
+			name: "cluster not reconciled - should requeue",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster",
+					Namespace:  "test-namespace",
+					Generation: 5, // Higher than observedGeneration
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					ObservedGeneration: 2, // Lower than generation
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+						"fd2": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-kcp",
+					Namespace:  "test-namespace",
+					Generation: 3,
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					ObservedGeneration: 3, // Same as generation - KCP is reconciled
+				},
+			},
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd2"),
+			},
+			expectRolloutTriggered: false,
+			expectRequeue:          true,
+			expectedRequeueAfter:   2 * time.Minute,
+			description:            "cluster observedGeneration < generation, should requeue",
+		},
+		{
+			name: "both cluster and kcp not reconciled - should requeue",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster",
+					Namespace:  "test-namespace",
+					Generation: 5, // Higher than observedGeneration
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					ObservedGeneration: 2, // Lower than generation
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+						"fd2": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-kcp",
+					Namespace:  "test-namespace",
+					Generation: 7, // Higher than observedGeneration
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					ObservedGeneration: 4, // Lower than generation
+				},
+			},
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd2"),
+			},
+			expectRolloutTriggered: false,
+			expectRequeue:          true,
+			expectedRequeueAfter:   2 * time.Minute,
+			description:            "both cluster and kcp observedGeneration < generation, should requeue",
+		},
+		{
+			name: "cluster being deleted - should skip reconciliation",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "test-namespace",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"test-finalizer"},
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+			},
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+			},
+			expectRolloutTriggered: false,
+			expectRequeue:          false,
+			description:            "cluster has deletion timestamp, should skip reconciliation",
+		},
+		{
+			name: "kcp being deleted - should skip reconciliation",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-kcp",
+					Namespace:         "test-namespace",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"test-finalizer"},
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+			},
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+			},
+			expectRolloutTriggered: false,
+			expectRequeue:          false,
+			description:            "kcp has deletion timestamp, should skip reconciliation",
+		},
+		{
+			name: "both cluster and kcp being deleted - should skip reconciliation",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "test-namespace",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"test-finalizer"},
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-kcp",
+					Namespace:         "test-namespace",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"test-finalizer"},
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+			},
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+			},
+			expectRolloutTriggered: false,
+			expectRequeue:          false,
+			description:            "both cluster and kcp have deletion timestamps, should skip reconciliation",
+		},
+		{
+			name: "cluster paused - should skip reconciliation",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Paused: true,
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			expectRolloutTriggered: false,
+			expectRequeue:          false,
+			description:            "cluster is paused, should skip reconciliation",
+		},
+		{
+			name: "kcp paused via annotation - should skip reconciliation",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Paused: false,
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						"cluster.x-k8s.io/paused": "",
+					},
+				},
+			},
+			expectRolloutTriggered: false,
+			expectRequeue:          false,
+			description:            "kcp has paused annotation, should skip reconciliation",
 		},
 	}
 
@@ -971,6 +1501,406 @@ func TestReconciler_Reconcile(t *testing.T) {
 	}
 }
 
+// TestReconciler_areResourcesDeleting tests the deletion check helper function.
+func TestReconciler_areResourcesDeleting(t *testing.T) {
+	tests := []struct {
+		name     string
+		cluster  *clusterv1.Cluster
+		kcp      *controlplanev1.KubeadmControlPlane
+		expected bool
+	}{
+		{
+			name: "no deletion timestamps - should not be deleting",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "cluster has deletion timestamp - should be deleting",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "test-namespace",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"test-finalizer"},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "kcp has deletion timestamp - should be deleting",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-kcp",
+					Namespace:         "test-namespace",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"test-finalizer"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "both have deletion timestamps - should be deleting",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "test-namespace",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"test-finalizer"},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-kcp",
+					Namespace:         "test-namespace",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"test-finalizer"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "nil cluster - should not be deleting",
+			cluster: nil,
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "nil kcp - should not be deleting",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+			},
+			kcp:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{}
+			result := r.areResourcesDeleting(tt.cluster, tt.kcp)
+			require.Equal(t, tt.expected, result, "areResourcesDeleting result should match expected")
+		})
+	}
+}
+
+// TestReconciler_areResourcesUpdating tests the updating check helper function.
+func TestReconciler_areResourcesUpdating(t *testing.T) {
+	tests := []struct {
+		name     string
+		cluster  *clusterv1.Cluster
+		kcp      *controlplanev1.KubeadmControlPlane
+		expected bool
+	}{
+		{
+			name: "both resources reconciled - should not be updating",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster",
+					Namespace:  "test-namespace",
+					Generation: 5,
+				},
+				Status: clusterv1.ClusterStatus{
+					ObservedGeneration: 5,
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-kcp",
+					Namespace:  "test-namespace",
+					Generation: 3,
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					ObservedGeneration: 3,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "cluster not reconciled - should be updating",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster",
+					Namespace:  "test-namespace",
+					Generation: 5,
+				},
+				Status: clusterv1.ClusterStatus{
+					ObservedGeneration: 3, // Lower than generation
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-kcp",
+					Namespace:  "test-namespace",
+					Generation: 3,
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					ObservedGeneration: 3,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "kcp not reconciled - should be updating",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster",
+					Namespace:  "test-namespace",
+					Generation: 5,
+				},
+				Status: clusterv1.ClusterStatus{
+					ObservedGeneration: 5,
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-kcp",
+					Namespace:  "test-namespace",
+					Generation: 7,
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					ObservedGeneration: 4, // Lower than generation
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "both not reconciled - should be updating",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster",
+					Namespace:  "test-namespace",
+					Generation: 5,
+				},
+				Status: clusterv1.ClusterStatus{
+					ObservedGeneration: 2, // Lower than generation
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-kcp",
+					Namespace:  "test-namespace",
+					Generation: 7,
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					ObservedGeneration: 4, // Lower than generation
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "nil cluster - should not be updating",
+			cluster: nil,
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-kcp",
+					Namespace:  "test-namespace",
+					Generation: 3,
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					ObservedGeneration: 3,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "nil kcp - should not be updating",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster",
+					Namespace:  "test-namespace",
+					Generation: 5,
+				},
+				Status: clusterv1.ClusterStatus{
+					ObservedGeneration: 5,
+				},
+			},
+			kcp:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{}
+			result := r.areResourcesUpdating(tt.cluster, tt.kcp)
+			require.Equal(t, tt.expected, result, "areResourcesUpdating result should match expected")
+		})
+	}
+}
+
+func TestReconciler_areResourcesPaused(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, controlplanev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name           string
+		cluster        *clusterv1.Cluster
+		kcp            *controlplanev1.KubeadmControlPlane
+		expectedPaused bool
+		description    string
+	}{
+		{
+			name: "cluster not paused - should not be paused",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					// Paused field not set (defaults to false)
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedPaused: false,
+			description:    "should not be paused when cluster is not paused",
+		},
+		{
+			name: "cluster explicitly not paused - should not be paused",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Paused: false,
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedPaused: false,
+			description:    "should not be paused when cluster is explicitly not paused",
+		},
+		{
+			name: "cluster paused - should be paused",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Paused: true,
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedPaused: true,
+			description:    "should be paused when cluster is paused",
+		},
+		{
+			name:    "nil cluster - should not be paused",
+			cluster: nil,
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedPaused: false,
+			description:    "should not be paused when cluster is nil",
+		},
+		{
+			name: "nil kcp - should respect cluster paused state",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Paused: true,
+				},
+			},
+			kcp:            nil,
+			expectedPaused: true,
+			description:    "should be paused when cluster is paused even if kcp is nil",
+		},
+		{
+			name:           "both nil - should not be paused",
+			cluster:        nil,
+			kcp:            nil,
+			expectedPaused: false,
+			description:    "should not be paused when both cluster and kcp are nil",
+		},
+		{
+			name: "kcp with paused annotation - should be paused",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Paused: false,
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						"cluster.x-k8s.io/paused": "",
+					},
+				},
+			},
+			expectedPaused: true,
+			description:    "should be paused when kcp has paused annotation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{}
+
+			isPaused := r.areResourcesPaused(tt.cluster, tt.kcp)
+
+			require.Equal(t, tt.expectedPaused, isPaused, "Test case: %s", tt.description)
+		})
+	}
+}
+
 // TestReconciler_SetupWithManager tests the controller setup.
 func TestReconciler_SetupWithManager(t *testing.T) {
 	// This test verifies that SetupWithManager doesn't panic when called with nil
@@ -984,178 +1914,6 @@ func TestReconciler_SetupWithManager(t *testing.T) {
 	// This ensures the function handles edge cases without panicking
 	err := r.SetupWithManager(nil, options)
 	require.Error(t, err, "SetupWithManager should return an error with nil manager")
-}
-
-// TestReconciler_kubeadmControlPlaneToCluster tests the KCP to cluster mapping.
-func TestReconciler_kubeadmControlPlaneToCluster(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, clusterv1.AddToScheme(scheme))
-	require.NoError(t, controlplanev1.AddToScheme(scheme))
-
-	tests := []struct {
-		name            string
-		obj             client.Object
-		clusters        []clusterv1.Cluster
-		expectedRequest []reconcile.Request
-		description     string
-	}{
-		{
-			name: "valid KCP with matching cluster",
-			obj: &controlplanev1.KubeadmControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-kcp",
-					Namespace: "test-namespace",
-				},
-			},
-			clusters: []clusterv1.Cluster{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-cluster",
-						Namespace: "test-namespace",
-					},
-					Spec: clusterv1.ClusterSpec{
-						ControlPlaneRef: &corev1.ObjectReference{
-							Name: "test-kcp",
-						},
-					},
-				},
-			},
-			expectedRequest: []reconcile.Request{
-				{
-					NamespacedName: types.NamespacedName{
-						Namespace: "test-namespace",
-						Name:      "test-cluster",
-					},
-				},
-			},
-			description: "should return reconcile request for matching cluster",
-		},
-		{
-			name: "valid KCP with no matching cluster",
-			obj: &controlplanev1.KubeadmControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-kcp",
-					Namespace: "test-namespace",
-				},
-			},
-			clusters: []clusterv1.Cluster{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "other-cluster",
-						Namespace: "test-namespace",
-					},
-					Spec: clusterv1.ClusterSpec{
-						ControlPlaneRef: &corev1.ObjectReference{
-							Name: "other-kcp",
-						},
-					},
-				},
-			},
-			expectedRequest: nil,
-			description:     "should return nil when no matching cluster found",
-		},
-		{
-			name: "invalid object type",
-			obj: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster",
-					Namespace: "test-namespace",
-				},
-			},
-			clusters:        []clusterv1.Cluster{},
-			expectedRequest: nil,
-			description:     "should return nil for non-KCP objects",
-		},
-		{
-			name: "cluster with nil ControlPlaneRef",
-			obj: &controlplanev1.KubeadmControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-kcp",
-					Namespace: "test-namespace",
-				},
-			},
-			clusters: []clusterv1.Cluster{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-cluster",
-						Namespace: "test-namespace",
-					},
-					Spec: clusterv1.ClusterSpec{
-						ControlPlaneRef: nil,
-					},
-				},
-			},
-			expectedRequest: nil,
-			description:     "should return nil when cluster has no ControlPlaneRef",
-		},
-		{
-			name: "multiple clusters with one match",
-			obj: &controlplanev1.KubeadmControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-kcp",
-					Namespace: "test-namespace",
-				},
-			},
-			clusters: []clusterv1.Cluster{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "other-cluster",
-						Namespace: "test-namespace",
-					},
-					Spec: clusterv1.ClusterSpec{
-						ControlPlaneRef: &corev1.ObjectReference{
-							Name: "other-kcp",
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-cluster",
-						Namespace: "test-namespace",
-					},
-					Spec: clusterv1.ClusterSpec{
-						ControlPlaneRef: &corev1.ObjectReference{
-							Name: "test-kcp",
-						},
-					},
-				},
-			},
-			expectedRequest: []reconcile.Request{
-				{
-					NamespacedName: types.NamespacedName{
-						Namespace: "test-namespace",
-						Name:      "test-cluster",
-					},
-				},
-			},
-			description: "should return reconcile request for the matching cluster among multiple",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create fake client with test clusters
-			objs := make([]client.Object, 0, len(tt.clusters))
-			for i := range tt.clusters {
-				objs = append(objs, &tt.clusters[i])
-			}
-
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(objs...).
-				Build()
-
-			r := &Reconciler{
-				Client: fakeClient,
-			}
-
-			// Execute the mapping function
-			result := r.kubeadmControlPlaneToCluster(context.Background(), tt.obj)
-
-			// Verify the result
-			require.Equal(t, tt.expectedRequest, result, "Test case: %s", tt.description)
-		})
-	}
 }
 
 // TestOptions_AddFlags tests the flag registration.

--- a/pkg/controllers/failuredomainrollout/controller_test.go
+++ b/pkg/controllers/failuredomainrollout/controller_test.go
@@ -1,0 +1,1085 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package failuredomainrollout
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconciler_shouldTriggerRollout(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, controlplanev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name            string
+		cluster         *clusterv1.Cluster
+		kcp             *controlplanev1.KubeadmControlPlane
+		machines        []clusterv1.Machine
+		expectedRollout bool
+		expectedReason  string
+	}{
+		{
+			name: "no previous hash - should not trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{
+							ControlPlane: true,
+						},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedRollout: false,
+		},
+		{
+			name: "same failure domains - should not trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{
+							ControlPlane: true,
+						},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedRollout: false,
+		},
+		{
+			name: "used failure domain removed - should trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd2": clusterv1.FailureDomainSpec{
+							ControlPlane: true,
+						},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			machines: []clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-machine-1",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							clusterv1.ClusterNameLabel:         "test-cluster",
+							clusterv1.MachineControlPlaneLabel: "",
+						},
+					},
+					Spec: clusterv1.MachineSpec{
+						FailureDomain: ptr.To("fd1"), // Using fd1 which is now removed
+					},
+				},
+			},
+			expectedRollout: true,
+			expectedReason:  "failure domain fd1 is removed",
+		},
+		{
+			name: "used failure domain disabled - should trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{
+							ControlPlane: false, // Disabled for control plane
+						},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			machines: []clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-machine-1",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							clusterv1.ClusterNameLabel:         "test-cluster",
+							clusterv1.MachineControlPlaneLabel: "",
+						},
+					},
+					Spec: clusterv1.MachineSpec{
+						FailureDomain: ptr.To("fd1"), // Using fd1 which is now disabled
+					},
+				},
+			},
+			expectedRollout: true,
+			expectedReason:  "failure domain fd1 is disabled for control plane",
+		},
+		{
+			name: "new failure domain added - should not trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{
+							ControlPlane: true,
+						},
+						"fd2": clusterv1.FailureDomainSpec{
+							ControlPlane: true,
+						},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			machines: []clusterv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-machine-1",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							clusterv1.ClusterNameLabel:         "test-cluster",
+							clusterv1.MachineControlPlaneLabel: "",
+						},
+					},
+					Spec: clusterv1.MachineSpec{
+						FailureDomain: ptr.To("fd1"), // Using fd1 which is still available
+					},
+				},
+			},
+			expectedRollout: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []client.Object{tt.cluster, tt.kcp}
+			for i := range tt.machines {
+				objs = append(objs, &tt.machines[i])
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				Build()
+
+			r := &Reconciler{
+				Client: fakeClient,
+			}
+
+			needsRollout, reason, err := r.shouldTriggerRollout(context.Background(), tt.cluster, tt.kcp)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedRollout, needsRollout)
+			if tt.expectedReason != "" {
+				require.Equal(t, tt.expectedReason, reason)
+			}
+		})
+	}
+}
+
+func TestReconciler_shouldImproveDistribution(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, controlplanev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name                    string
+		replicas                int32
+		machines                []clusterv1.Machine
+		availableFailureDomains []string
+		expectedImprove         bool
+		description             string
+	}{
+		// 1 replica tests
+		{
+			name:     "1 replica, 1 FD - already optimal",
+			replicas: 1,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+			},
+			availableFailureDomains: []string{"fd1"},
+			expectedImprove:         false,
+			description:             "1 replica on 1 FD is optimal",
+		},
+		{
+			name:     "1 replica, 1 FD, new FD added - no improvement possible",
+			replicas: 1,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2"},
+			expectedImprove:         false,
+			description:             "adding FDs doesn't help with 1 replica",
+		},
+
+		// 3 replica tests
+		{
+			name:     "3 replicas, 1 FD - should improve when 2nd FD added",
+			replicas: 3,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd1"),
+				createMachine("m3", "fd1"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2"},
+			expectedImprove:         true,
+			description:             "3 replicas on 1 FD can improve to [2,1]",
+		},
+		{
+			name:     "3 replicas, 2 FDs [2,1] - should improve when 3rd FD added",
+			replicas: 3,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd1"),
+				createMachine("m3", "fd2"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2", "fd3"},
+			expectedImprove:         true,
+			description:             "3 replicas [2,1] can improve to [1,1,1]",
+		},
+		{
+			name:     "3 replicas, 3 FDs [1,1,1] - already optimal",
+			replicas: 3,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd2"),
+				createMachine("m3", "fd3"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2", "fd3"},
+			expectedImprove:         false,
+			description:             "3 replicas evenly distributed is optimal",
+		},
+		{
+			name:     "3 replicas, 3 FDs [1,1,1], 4th FD added - no improvement needed",
+			replicas: 3,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd2"),
+				createMachine("m3", "fd3"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2", "fd3", "fd4"},
+			expectedImprove:         false,
+			description:             "3 replicas [1,1,1] is still optimal with 4th FD",
+		},
+
+		// 5 replica tests
+		{
+			name:     "5 replicas, 1 FD - should improve when 2nd FD added",
+			replicas: 5,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd1"),
+				createMachine("m3", "fd1"),
+				createMachine("m4", "fd1"),
+				createMachine("m5", "fd1"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2"},
+			expectedImprove:         true,
+			description:             "5 replicas on 1 FD can improve to [3,2]",
+		},
+		{
+			name:     "5 replicas, 2 FDs [3,2] - should improve when 3rd FD added",
+			replicas: 5,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd1"),
+				createMachine("m3", "fd1"),
+				createMachine("m4", "fd2"),
+				createMachine("m5", "fd2"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2", "fd3"},
+			expectedImprove:         true,
+			description:             "5 replicas [3,2] can improve to [2,2,1]",
+		},
+		{
+			name:     "5 replicas, 3 FDs [2,2,1] - should improve when 4th FD added",
+			replicas: 5,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd1"),
+				createMachine("m3", "fd2"),
+				createMachine("m4", "fd2"),
+				createMachine("m5", "fd3"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2", "fd3", "fd4"},
+			expectedImprove:         true,
+			description:             "5 replicas [2,2,1] can improve to [2,1,1,1]",
+		},
+		{
+			name:     "5 replicas, 4 FDs [2,1,1,1] - should improve when 5th FD added",
+			replicas: 5,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd1"),
+				createMachine("m3", "fd2"),
+				createMachine("m4", "fd3"),
+				createMachine("m5", "fd4"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2", "fd3", "fd4", "fd5"},
+			expectedImprove:         true,
+			description:             "5 replicas [2,1,1,1] can improve to [1,1,1,1,1]",
+		},
+		{
+			name:     "5 replicas, 5 FDs [1,1,1,1,1] - already optimal",
+			replicas: 5,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd2"),
+				createMachine("m3", "fd3"),
+				createMachine("m4", "fd4"),
+				createMachine("m5", "fd5"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2", "fd3", "fd4", "fd5"},
+			expectedImprove:         false,
+			description:             "5 replicas evenly distributed is optimal",
+		},
+		{
+			name:     "5 replicas, 5 FDs [1,1,1,1,1], 6th FD added - no improvement needed",
+			replicas: 5,
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd2"),
+				createMachine("m3", "fd3"),
+				createMachine("m4", "fd4"),
+				createMachine("m5", "fd5"),
+			},
+			availableFailureDomains: []string{"fd1", "fd2", "fd3", "fd4", "fd5", "fd6"},
+			expectedImprove:         false,
+			description:             "5 replicas [1,1,1,1,1] is still optimal with 6th FD",
+		},
+
+		// Edge cases
+		{
+			name:                    "no replicas specified",
+			replicas:                0,
+			machines:                []clusterv1.Machine{},
+			availableFailureDomains: []string{"fd1", "fd2"},
+			expectedImprove:         false,
+			description:             "0 replicas should not trigger improvement",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+			}
+
+			kcp := &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: &tt.replicas,
+				},
+			}
+
+			objs := []client.Object{cluster, kcp}
+			for i := range tt.machines {
+				objs = append(objs, &tt.machines[i])
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				Build()
+
+			r := &Reconciler{
+				Client: fakeClient,
+			}
+
+			// Get current distribution from the fake client
+			currentDistribution, err := r.getMachineDistribution(context.Background(), cluster)
+			require.NoError(t, err)
+
+			shouldImprove := r.shouldImproveDistribution(
+				kcp,
+				currentDistribution,
+				tt.availableFailureDomains,
+			)
+			require.Equal(t, tt.expectedImprove, shouldImprove, "Test case: %s", tt.description)
+		})
+	}
+}
+
+func TestReconciler_shouldSkipRollout(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, controlplanev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name                 string
+		kcp                  *controlplanev1.KubeadmControlPlane
+		expectedSkip         bool
+		expectedRequeueAfter time.Duration
+		description          string
+	}{
+		{
+			name: "no rollout after set - should not skip",
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					// No RolloutAfter set
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Replicas:        3,
+					UpdatedReplicas: 3,
+				},
+			},
+			expectedSkip:         false,
+			expectedRequeueAfter: 0,
+			description:          "should not skip when no rollout is in progress",
+		},
+		{
+			name: "recent rollout after set - should skip",
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					RolloutAfter: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Replicas:        3,
+					UpdatedReplicas: 3,
+				},
+			},
+			expectedSkip:         true,
+			expectedRequeueAfter: 5 * time.Minute,
+			description:          "should skip when rollout was triggered recently",
+		},
+		{
+			name: "old rollout after set - should not skip",
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					RolloutAfter: &metav1.Time{Time: time.Now().Add(-25 * time.Minute)},
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Replicas:        3,
+					UpdatedReplicas: 3,
+				},
+			},
+			expectedSkip:         false,
+			expectedRequeueAfter: 0,
+			description:          "should not skip when rollout was triggered long ago",
+		},
+		{
+			name: "rollout in progress - should skip",
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					// No RolloutAfter set
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Replicas:        3,
+					UpdatedReplicas: 1, // Rollout in progress
+				},
+			},
+			expectedSkip:         true,
+			expectedRequeueAfter: 2 * time.Minute,
+			description:          "should skip when rollout is in progress (updated < replicas)",
+		},
+		{
+			name: "machines not up to date - should skip",
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					// No RolloutAfter set
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Replicas:        3,
+					UpdatedReplicas: 3,
+					Conditions: []clusterv1.Condition{
+						{
+							Type:   controlplanev1.MachinesSpecUpToDateCondition,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			expectedSkip:         true,
+			expectedRequeueAfter: 2 * time.Minute,
+			description:          "should skip when machines are not up to date",
+		},
+		{
+			name: "multiple skip conditions - should skip with shortest requeue",
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					RolloutAfter: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Replicas:        3,
+					UpdatedReplicas: 1, // Also in progress
+				},
+			},
+			expectedSkip:         true,
+			expectedRequeueAfter: 5 * time.Minute, // First check returns first
+			description:          "should skip with first applicable condition",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{}
+
+			shouldSkip, requeueAfter := r.shouldSkipRollout(tt.kcp)
+
+			require.Equal(t, tt.expectedSkip, shouldSkip, "Test case: %s", tt.description)
+			require.Equal(t, tt.expectedRequeueAfter, requeueAfter, "Test case: %s", tt.description)
+		})
+	}
+}
+
+func TestReconciler_Reconcile(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, controlplanev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name                   string
+		cluster                *clusterv1.Cluster
+		kcp                    *controlplanev1.KubeadmControlPlane
+		machines               []clusterv1.Machine
+		expectRolloutTriggered bool
+		description            string
+	}{
+		{
+			name: "failure domain removed - should trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd2": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+			},
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd2"),
+			},
+			expectRolloutTriggered: true,
+			description:            "fd1 was removed from cluster, machine still uses it",
+		},
+		{
+			name: "failure domain disabled - should trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: false}, // Disabled
+						"fd2": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+			},
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd2"),
+			},
+			expectRolloutTriggered: true,
+			description:            "fd1 was disabled, machine still uses it",
+		},
+		{
+			name: "distribution improvement - should trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+						"fd2": clusterv1.FailureDomainSpec{ControlPlane: true},
+						"fd3": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+			},
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd1"),
+				createMachine("m3", "fd2"),
+			},
+			expectRolloutTriggered: true,
+			description:            "fd3 was added, can improve from [2,1] to [1,1,1]",
+		},
+		{
+			name: "no changes - should not trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+						"fd2": clusterv1.FailureDomainSpec{ControlPlane: true},
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+			},
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd2"),
+			},
+			expectRolloutTriggered: false,
+			description:            "same failure domains, no changes",
+		},
+		{
+			name: "no meaningful changes - should not trigger rollout",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "test-kcp",
+					},
+				},
+				Status: clusterv1.ClusterStatus{
+					FailureDomains: clusterv1.FailureDomains{
+						"fd1": clusterv1.FailureDomainSpec{ControlPlane: true},
+						"fd2": clusterv1.FailureDomainSpec{ControlPlane: true},
+						"fd3": clusterv1.FailureDomainSpec{ControlPlane: true},
+						"fd4": clusterv1.FailureDomainSpec{ControlPlane: true}, // 4th FD added
+					},
+				},
+			},
+			kcp: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: ptr.To[int32](3),
+				},
+			},
+			machines: []clusterv1.Machine{
+				createMachine("m1", "fd1"),
+				createMachine("m2", "fd2"),
+				createMachine("m3", "fd3"),
+			},
+			expectRolloutTriggered: false,
+			description:            "fd4 was added but distribution [1,1,1] is already optimal, no improvement possible",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client with test objects
+			objs := []client.Object{tt.cluster, tt.kcp}
+			for i := range tt.machines {
+				objs = append(objs, &tt.machines[i])
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				Build()
+
+			r := &Reconciler{
+				Client: fakeClient,
+			}
+
+			// Store initial state
+			initialRolloutAfter := tt.kcp.Spec.RolloutAfter
+
+			// Execute reconciliation
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(tt.cluster),
+			}
+
+			result, err := r.Reconcile(context.Background(), req)
+			require.NoError(t, err, "Reconciliation should not fail")
+			require.Equal(t, reconcile.Result{}, result, "Should return empty result")
+
+			// Verify the KCP was updated correctly
+			var updatedKCP controlplanev1.KubeadmControlPlane
+			err = fakeClient.Get(context.Background(), client.ObjectKeyFromObject(tt.kcp), &updatedKCP)
+			require.NoError(t, err, "Should be able to get updated KCP")
+
+			if tt.expectRolloutTriggered {
+				require.NotNil(t, updatedKCP.Spec.RolloutAfter, "RolloutAfter should be set")
+				require.NotEqual(t, initialRolloutAfter, updatedKCP.Spec.RolloutAfter, "RolloutAfter should be updated")
+				require.WithinDuration(
+					t,
+					time.Now(),
+					updatedKCP.Spec.RolloutAfter.Time,
+					5*time.Second,
+					"RolloutAfter should be recent",
+				)
+			} else {
+				require.Equal(t, initialRolloutAfter, updatedKCP.Spec.RolloutAfter, "RolloutAfter should not be changed")
+			}
+		})
+	}
+}
+
+// TestReconciler_SetupWithManager tests the controller setup.
+func TestReconciler_SetupWithManager(t *testing.T) {
+	// This test verifies that SetupWithManager doesn't panic when called with nil
+	// In real usage, this would be called with a proper manager
+	r := &Reconciler{}
+	options := &controller.Options{
+		MaxConcurrentReconciles: 1,
+	}
+
+	// Test that calling SetupWithManager with nil manager returns an error gracefully
+	// This ensures the function handles edge cases without panicking
+	err := r.SetupWithManager(nil, options)
+	require.Error(t, err, "SetupWithManager should return an error with nil manager")
+}
+
+// TestReconciler_kubeadmControlPlaneToCluster tests the KCP to cluster mapping.
+func TestReconciler_kubeadmControlPlaneToCluster(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, controlplanev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name            string
+		obj             client.Object
+		clusters        []clusterv1.Cluster
+		expectedRequest []reconcile.Request
+		description     string
+	}{
+		{
+			name: "valid KCP with matching cluster",
+			obj: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			clusters: []clusterv1.Cluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster",
+						Namespace: "test-namespace",
+					},
+					Spec: clusterv1.ClusterSpec{
+						ControlPlaneRef: &corev1.ObjectReference{
+							Name: "test-kcp",
+						},
+					},
+				},
+			},
+			expectedRequest: []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Namespace: "test-namespace",
+						Name:      "test-cluster",
+					},
+				},
+			},
+			description: "should return reconcile request for matching cluster",
+		},
+		{
+			name: "valid KCP with no matching cluster",
+			obj: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			clusters: []clusterv1.Cluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-cluster",
+						Namespace: "test-namespace",
+					},
+					Spec: clusterv1.ClusterSpec{
+						ControlPlaneRef: &corev1.ObjectReference{
+							Name: "other-kcp",
+						},
+					},
+				},
+			},
+			expectedRequest: nil,
+			description:     "should return nil when no matching cluster found",
+		},
+		{
+			name: "invalid object type",
+			obj: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+			},
+			clusters:        []clusterv1.Cluster{},
+			expectedRequest: nil,
+			description:     "should return nil for non-KCP objects",
+		},
+		{
+			name: "cluster with nil ControlPlaneRef",
+			obj: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			clusters: []clusterv1.Cluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster",
+						Namespace: "test-namespace",
+					},
+					Spec: clusterv1.ClusterSpec{
+						ControlPlaneRef: nil,
+					},
+				},
+			},
+			expectedRequest: nil,
+			description:     "should return nil when cluster has no ControlPlaneRef",
+		},
+		{
+			name: "multiple clusters with one match",
+			obj: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-kcp",
+					Namespace: "test-namespace",
+				},
+			},
+			clusters: []clusterv1.Cluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-cluster",
+						Namespace: "test-namespace",
+					},
+					Spec: clusterv1.ClusterSpec{
+						ControlPlaneRef: &corev1.ObjectReference{
+							Name: "other-kcp",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster",
+						Namespace: "test-namespace",
+					},
+					Spec: clusterv1.ClusterSpec{
+						ControlPlaneRef: &corev1.ObjectReference{
+							Name: "test-kcp",
+						},
+					},
+				},
+			},
+			expectedRequest: []reconcile.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Namespace: "test-namespace",
+						Name:      "test-cluster",
+					},
+				},
+			},
+			description: "should return reconcile request for the matching cluster among multiple",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client with test clusters
+			objs := make([]client.Object, 0, len(tt.clusters))
+			for i := range tt.clusters {
+				objs = append(objs, &tt.clusters[i])
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				Build()
+
+			r := &Reconciler{
+				Client: fakeClient,
+			}
+
+			// Execute the mapping function
+			result := r.kubeadmControlPlaneToCluster(context.Background(), tt.obj)
+
+			// Verify the result
+			require.Equal(t, tt.expectedRequest, result, "Test case: %s", tt.description)
+		})
+	}
+}
+
+// TestOptions_AddFlags tests the flag registration.
+func TestOptions_AddFlags(t *testing.T) {
+	// Test that AddFlags doesn't panic when called
+	t.Run("AddFlags doesn't panic", func(t *testing.T) {
+		flagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		options := &Options{}
+
+		// This should not panic
+		require.NotPanics(t, func() {
+			options.AddFlags(flagSet)
+		}, "AddFlags should not panic")
+	})
+
+	// Test struct field defaults
+	t.Run("default struct values", func(t *testing.T) {
+		options := &Options{}
+
+		// Test that we can set the fields directly
+		options.Enabled = true
+		options.Concurrency = 10
+
+		require.True(t, options.Enabled, "Enabled should be settable")
+		require.Equal(t, 10, options.Concurrency, "Concurrency should be settable")
+	})
+}
+
+// Helper function to create machines for testing.
+func createMachine(name, failureDomain string) clusterv1.Machine {
+	return clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:         "test-cluster",
+				clusterv1.MachineControlPlaneLabel: "",
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			FailureDomain: ptr.To(failureDomain),
+		},
+	}
+}

--- a/pkg/controllers/failuredomainrollout/doc.go
+++ b/pkg/controllers/failuredomainrollout/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package failuredomainrollout provides a controller that monitors cluster.status.failureDomains
+// and triggers rollouts on KubeAdmControlPlane when there are meaningful changes to failure domains
+// that impact the current control plane placement.
+//
+// A meaningful change is defined as:
+// - A failure domain currently in use by the control plane being disabled (controlPlane: false)
+// - A failure domain currently in use by the control plane being removed
+// - A failure domain is overutilized and can be improved by spreading the control plane across more failure domains
+//
+// The controller does NOT trigger rollouts when:
+// - New failure domains are added but existing ones remain valid
+// - Changes to failure domains that are not currently in use by the control plane
+//
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters/status,verbs=get
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kubeadmcontrolplanes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=get;list;watch
+package failuredomainrollout

--- a/pkg/controllers/failuredomainrollout/flags.go
+++ b/pkg/controllers/failuredomainrollout/flags.go
@@ -1,0 +1,30 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package failuredomainrollout
+
+import (
+	"github.com/spf13/pflag"
+)
+
+type Options struct {
+	Enabled     bool
+	Concurrency int
+}
+
+func (o *Options) AddFlags(flags *pflag.FlagSet) {
+	pflag.CommandLine.BoolVar(
+		&o.Enabled,
+		"failure-domain-rollout-enabled",
+		true,
+		"Enable failure domain rollout controller to monitor cluster.status.failureDomains and trigger rollouts on "+
+			"KubeAdmControlPlane when there are meaningful changes.",
+	)
+
+	pflag.CommandLine.IntVar(
+		&o.Concurrency,
+		"failure-domain-rollout-concurrency",
+		10,
+		"Number of Clusters to handle concurrently for failure domain rollout monitoring.",
+	)
+}


### PR DESCRIPTION
Adds a new controller that monitors cluster.status.failureDomains and triggers rollouts on KubeAdmControlPlane when failure domains currently in use by control plane machines are disabled or removed.

The controller is enabled by default and can be disabled with --failure-domain-rollout-enabled=false.

**How has this been tested?**
* Create 4 failure domains: fd-1, fd-2, fd-3, fd-4
* Create a cluster with control plane on 3 failure domains fd-1, fd-2, fd-3
* Remove fd-3 from the control plane configuration and observe a rollout to fd-1 & fd-2 only
* Add fd-3 again and observe a rollout to fd-1, fd-2, and fd-3
* Add fd-4 to control plane configuration and observe no rollout takes place