### PR TITLE
NCN-108428: When failureDomain is configured, machineDetails "cluster" and "subnets" should be optional

### DIFF
--- a/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
@@ -511,9 +511,7 @@ spec:
                               format: int32
                               type: integer
                           required:
-                            - cluster
                             - memorySize
-                            - subnets
                             - systemDiskSize
                             - vcpuSockets
                             - vcpusPerSocket

--- a/api/v1alpha1/crds/caren.nutanix.com_nutanixworkernodeconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_nutanixworkernodeconfigs.yaml
@@ -234,9 +234,7 @@ spec:
                           format: int32
                           type: integer
                       required:
-                        - cluster
                         - memorySize
-                        - subnets
                         - systemDiskSize
                         - vcpuSockets
                         - vcpusPerSocket

--- a/api/v1alpha1/nutanix_node_types.go
+++ b/api/v1alpha1/nutanix_node_types.go
@@ -50,13 +50,15 @@ type NutanixMachineDetails struct {
 
 	// cluster identifies the Prism Element in which the machine will be created.
 	// The identifier (uuid or name) can be obtained from the console or API.
-	// +kubebuilder:validation:Required
-	Cluster capxv1.NutanixResourceIdentifier `json:"cluster"`
+	// +kubebuilder:validation:Optional
+	// +optional
+	Cluster *capxv1.NutanixResourceIdentifier `json:"cluster,omitempty"`
 
 	// subnet identifies the network subnet to use for the machine.
 	// The identifier (uuid or name) can be obtained from the console or API.
-	// +kubebuilder:validation:Required
-	Subnets []capxv1.NutanixResourceIdentifier `json:"subnets"`
+	// +kubebuilder:validation:Optional
+	// +optional
+	Subnets []capxv1.NutanixResourceIdentifier `json:"subnets,omitempty"`
 
 	// List of categories that need to be added to the machines. Categories must already
 	// exist in Prism Central. One category key can have more than one value.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1609,7 +1609,11 @@ func (in *NutanixMachineDetails) DeepCopyInto(out *NutanixMachineDetails) {
 		*out = new(v1beta1.NutanixImageLookup)
 		(*in).DeepCopyInto(*out)
 	}
-	in.Cluster.DeepCopyInto(&out.Cluster)
+	if in.Cluster != nil {
+		in, out := &in.Cluster, &out.Cluster
+		*out = new(v1beta1.NutanixResourceIdentifier)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Subnets != nil {
 		in, out := &in.Subnets, &out.Subnets
 		*out = make([]v1beta1.NutanixResourceIdentifier, len(*in))

--- a/pkg/handlers/generic/mutation/kubeproxymode/variables_test.go
+++ b/pkg/handlers/generic/mutation/kubeproxymode/variables_test.go
@@ -162,13 +162,18 @@ func minimalNutanixClusterConfigSpec() v1alpha1.NutanixClusterConfigSpec {
 						Type: capxv1.NutanixIdentifierName,
 						Name: ptr.To("fake-image"),
 					},
-					Cluster: capxv1.NutanixResourceIdentifier{
+					Cluster: &capxv1.NutanixResourceIdentifier{
 						Type: capxv1.NutanixIdentifierName,
 						Name: ptr.To("fake-pe-cluster"),
 					},
 					MemorySize:     resource.MustParse("8Gi"),
 					SystemDiskSize: resource.MustParse("40Gi"),
-					Subnets:        []capxv1.NutanixResourceIdentifier{},
+					Subnets: []capxv1.NutanixResourceIdentifier{
+						{
+							Type: capxv1.NutanixIdentifierName,
+							Name: ptr.To("fake-subnet"),
+						},
+					},
 				},
 			},
 		},

--- a/pkg/handlers/nutanix/mutation/controlplanefailuredomains/variables_test.go
+++ b/pkg/handlers/nutanix/mutation/controlplanefailuredomains/variables_test.go
@@ -50,13 +50,18 @@ func minimumClusterConfigSpec() v1alpha1.NutanixClusterConfigSpec {
 						Type: capxv1.NutanixIdentifierName,
 						Name: ptr.To("fake-image"),
 					},
-					Cluster: capxv1.NutanixResourceIdentifier{
+					Cluster: &capxv1.NutanixResourceIdentifier{
 						Type: capxv1.NutanixIdentifierName,
 						Name: ptr.To("fake-pe-cluster"),
 					},
 					MemorySize:     resource.MustParse("8Gi"),
 					SystemDiskSize: resource.MustParse("40Gi"),
-					Subnets:        []capxv1.NutanixResourceIdentifier{},
+					Subnets: []capxv1.NutanixResourceIdentifier{
+						{
+							Type: capxv1.NutanixIdentifierName,
+							Name: ptr.To("fake-subnet"),
+						},
+					},
 				},
 			},
 		},

