### PR TITLE
fix(helm): add failuredomain rollout controller config to helm chart 

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -32,6 +32,9 @@ A Helm chart for cluster-api-runtime-extensions-nutanix
 | deployment.replicas | int | `1` |  |
 | enforceClusterAutoscalerLimits.enabled | bool | `true` |  |
 | env | object | `{}` |  |
+| failureDomainRollout | object | `{"concurrency":10,"enabled":true}` | Runtime configuration for the failure domain rollout controller. This controller monitors cluster.status.failureDomains and triggers rollouts on KubeadmControlPlane when there are meaningful changes to failure domains. e.g. when an active failure domain is disabled or removed, or when adding a new failure domain can improve the distribution of control plane nodes across failure domains. |
+| failureDomainRollout.concurrency | int | `10` | Concurrency of the failure domain rollout controller |
+| failureDomainRollout.enabled | bool | `true` | Enable the failure domain rollout controller |
 | helmAddonsConfigMap | string | `"default-helm-addons-config"` |  |
 | helmRepository.enabled | bool | `true` |  |
 | helmRepository.images.bundleInitializer.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
         - --namespacesync-source-namespace={{ default .Release.Namespace .Values.namespaceSync.sourceNamespace }}
         - --namespacesync-target-namespace-label-key={{ .Values.namespaceSync.targetNamespaceLabelKey }}
         - --enforce-clusterautoscaler-limits-enabled={{ .Values.enforceClusterAutoscalerLimits.enabled }}
+        - --failure-domain-rollout-enabled={{ .Values.failureDomainRollout.enabled }}
+        - --failure-domain-rollout-concurrency={{ .Values.failureDomainRollout.concurrency }}
         - --helm-addons-configmap={{ .Values.helmAddonsConfigMap }}
         - --cni.cilium.helm-addon.default-values-template-configmap-name={{ .Values.hooks.cni.cilium.helmAddonStrategy.defaultValueTemplateConfigMap.name }}
         - --nfd.helm-addon.default-values-template-configmap-name={{ .Values.hooks.nfd.helmAddonStrategy.defaultValueTemplateConfigMap.name }}

--- a/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
@@ -43,6 +43,17 @@
             "properties": {},
             "type": "object"
         },
+        "failureDomainRollout": {
+            "properties": {
+                "concurrency": {
+                    "type": "integer"
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "helmAddonsConfigMap": {
             "type": "string"
         },

--- a/charts/cluster-api-runtime-extensions-nutanix/values.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.yaml
@@ -146,6 +146,17 @@ namespaceSync:
 enforceClusterAutoscalerLimits:
   enabled: true
 
+# -- Runtime configuration for the failure domain rollout controller.
+# This controller monitors cluster.status.failureDomains and triggers rollouts
+# on KubeadmControlPlane when there are meaningful changes to failure domains.
+# e.g. when an active failure domain is disabled or removed, or when adding a new failure domain
+# can improve the distribution of control plane nodes across failure domains.
+failureDomainRollout:
+  # -- Enable the failure domain rollout controller
+  enabled: true
+  # -- Concurrency of the failure domain rollout controller
+  concurrency: 10
+
 deployment:
   replicas: 1
 


### PR DESCRIPTION
helm config can be used to enable/disable the controller and to set concurrency.