### PR TITLE
fix: Use JSONPath in check result fields

### DIFF
--- a/pkg/webhook/preflight/generic/registry.go
+++ b/pkg/webhook/preflight/generic/registry.go
@@ -201,7 +201,7 @@ func newRegistryCheck(
 	if cd.genericClusterConfigSpec != nil &&
 		cd.genericClusterConfigSpec.GlobalImageRegistryMirror != nil {
 		checks = append(checks, &registryCheck{
-			field:                 "cluster.spec.topology.variables[.name=clusterConfig].value.globalImageRegistryMirror",
+			field:                 "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.globalImageRegistryMirror",
 			kclient:               cd.kclient,
 			cluster:               cd.cluster,
 			regClientPingerGetter: defaultRegClientGetter,
@@ -215,7 +215,7 @@ func newRegistryCheck(
 			registry := cd.genericClusterConfigSpec.ImageRegistries[i]
 			checks = append(checks, &registryCheck{
 				field: fmt.Sprintf(
-					"cluster.spec.topology.variables[.name=clusterConfig].value.imageRegistries[%d]",
+					"$.spec.topology.variables[?@.name==\"clusterConfig\"].value.imageRegistries[%d]",
 					i,
 				),
 				kclient:               cd.kclient,

--- a/pkg/webhook/preflight/generic/registry_test.go
+++ b/pkg/webhook/preflight/generic/registry_test.go
@@ -112,7 +112,7 @@ func TestRegistryCheck(t *testing.T) {
 		},
 		{
 			name:  "registry mirror with invalid credentials secret",
-			field: "cluster.spec.topology.variables[.name=clusterConfig].value.globalImageRegistryMirror",
+			field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.globalImageRegistryMirror",
 			registryMirror: &carenv1.GlobalImageRegistryMirror{
 				URL: testRegistryURL,
 				Credentials: &carenv1.RegistryCredentials{
@@ -136,14 +136,14 @@ func TestRegistryCheck(t *testing.T) {
 				Causes: []preflight.Cause{
 					{
 						Message: "Failed to get Registry credentials Secret \"test-secret\": fake error. This is usually a temporary error. Please retry.", ///nolint:lll // Message is long.
-						Field:   "cluster.spec.topology.variables[.name=clusterConfig].value.globalImageRegistryMirror.credentials.secretRef",              //nolint:lll // Field is long.
+						Field:   "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.globalImageRegistryMirror.credentials.secretRef",             //nolint:lll // Field is long.
 					},
 				},
 			},
 		},
 		{
 			name:  "registry mirror with missing credentials secret",
-			field: "cluster.spec.topology.variables[.name=clusterConfig].value.globalImageRegistryMirror",
+			field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.globalImageRegistryMirror",
 			registryMirror: &carenv1.GlobalImageRegistryMirror{
 				URL: testRegistryURL,
 				Credentials: &carenv1.RegistryCredentials{
@@ -166,15 +166,15 @@ func TestRegistryCheck(t *testing.T) {
 				InternalError: false,
 				Causes: []preflight.Cause{
 					{
-						Message: "Registry credentials Secret \"test-secret\" not found. Create the Secret first, then create the Cluster.",   ///nolint:lll // Message is long.
-						Field:   "cluster.spec.topology.variables[.name=clusterConfig].value.globalImageRegistryMirror.credentials.secretRef", //nolint:lll // Field is long.
+						Message: "Registry credentials Secret \"test-secret\" not found. Create the Secret first, then create the Cluster.",    ///nolint:lll // Message is long.
+						Field:   "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.globalImageRegistryMirror.credentials.secretRef", //nolint:lll // Field is long.
 					},
 				},
 			},
 		},
 		{
 			name:  "registry mirror ping failure",
-			field: "cluster.spec.topology.variables[.name=clusterConfig].value.globalImageRegistryMirror",
+			field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.globalImageRegistryMirror",
 			registryMirror: &carenv1.GlobalImageRegistryMirror{
 				URL: testRegistryURL,
 			},
@@ -191,7 +191,7 @@ func TestRegistryCheck(t *testing.T) {
 							testRegistryURL,
 							testPingFailedError,
 						),
-						Field: "cluster.spec.topology.variables[.name=clusterConfig].value.globalImageRegistryMirror",
+						Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.globalImageRegistryMirror",
 					},
 				},
 			},
@@ -264,7 +264,7 @@ func TestRegistryCheck(t *testing.T) {
 		},
 		{
 			name:  "image registry with invalid URL",
-			field: "cluster.spec.topology.variables[.name=clusterConfig].value.imageRegistries[0]",
+			field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.imageRegistries[0]",
 			imageRegistry: &carenv1.ImageRegistry{
 				URL: "invalid-url",
 				Credentials: &carenv1.RegistryCredentials{
@@ -299,14 +299,14 @@ func TestRegistryCheck(t *testing.T) {
 				Causes: []preflight.Cause{
 					{
 						Message: "Failed to parse registry URL \"invalid-url\" with error: parse \"invalid-url\": invalid URI for request. Review the Cluster.", ///nolint:lll // Message is long.
-						Field:   "cluster.spec.topology.variables[.name=clusterConfig].value.imageRegistries[0].url",
+						Field:   "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.imageRegistries[0].url",
 					},
 				},
 			},
 		},
 		{
 			name:  "image registry with invalid URL scheme",
-			field: "cluster.spec.topology.variables[.name=clusterConfig].value.imageRegistries[0]",
+			field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.imageRegistries[0]",
 			imageRegistry: &carenv1.ImageRegistry{
 				URL: "tcp://some-registry.lol",
 				Credentials: &carenv1.RegistryCredentials{
@@ -341,7 +341,7 @@ func TestRegistryCheck(t *testing.T) {
 				Causes: []preflight.Cause{
 					{
 						Message: "The registry URL \"tcp://some-registry.lol\" uses the scheme \"tcp\". This scheme is not supported. Use either the \"http\" or \"https\" scheme.", ///nolint:lll // Message is long.
-						Field:   "cluster.spec.topology.variables[.name=clusterConfig].value.imageRegistries[0].url",
+						Field:   "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.imageRegistries[0].url",
 					},
 				},
 			},

--- a/pkg/webhook/preflight/generic/spec.go
+++ b/pkg/webhook/preflight/generic/spec.go
@@ -50,7 +50,7 @@ func newConfigurationCheck(
 					carenv1.ClusterConfigVariableName,
 					err,
 				),
-				Field: "cluster.spec.topology.variables[.name=clusterConfig].genericClusterConfigSpec",
+				Field: "$.spec.topology.variables[?@.name==\"clusterConfig\"].genericClusterConfigSpec",
 			},
 		)
 	}

--- a/pkg/webhook/preflight/generic/spec_test.go
+++ b/pkg/webhook/preflight/generic/spec_test.go
@@ -107,7 +107,7 @@ func TestNewConfigurationCheck(t *testing.T) {
 				Causes: []preflight.Cause{
 					{
 						Message: "Failed to unmarshal cluster variable \"clusterConfig\": failed to unmarshal json: invalid character 'i' looking for beginning of object key string. Review the Cluster.", ///nolint:lll // The message is long.
-						Field:   "cluster.spec.topology.variables[.name=clusterConfig].genericClusterConfigSpec",
+						Field:   "$.spec.topology.variables[?@.name==\"clusterConfig\"].genericClusterConfigSpec",
 					},
 				},
 			},


### PR DESCRIPTION
**What problem does this PR solve?**:
Some fields were still not using valid JSONPath. I already fixed the other fields earlier in https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/1202.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