--- a/pkg/handlers/nutanix/mutation/machinedetails/inject.go
+++ b/pkg/handlers/nutanix/mutation/machinedetails/inject.go
@@ -97,7 +97,14 @@ func (h *nutanixMachineDetailsPatchHandler) Mutate(
 			spec := obj.Spec.Template.Spec
 
 			spec.BootType = nutanixMachineDetailsVar.BootType
-			spec.Cluster = nutanixMachineDetailsVar.Cluster
+			if nutanixMachineDetailsVar.Cluster != nil {
+				spec.Cluster = *nutanixMachineDetailsVar.Cluster
+			} else {
+				// Have to set the required Type field.
+				spec.Cluster = capxv1.NutanixResourceIdentifier{
+					Type: capxv1.NutanixIdentifierName,
+				}
+			}
 
 			switch {
 			case nutanixMachineDetailsVar.Image != nil:
@@ -118,7 +125,6 @@ func (h *nutanixMachineDetailsPatchHandler) Mutate(
 			spec.Subnets = slices.Clone(nutanixMachineDetailsVar.Subnets)
 			spec.AdditionalCategories = slices.Clone(nutanixMachineDetailsVar.AdditionalCategories)
 			spec.GPUs = slices.Clone(nutanixMachineDetailsVar.GPUs)
-
 			spec.Project = nutanixMachineDetailsVar.Project.DeepCopy()
 
 			obj.Spec.Template.Spec = spec

--- a/pkg/handlers/nutanix/mutation/machinedetails/inject_control_plane_test.go
+++ b/pkg/handlers/nutanix/mutation/machinedetails/inject_control_plane_test.go
@@ -27,7 +27,7 @@ var (
 			Type: capxv1.NutanixIdentifierName,
 			Name: ptr.To("fake-image"),
 		},
-		Cluster: capxv1.NutanixResourceIdentifier{
+		Cluster: &capxv1.NutanixResourceIdentifier{
 			Type: capxv1.NutanixIdentifierName,
 			Name: ptr.To("fake-pe-cluster"),
 		},
@@ -72,7 +72,7 @@ var (
 		ImageLookup: &capxv1.NutanixImageLookup{
 			BaseOS: "rockylinux-9",
 		},
-		Cluster: capxv1.NutanixResourceIdentifier{
+		Cluster: &capxv1.NutanixResourceIdentifier{
 			Type: capxv1.NutanixIdentifierName,
 			Name: ptr.To("fake-pe-cluster"),
 		},

--- a/pkg/handlers/nutanix/mutation/machinedetails/variables_test.go
+++ b/pkg/handlers/nutanix/mutation/machinedetails/variables_test.go
@@ -109,13 +109,18 @@ func minimumClusterConfigSpec() v1alpha1.NutanixClusterConfigSpec {
 						Type: capxv1.NutanixIdentifierName,
 						Name: ptr.To("fake-image"),
 					},
-					Cluster: capxv1.NutanixResourceIdentifier{
+					Cluster: &capxv1.NutanixResourceIdentifier{
 						Type: capxv1.NutanixIdentifierName,
 						Name: ptr.To("fake-pe-cluster"),
 					},
 					MemorySize:     resource.MustParse("8Gi"),
 					SystemDiskSize: resource.MustParse("40Gi"),
-					Subnets:        []capxv1.NutanixResourceIdentifier{},
+					Subnets: []capxv1.NutanixResourceIdentifier{
+						{
+							Type: capxv1.NutanixIdentifierName,
+							Name: ptr.To("fake-subnet"),
+						},
+					},
 				},
 			},
 		},

--- a/pkg/webhook/preflight/nutanix/failuredomain.go
+++ b/pkg/webhook/preflight/nutanix/failuredomain.go
@@ -61,9 +61,12 @@ func newFailureDomainChecks(cd *checkDependencies) []preflight.Check {
 				checks = append(checks, &failureDomainCheck{
 					failureDomainName: *md.FailureDomain,
 					namespace:         cd.cluster.Namespace,
-					field:             "$.spec.topology.workers.machineDeployments[?@.name==%q].failureDomain",
-					kclient:           cd.kclient,
-					nclient:           cd.nclient,
+					field: fmt.Sprintf(
+						"$.spec.topology.workers.machineDeployments[?@.name==%q].failureDomain",
+						md.Name,
+					),
+					kclient: cd.kclient,
+					nclient: cd.nclient,
 				})
 			}
 		}

--- a/pkg/webhook/preflight/nutanix/storagecontainer.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer.go
@@ -45,7 +45,7 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 		return result
 	}
 
-	clusterIdentifier := &c.machineSpec.Cluster
+	clusterIdentifier := c.machineSpec.Cluster
 
 	// To avoid unnecessary API calls, we delay the retrieval of clusters until we actually
 	// need to check for storage containers.

--- a/pkg/webhook/preflight/nutanix/storagecontainer_test.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer_test.go
@@ -86,7 +86,7 @@ func TestInitStorageContainerChecks(t *testing.T) {
 				ControlPlane: &carenv1.NutanixControlPlaneSpec{
 					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{
 						MachineDetails: carenv1.NutanixMachineDetails{
-							Cluster: capxv1.NutanixResourceIdentifier{
+							Cluster: &capxv1.NutanixResourceIdentifier{
 								Type: capxv1.NutanixIdentifierName,
 								Name: ptr.To("my-cluster"),
 							},
@@ -120,7 +120,7 @@ func TestInitStorageContainerChecks(t *testing.T) {
 					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{
 						FailureDomains: []string{"fd-1", "fd-2", "fd-3"},
 						MachineDetails: carenv1.NutanixMachineDetails{
-							Cluster: capxv1.NutanixResourceIdentifier{
+							Cluster: &capxv1.NutanixResourceIdentifier{
 								Type: capxv1.NutanixIdentifierName,
 								Name: ptr.To("my-cluster"),
 							},
@@ -162,7 +162,7 @@ func TestInitStorageContainerChecks(t *testing.T) {
 				"worker-1": {
 					Nutanix: &carenv1.NutanixWorkerNodeSpec{
 						MachineDetails: carenv1.NutanixMachineDetails{
-							Cluster: capxv1.NutanixResourceIdentifier{
+							Cluster: &capxv1.NutanixResourceIdentifier{
 								Type: capxv1.NutanixIdentifierName,
 								Name: ptr.To("worker-cluster"),
 							},
@@ -188,7 +188,7 @@ func TestInitStorageContainerChecks(t *testing.T) {
 				"worker-1": {
 					Nutanix: &carenv1.NutanixWorkerNodeSpec{
 						MachineDetails: carenv1.NutanixMachineDetails{
-							Cluster: capxv1.NutanixResourceIdentifier{
+							Cluster: &capxv1.NutanixResourceIdentifier{
 								Type: capxv1.NutanixIdentifierName,
 								Name: ptr.To("worker-cluster"),
 							},
@@ -206,7 +206,7 @@ func TestInitStorageContainerChecks(t *testing.T) {
 				ControlPlane: &carenv1.NutanixControlPlaneSpec{
 					Nutanix: &carenv1.NutanixControlPlaneNodeSpec{
 						MachineDetails: carenv1.NutanixMachineDetails{
-							Cluster: capxv1.NutanixResourceIdentifier{
+							Cluster: &capxv1.NutanixResourceIdentifier{
 								Type: capxv1.NutanixIdentifierName,
 								Name: ptr.To("cp-cluster"),
 							},
@@ -225,7 +225,7 @@ func TestInitStorageContainerChecks(t *testing.T) {
 				"worker-1": {
 					Nutanix: &carenv1.NutanixWorkerNodeSpec{
 						MachineDetails: carenv1.NutanixMachineDetails{
-							Cluster: capxv1.NutanixResourceIdentifier{
+							Cluster: &capxv1.NutanixResourceIdentifier{
 								Type: capxv1.NutanixIdentifierName,
 								Name: ptr.To("worker1-cluster"),
 							},
@@ -235,7 +235,7 @@ func TestInitStorageContainerChecks(t *testing.T) {
 				"worker-2": {
 					Nutanix: &carenv1.NutanixWorkerNodeSpec{
 						MachineDetails: carenv1.NutanixMachineDetails{
-							Cluster: capxv1.NutanixResourceIdentifier{
+							Cluster: &capxv1.NutanixResourceIdentifier{
 								Type: capxv1.NutanixIdentifierName,
 								Name: ptr.To("worker2-cluster"),
 							},
@@ -279,7 +279,7 @@ func TestInitStorageContainerChecks(t *testing.T) {
 				"worker-1": {
 					Nutanix: &carenv1.NutanixWorkerNodeSpec{
 						MachineDetails: carenv1.NutanixMachineDetails{
-							Cluster: capxv1.NutanixResourceIdentifier{
+							Cluster: &capxv1.NutanixResourceIdentifier{
 								Type: capxv1.NutanixIdentifierName,
 								Name: ptr.To("worker1-cluster"),
 							},
@@ -333,7 +333,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "nil storage class configs",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -347,7 +347,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "storage class config without parameters",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -366,7 +366,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "storage class config without storage container parameter",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -387,7 +387,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "storage container not found",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -455,7 +455,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "multiple storage containers with same name in same cluster found",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -530,7 +530,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "successful storage container check",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -601,7 +601,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "multiple clusters found",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -652,7 +652,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "error getting cluster",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -692,7 +692,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "error listing storage containers",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -755,7 +755,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "error response from ListStorageContainers",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -821,7 +821,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "nil data from ListStorageContainers",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},
@@ -884,7 +884,7 @@ func TestStorageContainerCheck(t *testing.T) {
 		{
 			name: "multiple storage class configs with success",
 			machineSpec: &carenv1.NutanixMachineDetails{
-				Cluster: capxv1.NutanixResourceIdentifier{
+				Cluster: &capxv1.NutanixResourceIdentifier{
 					Type: capxv1.NutanixIdentifierName,
 					Name: ptr.To(clusterName),
 				},


### PR DESCRIPTION
https://jira.nutanix.com/browse/NCN-108428:
When failureDomain is configured, machineDetails "cluster" and "subnets" should be optional
