### PR TITLE
feat: Skip FD dependent preflight checks when failureDomain configured

### DIFF
--- a/pkg/webhook/preflight/nutanix/checker.go
+++ b/pkg/webhook/preflight/nutanix/checker.go
@@ -60,6 +60,7 @@ type checkDependencies struct {
 
 	nutanixClusterConfigSpec                           *carenv1.NutanixClusterConfigSpec
 	nutanixWorkerNodeConfigSpecByMachineDeploymentName map[string]*carenv1.NutanixWorkerNodeConfigSpec
+	failureDomainByMachineDeploymentName               map[string]string
 
 	nclient client
 	log     logr.Logger

--- a/pkg/webhook/preflight/nutanix/specs.go
+++ b/pkg/webhook/preflight/nutanix/specs.go
@@ -64,10 +64,18 @@ func newConfigurationCheck(
 		cd.nutanixClusterConfigSpec = nutanixClusterConfigSpec
 	}
 
+	failureDomainByMachineDeploymentName := make(map[string]string)
 	nutanixWorkerNodeConfigSpecByMachineDeploymentName := make(map[string]*carenv1.NutanixWorkerNodeConfigSpec)
+
 	if cd.cluster.Spec.Topology.Workers != nil {
 		for i := range cd.cluster.Spec.Topology.Workers.MachineDeployments {
 			md := &cd.cluster.Spec.Topology.Workers.MachineDeployments[i]
+
+			// Save the failureDomain only if it is configured
+			if md.FailureDomain != nil && *md.FailureDomain != "" {
+				failureDomainByMachineDeploymentName[md.Name] = *md.FailureDomain
+			}
+
 			if md.Variables == nil {
 				continue
 			}
@@ -104,6 +112,9 @@ func newConfigurationCheck(
 	if len(nutanixWorkerNodeConfigSpecByMachineDeploymentName) > 0 {
 		cd.nutanixWorkerNodeConfigSpecByMachineDeploymentName = nutanixWorkerNodeConfigSpecByMachineDeploymentName
 	}
+
+	// Save the failureDomainByMachineDeploymentName
+	cd.failureDomainByMachineDeploymentName = failureDomainByMachineDeploymentName
 
 	return configurationCheck
 }

--- a/pkg/webhook/preflight/nutanix/storagecontainer.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer.go
@@ -145,20 +145,36 @@ func newStorageContainerChecks(cd *checkDependencies) []preflight.Check {
 		return checks
 	}
 
-	if cd.nutanixClusterConfigSpec != nil && cd.nutanixClusterConfigSpec.ControlPlane != nil &&
+	if cd.nutanixClusterConfigSpec != nil &&
+		cd.nutanixClusterConfigSpec.ControlPlane != nil &&
 		cd.nutanixClusterConfigSpec.ControlPlane.Nutanix != nil {
-		checks = append(checks,
-			&storageContainerCheck{
-				machineSpec: &cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.MachineDetails,
-				field:       "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.controlPlane.nutanix.machineDetails",
-				csiSpec:     &cd.nutanixClusterConfigSpec.Addons.CSI.Providers.NutanixCSI,
-				nclient:     cd.nclient,
-			},
-		)
+		// Skip the check if failureDomains are configured
+		if len(cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.FailureDomains) > 0 {
+			cd.log.V(5).
+				Info("Skip preflight check NutanixStorageContainer for controlPlane with failureDomains configured.")
+		} else {
+			checks = append(checks,
+				&storageContainerCheck{
+					machineSpec: &cd.nutanixClusterConfigSpec.ControlPlane.Nutanix.MachineDetails,
+					field:       "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.controlPlane.nutanix.machineDetails",
+					csiSpec:     &cd.nutanixClusterConfigSpec.Addons.CSI.Providers.NutanixCSI,
+					nclient:     cd.nclient,
+				},
+			)
+		}
 	}
 
 	for mdName, nutanixWorkerNodeConfigSpec := range cd.nutanixWorkerNodeConfigSpecByMachineDeploymentName {
 		if nutanixWorkerNodeConfigSpec.Nutanix != nil {
+			// Skip the check if failureDomain is configured
+			if fdName, ok := cd.failureDomainByMachineDeploymentName[mdName]; ok {
+				cd.log.V(5).Info(
+					"Skip preflight check NutanixStorageContainer for machineDeployment with failureDomain configured.",
+					"machineDeployment", mdName, "failureDomain", fdName,
+				)
+				continue
+			}
+
 			checks = append(checks,
 				&storageContainerCheck{
 					machineSpec: &nutanixWorkerNodeConfigSpec.Nutanix.MachineDetails,


### PR DESCRIPTION
https://jira.nutanix.com/browse/NCN-108172
Ensure all existing preflight checks are also handling failure domains

For 2.16, just to skip the preflight checks that depends on the PE cluster configuration.

Added corresponding unit tests.