### PR TITLE
fix(preflight): check storage containers on all failure domains

### DIFF
--- a/pkg/webhook/preflight/nutanix/clients_test.go
+++ b/pkg/webhook/preflight/nutanix/clients_test.go
@@ -9,6 +9,7 @@ import (
 	clustermgmtv4 "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
 	netv4 "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
 	vmmv4 "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/content"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	prismv3 "github.com/nutanix-cloud-native/prism-go-client/v3"
 )
@@ -70,6 +71,30 @@ type mocknclient struct {
 		select_ *string,
 		args ...map[string]interface{},
 	) (*netv4.ListSubnetsApiResponse, error)
+}
+
+type mockKubeClient struct {
+	ctrlclient.Client
+	SubResourceClient ctrlclient.SubResourceClient
+	getFunc           func(
+		ctx context.Context,
+		key ctrlclient.ObjectKey,
+		obj ctrlclient.Object,
+		opts ...ctrlclient.GetOption,
+	) error
+}
+
+func (m *mockKubeClient) Get(
+	ctx context.Context,
+	key ctrlclient.ObjectKey,
+	obj ctrlclient.Object,
+	opts ...ctrlclient.GetOption,
+) error {
+	return m.getFunc(ctx, key, obj, opts...)
+}
+
+func (m *mockKubeClient) SubResource(subResource string) ctrlclient.SubResourceClient {
+	return m.SubResourceClient
 }
 
 func (m *mocknclient) GetCurrentLoggedInUser(ctx context.Context) (*prismv3.UserIntentResponse, error) {

--- a/pkg/webhook/preflight/nutanix/storagecontainer.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer.go
@@ -222,7 +222,6 @@ func newStorageContainerChecks(cd *checkDependencies) []preflight.Check {
 	if cd.nutanixClusterConfigSpec != nil &&
 		cd.nutanixClusterConfigSpec.ControlPlane != nil &&
 		cd.nutanixClusterConfigSpec.ControlPlane.Nutanix != nil {
-
 		controlPlaneNutanix := cd.nutanixClusterConfigSpec.ControlPlane.Nutanix
 
 		// Check if failureDomains are configured for control plane
@@ -235,7 +234,7 @@ func newStorageContainerChecks(cd *checkDependencies) []preflight.Check {
 							failureDomainName: fdName,
 							namespace:         cd.cluster.Namespace,
 							kclient:           cd.kclient,
-							field:             "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.controlPlane.nutanix.failureDomains",
+							field:             "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.controlPlane.nutanix.failureDomains", //nolint:lll // The field is long.
 							csiSpec:           &cd.nutanixClusterConfigSpec.Addons.CSI.Providers.NutanixCSI,
 							nclient:           cd.nclient,
 						},
@@ -257,7 +256,10 @@ func newStorageContainerChecks(cd *checkDependencies) []preflight.Check {
 	for mdName, nutanixWorkerNodeConfigSpec := range cd.nutanixWorkerNodeConfigSpecByMachineDeploymentName {
 		if nutanixWorkerNodeConfigSpec.Nutanix != nil {
 			// Check if failureDomain is configured for this machine deployment
-			if fdName, ok := cd.failureDomainByMachineDeploymentName[mdName]; ok && fdName != "" && cd.cluster != nil && cd.kclient != nil {
+			if fdName, ok := cd.failureDomainByMachineDeploymentName[mdName]; ok &&
+				fdName != "" &&
+				cd.cluster != nil &&
+				cd.kclient != nil {
 				// Use failure domain for cluster information
 				checks = append(checks,
 					&storageContainerCheck{


### PR DESCRIPTION
If control plane or a machine deployment uses failure domains, use the cluster from the failure domain instead of machine details.

**How has this been tested?**

1. Misconfigured storage container (doesn't actually exist) on cluster in machine details or on cluster in failure domain (e.g. `ncn-dev-sandbox-gpu` doesn't have `k8s` storage container)
2. Create failure domain
```
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: NutanixFailureDomain
metadata:
  name: fd-2
  namespace: default
spec:
  prismElementCluster:
    type: name
    name: ncn-dev-sandbox-gpu
  subnets:
    - type: name
      name: subnet-2
```
3. Create a cluster
```
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  ...
spec:
  ...
  topology:
    class: nutanix-quick-start
    controlPlane:
      metadata: {}
      replicas: 3
    variables:
    ...
    - name: workerConfig
      value:
        nutanix:
          machineDetails:
            bootType: uefi
            cluster:
              name: ncn-dev-sandbox-gpu
              type: name
            imageLookup:
              baseOS: rocky-9.6
              format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
            memorySize: 4Gi
            subnets:
            - name: vlan173
              type: name
            systemDiskSize: 40Gi
            vcpuSockets: 2
            vcpusPerSocket: 1
    version: 1.33.1
    workers:
      machineDeployments:
      - class: default-worker
        name: md-variable-override
        variables:
          overrides:
          - name: workerConfig
            value:
              nutanix:
                machineDetails:
                  ...
                  cluster:
                    name: ncn-dev-sandbox-gpu
                    type: name
      - class: default-worker
        failureDomain: fd-2
        name: md-variable-override-failure-domain
        variables:
          overrides:
          - name: workerConfig
            value:
              nutanix:
                machineDetails:
                  ...
                  cluster:
                    name: ncn-dev-sandbox-gpu
                    type: name
```
4. Observe pre-flight failure on 2 machine deployments
```
The request is invalid: 
* $.spec.topology.workers.machineDeployments[?@.name=="md-variable-override-failure-domain"].failureDomain: Found no Storage Containers with name "k8s" on Cluster "ncn-dev-sandbox-gpu". Create a Storage Container with this name on Cluster "ncn-dev-sandbox-gpu", and then retry.
* $.spec.topology.workers.machineDeployments[?@.name=="md-variable-override"].variables[?@.name=workerConfig].value.nutanix.machineDetails: Found no Storage Containers with name "k8s" on Cluster "ncn-dev-sandbox-gpu". Create a Storage Container with this name on Cluster "ncn-dev-sandbox-gpu", and then retry.
```