### PR TITLE
fix: Namespacesync copies resources after partial copy failure

### DIFF
--- a/pkg/controllers/namespacesync/controller.go
+++ b/pkg/controllers/namespacesync/controller.go
@@ -138,7 +138,7 @@ func (r *Reconciler) Reconcile(
 			scc,
 			namespace,
 		)
-		if client.IgnoreAlreadyExists(err) != nil {
+		if err != nil {
 			// TODO Record an Event.
 			return ctrl.Result{}, fmt.Errorf(
 				"failed to copy source ClusterClass %s or its referenced Templates to namespace %s: %w",

--- a/pkg/controllers/namespacesync/copy.go
+++ b/pkg/controllers/namespacesync/copy.go
@@ -32,7 +32,8 @@ func copyClusterClassAndTemplates(
 		// Copy Template to target namespace
 		targetTemplate := copyObjectForCreate(sourceTemplate, sourceTemplate.GetName(), namespace)
 
-		if err := w.Create(ctx, targetTemplate); err != nil {
+		//nolint:gocritic // Inline error is checked.
+		if err := w.Create(ctx, targetTemplate); client.IgnoreAlreadyExists(err) != nil {
 			return fmt.Errorf(
 				"failed to create %s %s: %w",
 				targetTemplate.GetKind(),
@@ -50,7 +51,8 @@ func copyClusterClassAndTemplates(
 		return fmt.Errorf("error processing references: %w", err)
 	}
 
-	if err := w.Create(ctx, target); err != nil {
+	//nolint:gocritic // Inline error is checked.
+	if err := w.Create(ctx, target); client.IgnoreAlreadyExists(err) != nil {
 		return fmt.Errorf(
 			"failed to create %s %s: %w",
 			target.Kind,

--- a/pkg/controllers/namespacesync/copy_test.go
+++ b/pkg/controllers/namespacesync/copy_test.go
@@ -19,7 +19,7 @@ func TestDoNotUpdateIfTargetExists(t *testing.T) {
 	timeout := 50 * time.Second
 
 	prefix := names.SimpleNameGenerator.GenerateName("test-")
-	sourceClusterClassName, cleanup, err := createClusterClassAndTemplates(
+	sourceClusterClassName, _, cleanup, err := createClusterClassAndTemplates(
 		prefix,
 		sourceClusterClassNamespace,
 	)
@@ -44,7 +44,7 @@ func TestDoNotUpdateIfTargetExists(t *testing.T) {
 	g.Expect(cleanup()).To(Succeed())
 
 	// Create source class again
-	sourceClusterClassName, cleanup, err = createClusterClassAndTemplates(
+	sourceClusterClassName, _, cleanup, err = createClusterClassAndTemplates(
 		prefix,
 		sourceClusterClassNamespace,
 	)

--- a/pkg/controllers/namespacesync/copy_test.go
+++ b/pkg/controllers/namespacesync/copy_test.go
@@ -4,76 +4,153 @@
 package namespacesync
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage/names"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/internal/test/builder"
 )
 
-func TestDoNotUpdateIfTargetExists(t *testing.T) {
+const (
+	sourceNamespace = "source-ns"
+	targetNamespace = "target-ns"
+)
+
+var errFakeCreate = errors.New("fake create error")
+
+type mockWriter struct {
+	client.Writer
+	createErrOnKind string
+	createdObjects  []client.Object
+}
+
+func (m *mockWriter) Create(
+	ctx context.Context,
+	obj client.Object,
+	opts ...client.CreateOption,
+) error {
+	if m.createErrOnKind != "" && obj.GetObjectKind().GroupVersionKind().Kind == m.createErrOnKind {
+		return errFakeCreate
+	}
+	m.createdObjects = append(m.createdObjects, obj)
+	// Fake setting of UID to simulate a real API server create.
+	obj.SetUID("fake-uid")
+	return nil
+}
+
+func TestCopyClusterClassAndTemplates(t *testing.T) {
 	g := NewWithT(t)
-	timeout := 50 * time.Second
+	ctx := context.Background()
 
-	prefix := names.SimpleNameGenerator.GenerateName("test-")
-	sourceClusterClassName, _, cleanup, err := createClusterClassAndTemplates(
-		prefix,
-		sourceClusterClassNamespace,
-	)
-	g.Expect(err).ToNot(HaveOccurred())
+	testCases := []struct {
+		name            string
+		createErrOnKind string
+		expectErr       error
+		expectNumCopies int
+	}{
+		{
+			name:            "should succeed if all objects are created",
+			expectNumCopies: 6, // 1 ClusterClass + 5 templates
+		},
+		{
+			name:            "should fail if creating a template fails",
+			createErrOnKind: "GenericInfrastructureClusterTemplate",
+			expectErr:       errFakeCreate,
+			expectNumCopies: 0, // The first template create will fail.
+		},
+		{
+			name:            "should fail if creating the clusterclass fails",
+			createErrOnKind: "ClusterClass",
+			expectErr:       errFakeCreate,
+			expectNumCopies: 5, // All 5 templates are created before ClusterClass.
+		},
+	}
 
-	targetNamespaces, err := createTargetNamespaces(3)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	for _, targetNamespace := range targetNamespaces {
-		g.Eventually(func() error {
-			return verifyClusterClassAndTemplates(
-				env.Client,
-				sourceClusterClassName,
-				targetNamespace.Name,
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sourceClusterClass, sourceTemplates := newTestClusterClassAndTemplates(
+				sourceNamespace,
+				names.SimpleNameGenerator.GenerateName("test-cc-"),
 			)
-		},
-			timeout,
-		).Should(Succeed())
+			initObjs := []runtime.Object{sourceClusterClass}
+			for _, template := range sourceTemplates {
+				initObjs = append(initObjs, template)
+			}
+
+			fakeReader := fake.NewClientBuilder().WithRuntimeObjects(initObjs...).Build()
+			mockWriter := &mockWriter{
+				createErrOnKind: tc.createErrOnKind,
+			}
+
+			err := copyClusterClassAndTemplates(
+				ctx,
+				mockWriter,
+				fakeReader,
+				sourceClusterClass,
+				targetNamespace,
+			)
+
+			if tc.expectErr != nil {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(tc.expectErr.Error())))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			g.Expect(len(mockWriter.createdObjects)).To(Equal(tc.expectNumCopies))
+
+			for _, obj := range mockWriter.createdObjects {
+				g.Expect(obj.GetNamespace()).To(Equal(targetNamespace))
+				g.Expect(obj.GetOwnerReferences()).To(BeEmpty())
+				g.Expect(obj.GetUID()).ToNot(BeEmpty())
+				g.Expect(obj.GetResourceVersion()).To(BeEmpty())
+			}
+		})
+	}
+}
+
+// newTestClusterClassAndTemplates is a helper to generate a valid ClusterClass with all its referenced templates.
+func newTestClusterClassAndTemplates(
+	namespace,
+	prefix string,
+) (*clusterv1.ClusterClass, []client.Object) {
+	bootstrapTemplate := builder.BootstrapTemplate(namespace, prefix).Build()
+	infraMachineTemplateControlPlane := builder.InfrastructureMachineTemplate(
+		namespace,
+		fmt.Sprintf("%s-control-plane", prefix),
+	).Build()
+	infraMachineTemplateWorker := builder.InfrastructureMachineTemplate(
+		namespace,
+		fmt.Sprintf("%s-worker", prefix),
+	).Build()
+	controlPlaneTemplate := builder.ControlPlaneTemplate(namespace, prefix).Build()
+	infraClusterTemplate := builder.InfrastructureClusterTemplate(namespace, prefix).Build()
+	machineDeploymentClass := builder.MachineDeploymentClass(fmt.Sprintf("%s-worker", prefix)).
+		WithBootstrapTemplate(bootstrapTemplate).
+		WithInfrastructureTemplate(infraMachineTemplateWorker).
+		Build()
+	clusterClass := builder.ClusterClass(namespace, prefix).
+		WithInfrastructureClusterTemplate(infraClusterTemplate).
+		WithControlPlaneTemplate(controlPlaneTemplate).
+		WithControlPlaneInfrastructureMachineTemplate(infraMachineTemplateControlPlane).
+		WithWorkerMachineDeploymentClasses(*machineDeploymentClass).
+		Build()
+
+	templates := []client.Object{
+		bootstrapTemplate,
+		infraMachineTemplateWorker,
+		infraMachineTemplateControlPlane,
+		controlPlaneTemplate,
+		infraClusterTemplate,
 	}
 
-	// Delete source class
-	g.Expect(cleanup()).To(Succeed())
-
-	// Create source class again
-	sourceClusterClassName, _, cleanup, err = createClusterClassAndTemplates(
-		prefix,
-		sourceClusterClassNamespace,
-	)
-	g.Expect(err).ToNot(HaveOccurred())
-	defer func() {
-		g.Expect(cleanup()).To(Succeed())
-	}()
-
-	source := &clusterv1.ClusterClass{}
-	err = env.Get(
-		ctx,
-		client.ObjectKey{
-			Namespace: sourceClusterClassNamespace,
-			Name:      sourceClusterClassName,
-		},
-		source,
-	)
-	g.Expect(err).ToNot(HaveOccurred())
-
-	// Verify that the copy function returns an error because the target ClusterClass and Templates
-	// already exist.
-	for _, targetNamespace := range targetNamespaces {
-		err = copyClusterClassAndTemplates(
-			ctx,
-			env.Client,
-			env.Client,
-			source,
-			targetNamespace.Name,
-		)
-		g.Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
-	}
+	return clusterClass, templates
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
By design, the namespacesync controller does not update resources in the target namespace. However, if it only copies some resources before being interrupted (i.e. the controller restarts), it will never copy the remaining resources.

This PR adds a (failing) test that simulates this scenario, and then adds a fix.

**Which issue(s) this PR fixes**:
Fixes https://jira.nutanix.com/browse/NCN-108612

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
