### PR TITLE
fix(webhook): Update cluster webhook to validate failure domains

### DIFF
--- a/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1/nutanixmachine_types.go
+++ b/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1/nutanixmachine_types.go
@@ -132,12 +132,12 @@ type NutanixMachineSpec struct {
 	// The cluster identifier (uuid or name) can be obtained from the Prism Central console
 	// or using the prism_central API.
 	// +kubebuilder:validation:Optional
-	Cluster NutanixResourceIdentifier `json:"cluster"`
+	Cluster NutanixResourceIdentifier `json:"cluster,omitzero"`
 	// subnet is to identify the cluster's network subnet to use for the Machine's VM
 	// The cluster identifier (uuid or name) can be obtained from the Prism Central console
 	// or using the prism_central API.
 	// +kubebuilder:validation:Optional
-	Subnets []NutanixResourceIdentifier `json:"subnet"`
+	Subnets []NutanixResourceIdentifier `json:"subnet,omitempty"`
 	// List of categories that need to be added to the machines. Categories must already exist in Prism Central
 	// +kubebuilder:validation:Optional
 	AdditionalCategories []NutanixCategoryIdentifier `json:"additionalCategories,omitempty"`

--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
@@ -304,16 +304,10 @@ spec:
   template:
     spec:
       bootType: legacy
-      cluster:
-        name: ""
-        type: name
       image:
         name: ""
         type: name
       memorySize: 4Gi
-      subnet:
-      - name: ""
-        type: name
       systemDiskSize: 40Gi
       vcpuSockets: 2
       vcpusPerSocket: 1
@@ -328,16 +322,10 @@ spec:
   template:
     spec:
       bootType: legacy
-      cluster:
-        name: ""
-        type: name
       image:
         name: ""
         type: name
       memorySize: 4Gi
-      subnet:
-      - name: ""
-        type: name
       systemDiskSize: 40Gi
       vcpuSockets: 2
       vcpusPerSocket: 1

--- a/hack/examples/overlays/clusterclasses/nutanix/kustomization.yaml.tmpl
+++ b/hack/examples/overlays/clusterclasses/nutanix/kustomization.yaml.tmpl
@@ -49,3 +49,7 @@ patches:
       kind: KubeadmControlPlaneTemplate
     path: ../../../patches/cis-admissionconfiguration.yaml
   # END CIS patches
+
+  - target:
+      kind: NutanixMachineTemplate
+    path: ../../../patches/nutanix/remove-cluster-and-subnet-from-machinetemplates.yaml

--- a/hack/examples/patches/nutanix/remove-cluster-and-subnet-from-machinetemplates.yaml
+++ b/hack/examples/patches/nutanix/remove-cluster-and-subnet-from-machinetemplates.yaml
@@ -1,0 +1,4 @@
+- op: remove
+  path: /spec/template/spec/cluster
+- op: remove
+  path: /spec/template/spec/subnet

--- a/hack/third-party/capx/go.mod
+++ b/hack/third-party/capx/go.mod
@@ -3,11 +3,11 @@
 
 module github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/external/capx
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.3
 
-require github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.2
+require github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.4
 
 require (
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
@@ -28,7 +28,6 @@ require (
 	github.com/nutanix-cloud-native/prism-go-client v0.5.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	go.uber.org/automaxprocs v1.6.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect

--- a/hack/third-party/capx/go.sum
+++ b/hack/third-party/capx/go.sum
@@ -76,8 +76,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.2 h1:RsqSaYm5Vg6887taqJ8mRtqa1zckiwtqZVf3/xJRcro=
-github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.2/go.mod h1:8F3sXZInz+dShppYLmMzQwUAzFsZTyaxaB3bf5rIk/A=
+github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.4 h1:SNfZlG/AJ/RUpEij0Lu1XbrIoOxk+tZvzQktFdPkGYc=
+github.com/nutanix-cloud-native/cluster-api-provider-nutanix v1.7.0-beta.4/go.mod h1:6AJwae8W/nGmITlnuTnvMxCxxztctEAUJulxC9z/jgU=
 github.com/nutanix-cloud-native/prism-go-client v0.5.0 h1:aSNuKDOK7+q676MQyetYXcySY41IjSvN2UmrDIU3+6s=
 github.com/nutanix-cloud-native/prism-go-client v0.5.0/go.mod h1:QhLX+sEep0cStzHVYU6mPgIlnA8U3DySskagrbDprRk=
 github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus=

--- a/pkg/handlers/nutanix/mutation/controlplanefailuredomains/inject.go
+++ b/pkg/handlers/nutanix/mutation/controlplanefailuredomains/inject.go
@@ -71,7 +71,7 @@ func (h *nutanixControlPlaneFailureDomains) Mutate(
 	)
 	if err != nil {
 		if variables.IsNotFoundError(err) {
-			log.V(5).Info("ControlPlane nutanix failureDomains variable not defined", "error", err.Error())
+			log.V(5).Info("ControlPlane nutanix failureDomains variable not defined in cluster config")
 			return nil
 		}
 		log.V(5).Error(err, "failed to get controlPlane nutanix failureDomains variable")

--- a/pkg/handlers/nutanix/mutation/machinedetails/inject.go
+++ b/pkg/handlers/nutanix/mutation/machinedetails/inject.go
@@ -99,11 +99,6 @@ func (h *nutanixMachineDetailsPatchHandler) Mutate(
 			spec.BootType = nutanixMachineDetailsVar.BootType
 			if nutanixMachineDetailsVar.Cluster != nil {
 				spec.Cluster = *nutanixMachineDetailsVar.Cluster
-			} else {
-				// Have to set the required Type field.
-				spec.Cluster = capxv1.NutanixResourceIdentifier{
-					Type: capxv1.NutanixIdentifierName,
-				}
 			}
 
 			switch {
@@ -122,7 +117,10 @@ func (h *nutanixMachineDetailsPatchHandler) Mutate(
 			spec.MemorySize = nutanixMachineDetailsVar.MemorySize
 			spec.SystemDiskSize = nutanixMachineDetailsVar.SystemDiskSize
 
-			spec.Subnets = slices.Clone(nutanixMachineDetailsVar.Subnets)
+			if len(nutanixMachineDetailsVar.Subnets) > 0 {
+				spec.Subnets = slices.Clone(nutanixMachineDetailsVar.Subnets)
+			}
+
 			spec.AdditionalCategories = slices.Clone(nutanixMachineDetailsVar.AdditionalCategories)
 			spec.GPUs = slices.Clone(nutanixMachineDetailsVar.GPUs)
 			spec.Project = nutanixMachineDetailsVar.Project.DeepCopy()

--- a/pkg/handlers/nutanix/mutation/machinedetails/inject_control_plane_test.go
+++ b/pkg/handlers/nutanix/mutation/machinedetails/inject_control_plane_test.go
@@ -86,24 +86,19 @@ var (
 		},
 	}
 	matchersForAllImageTemplating = []capitest.JSONPatchMatcher{
-		// boot type
 		{
 			Operation:    "add",
 			Path:         "/spec/template/spec/bootType",
 			ValueMatcher: gomega.BeEquivalentTo(capxv1.NutanixBootTypeLegacy),
 		},
-		// cluster
 		{
-			Operation:    "add",
-			Path:         "/spec/template/spec/cluster/name",
-			ValueMatcher: gomega.BeEquivalentTo("fake-pe-cluster"),
+			Operation: "add",
+			Path:      "/spec/template/spec/cluster",
+			ValueMatcher: gomega.SatisfyAll(
+				gomega.HaveKeyWithValue("type", gomega.BeEquivalentTo(capxv1.NutanixIdentifierName)),
+				gomega.HaveKeyWithValue("name", gomega.BeEquivalentTo("fake-pe-cluster")),
+			),
 		},
-		{
-			Operation:    "replace",
-			Path:         "/spec/template/spec/cluster/type",
-			ValueMatcher: gomega.BeEquivalentTo(capxv1.NutanixIdentifierName),
-		},
-
 		{
 			Operation:    "replace",
 			Path:         "/spec/template/spec/vcpuSockets",
@@ -125,9 +120,14 @@ var (
 			ValueMatcher: gomega.BeEquivalentTo("40Gi"),
 		},
 		{
-			Operation:    "replace",
-			Path:         "/spec/template/spec/subnet",
-			ValueMatcher: gomega.HaveLen(1),
+			Operation: "add",
+			Path:      "/spec/template/spec/subnet",
+			ValueMatcher: gomega.ContainElement(
+				gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("type", gomega.BeEquivalentTo(capxv1.NutanixIdentifierName)),
+					gomega.HaveKeyWithValue("name", gomega.BeEquivalentTo("fake-subnet")),
+				),
+			),
 		},
 		{
 			Operation: "add",
@@ -159,14 +159,12 @@ var (
 			ValueMatcher: gomega.BeEquivalentTo(capxv1.NutanixBootTypeLegacy),
 		},
 		{
-			Operation:    "add",
-			Path:         "/spec/template/spec/cluster/name",
-			ValueMatcher: gomega.BeEquivalentTo("fake-pe-cluster"),
-		},
-		{
-			Operation:    "replace",
-			Path:         "/spec/template/spec/cluster/type",
-			ValueMatcher: gomega.BeEquivalentTo(capxv1.NutanixIdentifierName),
+			Operation: "add",
+			Path:      "/spec/template/spec/cluster",
+			ValueMatcher: gomega.SatisfyAll(
+				gomega.HaveKeyWithValue("type", gomega.BeEquivalentTo(capxv1.NutanixIdentifierName)),
+				gomega.HaveKeyWithValue("name", gomega.BeEquivalentTo("fake-pe-cluster")),
+			),
 		},
 		{
 			Operation:    "replace",
@@ -189,9 +187,14 @@ var (
 			ValueMatcher: gomega.BeEquivalentTo("40Gi"),
 		},
 		{
-			Operation:    "replace",
-			Path:         "/spec/template/spec/subnet",
-			ValueMatcher: gomega.HaveLen(1),
+			Operation: "add",
+			Path:      "/spec/template/spec/subnet",
+			ValueMatcher: gomega.ContainElement(
+				gomega.SatisfyAll(
+					gomega.HaveKeyWithValue("type", gomega.BeEquivalentTo(capxv1.NutanixIdentifierName)),
+					gomega.HaveKeyWithValue("name", gomega.BeEquivalentTo("fake-subnet")),
+				),
+			),
 		},
 		{
 			Operation: "add",


### PR DESCRIPTION
* Use XOR instead of OR for cluster and subnet presence check against failure domains on control plane and worker overrides.
* Update CAPX version to latest beta to omit zero values for cluster and null values for subnet
* Update patch unit tests as those are fragile (due to ordering) and there were changes in patches
* Add kustomize patches for nutanix clusterclass template's NutanixMachineTemplate to strip out cluster and subnet
* Improve verbose-mode logging for easier debugging in future

**How has this been tested?**
* Run `make dev.run-on-kind` and see default NutanixMachineTemplates when management cluster is created and observe no placeholder cluster and subnet fields
```yaml
- apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
  kind: NutanixMachineTemplate
  metadata:
    ...
    name: nutanix-quick-start-cp-nmt
    namespace: default
    ownerReferences:
    - apiVersion: cluster.x-k8s.io/v1beta1
      kind: ClusterClass
      name: nutanix-quick-start
      uid: 5b002494-0fab-41a8-a702-5cdf6f791b7c
  spec:
    template:
      spec:
        bootType: legacy
        image:
          name: ""
          type: name
        memorySize: 4Gi
        systemDiskSize: 40Gi
        vcpuSockets: 2
        vcpusPerSocket: 1
- apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
  kind: NutanixMachineTemplate
  metadata:
    ...
    name: nutanix-quick-start-md-nmt
    namespace: default
    ownerReferences:
    - apiVersion: cluster.x-k8s.io/v1beta1
      kind: ClusterClass
      name: nutanix-quick-start
      uid: 5b002494-0fab-41a8-a702-5cdf6f791b7c
  spec:
    template:
      spec:
        bootType: legacy
        image:
          name: ""
          type: name
        memorySize: 4Gi
        systemDiskSize: 40Gi
        vcpuSockets: 2
        vcpusPerSocket: 1
```

* Create a cluster with control plane and machine deployments with failure domains with cluster and subnet variables also set in controlPlane machineDetails and machineDeployment variables overrides.
```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: nkp-sid-caren
    cluster.x-k8s.io/provider: nutanix
  name: nkp-sid-caren
spec:
  ...
  topology:
    class: nutanix-quick-start
    controlPlane:
      metadata: {}
      replicas: 3
    variables:
    - name: clusterConfig
      value:
        ...
        controlPlane:
          nutanix:
            failureDomains:
            - fd-1
            - fd-2
            - fd-3
            machineDetails:
              bootType: uefi
              cluster:
                type: name
                name: ncn-dev-sandbox
              subnets:
              - type: name
                name: vlan173
              imageLookup:
                baseOS: rocky-9.6
                format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
              memorySize: 4Gi
              systemDiskSize: 40Gi
              vcpuSockets: 2
              vcpusPerSocket: 1
        ...
    - name: workerConfig
      value:
        nutanix:
          machineDetails:
            bootType: uefi
            cluster:
              name: ncn-dev-sandbox
              type: name
            imageLookup:
              baseOS: rocky-9.6
              format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
            memorySize: 4Gi
            subnets:
            - name: vlan173
              type: name
            systemDiskSize: 40Gi
            vcpuSockets: 2
            vcpusPerSocket: 1
    version: 1.33.1
    workers:
      machineDeployments:
      - class: default-worker
        failureDomain: fd-1
        metadata:
          annotations:
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "1"
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
        name: md-0
        variables:
          overrides:
          - name: workerConfig
            value:
              nutanix:
                machineDetails:
                  bootType: uefi
                  cluster:
                    type: name
                    name: ncn-dev-sandbox
                  subnets:
                  - type: name
                    name: vlan173
                  imageLookup:
                    baseOS: rocky-9.6
                    format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
                  memorySize: 8Gi
                  systemDiskSize: 80Gi
                  vcpuSockets: 8
                  vcpusPerSocket: 1
```
and expect failures from the webhook
```sh
$ k apply -f nkp-sid-caren-neg.yaml
...
Error from server (Forbidden): error when creating "nkp-sid-caren-neg.yaml": admission webhook "cluster-validator.caren.nutanix.com" denied the request: [spec.topology.variables.clusterConfig.value.controlPlane.nutanix.machineDetails.cluster: Forbidden: "cluster" must not be set when failureDomains are configured., spec.topology.variables.clusterConfig.value.controlPlane.nutanix.machineDetails.subnets: Forbidden: "subnets" must not be set when failureDomains are configured., spec.topology.workers.machineDeployments.variables.overrides.workerConfig.value.nutanix.machineDetails.cluster: Forbidden: "cluster" must not be set when failureDomain is configured., spec.topology.workers.machineDeployments.variables.overrides.workerConfig.value.nutanix.machineDetails.subnets: Forbidden: "subnets" must not be set when failureDomain is configured.]
```
* Create a cluster without failure domains with a machine deployment with cluster and subnet not set
```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: nkp-sid-caren-no-fd
    cluster.x-k8s.io/provider: nutanix
  name: nkp-sid-caren-no-fd
spec:
  ...
  topology:
    class: nutanix-quick-start
    controlPlane:
      metadata: {}
      replicas: 3
    variables:
    - name: clusterConfig
      value:
        ...
        controlPlane:
          nutanix:
            machineDetails:
              bootType: uefi
              imageLookup:
                baseOS: rocky-9.6
                format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
              memorySize: 4Gi
              systemDiskSize: 40Gi
              vcpuSockets: 2
              vcpusPerSocket: 1
        ...
    - name: workerConfig
      value:
        nutanix:
          machineDetails:
            bootType: uefi
            cluster:
              name: ncn-dev-sandbox
              type: name
            imageLookup:
              baseOS: rocky-9.6
              format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
            memorySize: 4Gi
            subnets:
            - name: vlan173
              type: name
            systemDiskSize: 40Gi
            vcpuSockets: 2
            vcpusPerSocket: 1
    version: 1.33.1
    workers:
      machineDeployments:
      - class: default-worker
        metadata:
          annotations:
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "1"
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
        name: md-0
        variables:
          overrides:
          - name: workerConfig
            value:
              nutanix:
                machineDetails:
                  bootType: uefi
                  imageLookup:
                    baseOS: rocky-9.6
                    format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
                  memorySize: 8Gi
                  cluster:
                    type: name
                    name: ncn-dev-sandbox
                  subnets:
                  - type: name
                    name: vlan173
                  systemDiskSize: 80Gi
                  vcpuSockets: 8
                  vcpusPerSocket: 1
      - class: default-worker
        metadata:
          annotations:
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "1"
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
        name: md-1
        variables:
          overrides:
          - name: workerConfig
            value:
              nutanix:
                machineDetails:
                  bootType: uefi
                  imageLookup:
                    baseOS: rocky-9.6
                    format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
                  memorySize: 8Gi
                  systemDiskSize: 80Gi
                  vcpuSockets: 8
                  vcpusPerSocket: 1
```
and expect failures from webhook
```sh
$ k apply -f no-fd-neg.yaml
...
Error from server (Forbidden): error when creating "no-fd-neg.yaml": admission webhook "cluster-validator.caren.nutanix.com" denied the request: [spec.topology.variables.clusterConfig.value.controlPlane.nutanix.machineDetails.cluster: Required value: "cluster" must be set when failureDomains are not configured., spec.topology.variables.clusterConfig.value.controlPlane.nutanix.machineDetails.subnets: Required value: "subnets" must be set when failureDomains are not configured., spec.topology.workers.machineDeployments.variables.overrides.workerConfig.value.nutanix.machineDetails.cluster: Required value: "cluster" must be set when failureDomain is not configured., spec.topology.workers.machineDeployments.variables.overrides.workerConfig.value.nutanix.machineDetails.subnets: Required value: "subnets" must be set when failureDomain is not configured.]
```

* Create a cluster without failure domains with a machine deployment with cluster and subnet set
```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  ...
  name: nkp-sid-caren-no-fd
spec:
  ...
  topology:
    class: nutanix-quick-start
    controlPlane:
      metadata: {}
      replicas: 3
    variables:
    - name: clusterConfig
      value:
        ...
        controlPlane:
          nutanix:
            machineDetails:
              bootType: uefi
              imageLookup:
                baseOS: rocky-9.6
                format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
              memorySize: 4Gi
              systemDiskSize: 40Gi
              vcpuSockets: 2
              vcpusPerSocket: 1
              cluster:
                type: name
                name: ncn-dev-sandbox
              subnets:
              - type: name
                name: vlan173
        ...
    - name: workerConfig
      value:
        nutanix:
          machineDetails:
            bootType: uefi
            cluster:
              name: ncn-dev-sandbox
              type: name
            imageLookup:
              baseOS: rocky-9.6
              format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
            memorySize: 4Gi
            subnets:
            - name: vlan173
              type: name
            systemDiskSize: 40Gi
            vcpuSockets: 2
            vcpusPerSocket: 1
    version: 1.33.1
    workers:
      machineDeployments:
      - class: default-worker
        metadata:
          annotations:
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "1"
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
        name: md-0
        variables:
          overrides:
          - name: workerConfig
            value:
              nutanix:
                machineDetails:
                  bootType: uefi
                  imageLookup:
                    baseOS: rocky-9.6
                    format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
                  memorySize: 8Gi
                  cluster:
                    type: name
                    name: ncn-dev-sandbox
                  subnets:
                  - type: name
                    name: vlan173
                  systemDiskSize: 80Gi
                  vcpuSockets: 8
                  vcpusPerSocket: 1
      - class: default-worker
        metadata:
          annotations:
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "1"
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
        name: md-1
        variables:
          overrides:
          - name: workerConfig
            value:
              nutanix:
                machineDetails:
                  bootType: uefi
                  imageLookup:
                    baseOS: rocky-9.6
                    format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
                  memorySize: 8Gi
                  cluster:
                    type: uuid
                    uuid: 00061f7f-44f7-19dc-3be1-7cc25586ee44
                  subnets:
                  - type: name
                    name: vlan173
                  systemDiskSize: 80Gi
                  vcpuSockets: 8
                  vcpusPerSocket: 1
```
Observe the generated NutanixMachineTemplate has cluster and subnets set correctly
```yaml
apiVersion: v1
items:
- apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
  kind: NutanixMachineTemplate
  metadata:
    ...
    name: nkp-sid-caren-no-fd-7np7m
    namespace: default
    ownerReferences:
    - apiVersion: cluster.x-k8s.io/v1beta1
      kind: Cluster
      name: nkp-sid-caren-no-fd
  spec:
    template:
      spec:
        bootType: uefi
        cluster:
          name: ncn-dev-sandbox
          type: name
        imageLookup:
          baseOS: rocky-9.6
          format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
        memorySize: 4Gi
        subnet:
        - name: vlan173
          type: name
        systemDiskSize: 40Gi
        vcpuSockets: 2
        vcpusPerSocket: 1
- apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
  kind: NutanixMachineTemplate
  metadata:
    ...
    name: nkp-sid-caren-no-fd-md-0-qnr58
    namespace: default
    ownerReferences:
    - apiVersion: cluster.x-k8s.io/v1beta1
      kind: Cluster
      name: nkp-sid-caren-no-fd
  spec:
    template:
      spec:
        bootType: uefi
        cluster:
          name: ncn-dev-sandbox
          type: name
        imageLookup:
          baseOS: rocky-9.6
          format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
        memorySize: 8Gi
        subnet:
        - name: vlan173
          type: name
        systemDiskSize: 80Gi
        vcpuSockets: 8
        vcpusPerSocket: 1
- apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
  kind: NutanixMachineTemplate
  metadata:
    ...
    name: nkp-sid-caren-no-fd-md-1-59tlq
    namespace: default
    ownerReferences:
    - apiVersion: cluster.x-k8s.io/v1beta1
      kind: Cluster
      name: nkp-sid-caren-no-fd
  spec:
    template:
      spec:
        bootType: uefi
        cluster:
          type: uuid
          uuid: 00061f7f-44f7-19dc-3be1-7cc25586ee44
        imageLookup:
          baseOS: rocky-9.6
          format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
        memorySize: 8Gi
        subnet:
        - name: vlan173
          type: name
        systemDiskSize: 80Gi
        vcpuSockets: 8
        vcpusPerSocket: 1

```

* Create a cluster with control plane and machine deployment on  failure domains
```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  labels:
    cluster.x-k8s.io/cluster-name: nkp-sid-caren
    cluster.x-k8s.io/provider: nutanix
  name: nkp-sid-caren
spec:
  ...
  topology:
    class: nutanix-quick-start
    controlPlane:
      metadata: {}
      replicas: 3
    variables:
    - name: clusterConfig
      value:
        ...
        controlPlane:
          nutanix:
            failureDomains:
            - fd-1
            - fd-2
            - fd-3
            machineDetails:
              bootType: uefi
              imageLookup:
                baseOS: rocky-9.6
                format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
              memorySize: 4Gi
              systemDiskSize: 40Gi
              vcpuSockets: 2
              vcpusPerSocket: 1
        ...
    - name: workerConfig
      value:
        nutanix:
          machineDetails:
            bootType: uefi
            cluster:
              name: ncn-dev-sandbox
              type: name
            imageLookup:
              baseOS: rocky-9.6
              format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
            memorySize: 4Gi
            subnets:
            - name: vlan173
              type: name
            systemDiskSize: 40Gi
            vcpuSockets: 2
            vcpusPerSocket: 1
    version: 1.33.1
    workers:
      machineDeployments:
      - class: default-worker
        failureDomain: fd-1
        metadata:
          annotations:
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "1"
            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
        name: md-0
        variables:
          overrides:
          - name: workerConfig
            value:
              nutanix:
                machineDetails:
                  bootType: uefi
                  imageLookup:
                    baseOS: rocky-9.6
                    format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
                  memorySize: 8Gi
                  systemDiskSize: 80Gi
                  vcpuSockets: 8
                  vcpusPerSocket: 1
```
Observe the generated NutanixMachineTemplate does not have cluster and subnet set
```yaml
- apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
  kind: NutanixMachineTemplate
  metadata:
    annotations:
      cluster.x-k8s.io/cloned-from-groupkind: NutanixMachineTemplate.infrastructure.cluster.x-k8s.io
      cluster.x-k8s.io/cloned-from-name: nutanix-quick-start-cp-nmt
      meta.helm.sh/release-name: cluster-api-runtime-extensions-nutanix
      meta.helm.sh/release-namespace: default
    creationTimestamp: "2025-07-23T17:12:31Z"
    generation: 1
    labels:
      app.kubernetes.io/managed-by: Helm
      cluster.x-k8s.io/cluster-name: nkp-sid-caren
      cluster.x-k8s.io/provider: nutanix
      topology.cluster.x-k8s.io/owned: ""
    name: nkp-sid-caren-kp4nc
    namespace: default
    ownerReferences:
    - apiVersion: cluster.x-k8s.io/v1beta1
      kind: Cluster
      name: nkp-sid-caren
      uid: edd422ad-d4d4-497a-9e6b-892f220252c6
    resourceVersion: "57785"
    uid: ff0a17f3-50a4-41bc-90b8-b1c0efc8311f
  spec:
    template:
      spec:
        bootType: uefi
        imageLookup:
          baseOS: rocky-9.6
          format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
        memorySize: 4Gi
        systemDiskSize: 40Gi
        vcpuSockets: 2
        vcpusPerSocket: 1
- apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
  kind: NutanixMachineTemplate
  metadata:
    annotations:
      cluster.x-k8s.io/cloned-from-groupkind: NutanixMachineTemplate.infrastructure.cluster.x-k8s.io
      cluster.x-k8s.io/cloned-from-name: nutanix-quick-start-md-nmt
      meta.helm.sh/release-name: cluster-api-runtime-extensions-nutanix
      meta.helm.sh/release-namespace: default
    creationTimestamp: "2025-07-23T17:12:31Z"
    generation: 1
    labels:
      app.kubernetes.io/managed-by: Helm
      cluster.x-k8s.io/cluster-name: nkp-sid-caren
      cluster.x-k8s.io/provider: nutanix
      topology.cluster.x-k8s.io/deployment-name: md-0
      topology.cluster.x-k8s.io/owned: ""
    name: nkp-sid-caren-md-0-bfm6v
    namespace: default
    ownerReferences:
    - apiVersion: cluster.x-k8s.io/v1beta1
      kind: Cluster
      name: nkp-sid-caren
      uid: edd422ad-d4d4-497a-9e6b-892f220252c6
    resourceVersion: "57795"
    uid: a9ea9499-ad82-4082-b9cb-4c920940e06d
  spec:
    template:
      spec:
        bootType: uefi
        imageLookup:
          baseOS: rocky-9.6
          format: nkp-{{.BaseOS}}-release-{{.K8sVersion}}-*
        memorySize: 8Gi
        systemDiskSize: 80Gi
        vcpuSockets: 8
        vcpusPerSocket: 1
```