### PR TITLE
fix(auto-cert-renewal): adds 0 as valid value for daysBeforeExpiry

### DIFF
--- a/api/v1alpha1/controlplane_types.go
+++ b/api/v1alpha1/controlplane_types.go
@@ -13,9 +13,10 @@ type GenericControlPlaneSpec struct {
 type AutoRenewCertificatesSpec struct {
 	// DaysBeforeExpiry indicates a rollout needs to be performed if the
 	// certificates of the control plane will expire within the specified days.
+	// Set to 0 to disable automated certificate renewal.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Minimum=7
-	DaysBeforeExpiry int32 `json:"daysBeforeExpiry,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="self == 0 || self >= 7",message="Value must be 0 or at least 7"
+	DaysBeforeExpiry int32 `json:"daysBeforeExpiry"`
 }
 
 // DockerControlPlaneSpec defines the desired state of the control plane for a Docker cluster.

--- a/api/v1alpha1/crds/caren.nutanix.com_awsclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_awsclusterconfigs.yaml
@@ -339,9 +339,12 @@ spec:
                           description: |-
                             DaysBeforeExpiry indicates a rollout needs to be performed if the
                             certificates of the control plane will expire within the specified days.
+                            Set to 0 to disable automated certificate renewal.
                           format: int32
-                          minimum: 7
                           type: integer
+                          x-kubernetes-validations:
+                            - message: Value must be 0 or at least 7
+                              rule: self == 0 || self >= 7
                       required:
                         - daysBeforeExpiry
                       type: object

--- a/api/v1alpha1/crds/caren.nutanix.com_dockerclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_dockerclusterconfigs.yaml
@@ -304,9 +304,12 @@ spec:
                           description: |-
                             DaysBeforeExpiry indicates a rollout needs to be performed if the
                             certificates of the control plane will expire within the specified days.
+                            Set to 0 to disable automated certificate renewal.
                           format: int32
-                          minimum: 7
                           type: integer
+                          x-kubernetes-validations:
+                            - message: Value must be 0 or at least 7
+                              rule: self == 0 || self >= 7
                       required:
                         - daysBeforeExpiry
                       type: object

--- a/api/v1alpha1/crds/caren.nutanix.com_dockerworkernodeconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_dockerworkernodeconfigs.yaml
@@ -52,9 +52,12 @@ spec:
                     description: |-
                       DaysBeforeExpiry indicates a rollout needs to be performed if the
                       certificates of the control plane will expire within the specified days.
+                      Set to 0 to disable automated certificate renewal.
                     format: int32
-                    minimum: 7
                     type: integer
+                    x-kubernetes-validations:
+                    - message: Value must be 0 or at least 7
+                      rule: self == 0 || self >= 7
                 required:
                 - daysBeforeExpiry
                 type: object

--- a/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
@@ -304,9 +304,12 @@ spec:
                           description: |-
                             DaysBeforeExpiry indicates a rollout needs to be performed if the
                             certificates of the control plane will expire within the specified days.
+                            Set to 0 to disable automated certificate renewal.
                           format: int32
-                          minimum: 7
                           type: integer
+                          x-kubernetes-validations:
+                            - message: Value must be 0 or at least 7
+                              rule: self == 0 || self >= 7
                       required:
                         - daysBeforeExpiry
                       type: object

--- a/common/pkg/testutils/openapi/cel.go
+++ b/common/pkg/testutils/openapi/cel.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package openapi
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// validateCELRecursively recursively validates CEL rules across all schema.Properties.
+// validator.Validate() does not traverse nested structs, so we need to do it manually.
+// It walks each field of the struct, checking if it has a CEL validation rule,
+// and if so, it validates the field using the CEL validator.
+func validateCELRecursively(
+	ctx context.Context,
+	validator *cel.Validator,
+	path *field.Path,
+	schema *structuralschema.Structural,
+	newVal reflect.Value,
+	oldVal reflect.Value,
+	budget int64,
+) field.ErrorList {
+	var errs field.ErrorList
+
+	// Prepare values for top-level Validate call
+	newIface := reflectValueToInterface(newVal)
+	oldIface := reflectValueToInterface(oldVal)
+
+	selfErrs, _ := validator.Validate(ctx, path, schema, newIface, oldIface, budget)
+	errs = append(errs, selfErrs...)
+
+	// Dereference pointers
+	if newVal.Kind() == reflect.Pointer && !newVal.IsNil() {
+		newVal = newVal.Elem()
+	}
+	if oldVal.Kind() == reflect.Pointer && !oldVal.IsNil() {
+		oldVal = oldVal.Elem()
+	}
+
+	// Recurse only if newVal is struct
+	if newVal.Kind() != reflect.Struct {
+		return errs
+	}
+
+	typ := newVal.Type()
+	for i := 0; i < newVal.NumField(); i++ {
+		fieldType := typ.Field(i)
+		newFieldVal := newVal.Field(i)
+
+		if fieldType.PkgPath != "" {
+			continue // unexported
+		}
+
+		// Get old value safely
+		var oldFieldVal reflect.Value
+		if oldVal.IsValid() && oldVal.Kind() == reflect.Struct {
+			oldFieldVal = oldVal.FieldByName(fieldType.Name)
+		}
+
+		// Handle embedded fields
+		if fieldType.Anonymous && newFieldVal.Kind() == reflect.Struct {
+			errs = append(errs,
+				validateCELRecursively(ctx, validator, path, schema, newFieldVal, oldFieldVal, budget)...)
+			continue
+		}
+
+		jsonName := jsonFieldName(fieldType)
+		if jsonName == "" {
+			continue
+		}
+
+		subSchema, okSchema := schema.Properties[jsonName]
+		subValidator, okValidator := validator.Properties[jsonName]
+		if !okSchema || !okValidator {
+			continue
+		}
+
+		subPath := path.Child(jsonName)
+		errs = append(errs,
+			validateCELRecursively(ctx, &subValidator, subPath, &subSchema, newFieldVal, oldFieldVal, budget)...)
+	}
+
+	return errs
+}
+
+func reflectValueToInterface(v reflect.Value) interface{} {
+	if !v.IsValid() {
+		return nil
+	}
+	if v.Kind() == reflect.Pointer && v.IsNil() {
+		return nil
+	}
+	return v.Interface()
+}
+
+func jsonFieldName(field reflect.StructField) string {
+	tag := field.Tag.Get("json")
+	if tag == "-" {
+		return ""
+	}
+	if tag == "" {
+		return field.Name
+	}
+	return strings.Split(tag, ",")[0]
+}

--- a/pkg/handlers/generic/mutation/autorenewcerts/inject.go
+++ b/pkg/handlers/generic/mutation/autorenewcerts/inject.go
@@ -67,8 +67,12 @@ func (h *autoRenewCerts) Mutate(
 		h.variableName,
 		h.variableFieldPath...,
 	)
-	if err != nil && !variables.IsNotFoundError(err) {
-		return err
+	if err != nil {
+		if variables.IsNotFoundError(err) {
+			log.V(5).Info("Control Plane auto renew certs variable not defined")
+		} else {
+			return err
+		}
 	}
 
 	log = log.WithValues(

--- a/pkg/handlers/generic/mutation/autorenewcerts/inject_test.go
+++ b/pkg/handlers/generic/mutation/autorenewcerts/inject_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Generate auto renew patches", func() {
 		},
 		{
 			patchTest: capitest.PatchTestDef{
-				Name: "auto cert renewal set with Nutanix",
+				Name: "auto cert renewal set to 10 with Nutanix",
 				Vars: []runtimehooksv1.Variable{
 					capitest.VariableWithValue(
 						v1alpha1.ClusterConfigVariableName,
@@ -112,6 +112,31 @@ var _ = Describe("Generate auto renew patches", func() {
 						"certificatesExpiryDays",
 						gomega.BeEquivalentTo(10),
 					),
+				}},
+			},
+		},
+		{
+			patchTest: capitest.PatchTestDef{
+				Name: "auto cert renewal set to 0 with Nutanix",
+				Vars: []runtimehooksv1.Variable{
+					capitest.VariableWithValue(
+						v1alpha1.ClusterConfigVariableName,
+						v1alpha1.NutanixClusterConfigSpec{
+							ControlPlane: &v1alpha1.NutanixControlPlaneSpec{
+								GenericControlPlaneSpec: v1alpha1.GenericControlPlaneSpec{
+									AutoRenewCertificates: &v1alpha1.AutoRenewCertificatesSpec{
+										DaysBeforeExpiry: 0,
+									},
+								},
+							},
+						},
+					),
+				},
+				RequestItem: request.NewKubeadmControlPlaneTemplateRequestItem(""),
+				UnexpectedPatchMatchers: []capitest.JSONPatchMatcher{{
+					Operation:    "add",
+					Path:         "/spec/template/spec",
+					ValueMatcher: gomega.HaveKey("rolloutBefore"),
 				}},
 			},
 		},

--- a/pkg/handlers/generic/mutation/autorenewcerts/variables_test.go
+++ b/pkg/handlers/generic/mutation/autorenewcerts/variables_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package autorenewcerts
+
+import (
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
+	nutanixclusterconfig "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/nutanix/clusterconfig"
+)
+
+var nutanixTestDefs = []capitest.VariableTestDef{
+	{
+		Name: "unset",
+		Vals: v1alpha1.NutanixClusterConfigSpec{
+			ControlPlane: &v1alpha1.NutanixControlPlaneSpec{
+				GenericControlPlaneSpec: v1alpha1.GenericControlPlaneSpec{},
+			},
+		},
+	},
+	{
+		Name: "set with a valid value of 0",
+		Vals: v1alpha1.NutanixClusterConfigSpec{
+			ControlPlane: &v1alpha1.NutanixControlPlaneSpec{
+				GenericControlPlaneSpec: v1alpha1.GenericControlPlaneSpec{
+					AutoRenewCertificates: &v1alpha1.AutoRenewCertificatesSpec{
+						DaysBeforeExpiry: 0,
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "set with a minimum valid value of 7",
+		Vals: v1alpha1.NutanixClusterConfigSpec{
+			ControlPlane: &v1alpha1.NutanixControlPlaneSpec{
+				GenericControlPlaneSpec: v1alpha1.GenericControlPlaneSpec{
+					AutoRenewCertificates: &v1alpha1.AutoRenewCertificatesSpec{
+						DaysBeforeExpiry: 7,
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "set with an invalid value",
+		Vals: v1alpha1.NutanixClusterConfigSpec{
+			ControlPlane: &v1alpha1.NutanixControlPlaneSpec{
+				GenericControlPlaneSpec: v1alpha1.GenericControlPlaneSpec{
+					AutoRenewCertificates: &v1alpha1.AutoRenewCertificatesSpec{
+						DaysBeforeExpiry: 1,
+					},
+				},
+			},
+		},
+		ExpectError: true,
+	},
+}
+
+func TestVariableValidation_Nutanix(t *testing.T) {
+	capitest.ValidateDiscoverVariablesAs[mutation.DiscoverVariables, v1alpha1.NutanixClusterConfigSpec](
+		t,
+		v1alpha1.ClusterConfigVariableName,
+		ptr.To(v1alpha1.NutanixClusterConfig{}.VariableSchema()),
+		true,
+		func() mutation.DiscoverVariables {
+			return nutanixclusterconfig.NewVariable()
+		},
+		nutanixTestDefs...,
+	)
+}


### PR DESCRIPTION
**What problem does this PR solve?**:
As of now to disable CAPI based automated certificate renewal we have to set `autoRenewCertificates` to `nil` which results in SSA patch [issue](https://github.com/kubernetes/kubernetes/issues/117447). To avoid this added 0 as a valid value for `autoRenewCertificates.daysBeforeExpiry` denoting the feat is disabled.

**Which issue(s) this PR fixes**:
Fixes [NCN-108329](https://jira.nutanix.com/browse/NCN-108329)

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->
- Tested using the dev workflow along with the konvoy [changes](https://github.com/mesosphere/konvoy2/pull/3959)
