### PR TITLE
feat: Support context for all Nutanix client calls

### DIFF
--- a/pkg/webhook/preflight/nutanix/clients.go
+++ b/pkg/webhook/preflight/nutanix/clients.go
@@ -26,6 +26,7 @@ type client interface {
 	)
 
 	GetImageById(
+		ctx context.Context,
 		uuid *string,
 		args ...map[string]interface{},
 	) (
@@ -34,6 +35,7 @@ type client interface {
 	)
 
 	ListImages(
+		ctx context.Context,
 		page_ *int,
 		limit_ *int,
 		filter_ *string,
@@ -46,6 +48,7 @@ type client interface {
 	)
 
 	GetClusterById(
+		ctx context.Context,
 		uuid *string,
 		args ...map[string]interface{},
 	) (
@@ -53,6 +56,7 @@ type client interface {
 	)
 
 	ListClusters(
+		ctx context.Context,
 		page_ *int,
 		limit_ *int,
 		filter_ *string,
@@ -65,6 +69,7 @@ type client interface {
 		error,
 	)
 	ListStorageContainers(
+		ctx context.Context,
 		page_ *int,
 		limit_ *int,
 		filter_ *string,
@@ -77,6 +82,7 @@ type client interface {
 	)
 
 	GetSubnetById(
+		ctx context.Context,
 		uuid *string,
 		args ...map[string]interface{},
 	) (
@@ -84,6 +90,7 @@ type client interface {
 	)
 
 	ListSubnets(
+		ctx context.Context,
 		page_ *int,
 		limit_ *int,
 		filter_ *string,
@@ -211,23 +218,23 @@ func (c *clientWrapper) GetCurrentLoggedInUser(
 }
 
 func (c *clientWrapper) GetImageById(
+	ctx context.Context,
 	uuid *string,
 	args ...map[string]interface{},
 ) (
 	*vmmv4.GetImageApiResponse,
 	error,
 ) {
-	resp, err := c.GetImageByIdFunc(
-		uuid,
-		args...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return callWithContext(ctx, func() (*vmmv4.GetImageApiResponse, error) {
+		return c.GetImageByIdFunc(
+			uuid,
+			args...,
+		)
+	})
 }
 
 func (c *clientWrapper) ListImages(
+	ctx context.Context,
 	page_ *int,
 	limit_ *int,
 	filter_ *string,
@@ -238,38 +245,36 @@ func (c *clientWrapper) ListImages(
 	*vmmv4.ListImagesApiResponse,
 	error,
 ) {
-	resp, err := c.ListImagesFunc(
-		page_,
-		limit_,
-		filter_,
-		orderby_,
-		select_,
-		args...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return callWithContext(ctx, func() (*vmmv4.ListImagesApiResponse, error) {
+		return c.ListImagesFunc(
+			page_,
+			limit_,
+			filter_,
+			orderby_,
+			select_,
+			args...,
+		)
+	})
 }
 
 func (c *clientWrapper) GetClusterById(
+	ctx context.Context,
 	uuid *string,
 	args ...map[string]interface{},
 ) (
 	*clustermgmtv4.GetClusterApiResponse,
 	error,
 ) {
-	resp, err := c.GetClusterByIdFunc(
-		uuid,
-		args...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return callWithContext(ctx, func() (*clustermgmtv4.GetClusterApiResponse, error) {
+		return c.GetClusterByIdFunc(
+			uuid,
+			args...,
+		)
+	})
 }
 
 func (c *clientWrapper) ListClusters(
+	ctx context.Context,
 	page_ *int,
 	limit_ *int,
 	filter_ *string,
@@ -281,22 +286,21 @@ func (c *clientWrapper) ListClusters(
 	*clustermgmtv4.ListClustersApiResponse,
 	error,
 ) {
-	resp, err := c.ListClustersFunc(
-		page_,
-		limit_,
-		filter_,
-		orderby_,
-		apply_,
-		select_,
-		args...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return callWithContext(ctx, func() (*clustermgmtv4.ListClustersApiResponse, error) {
+		return c.ListClustersFunc(
+			page_,
+			limit_,
+			filter_,
+			orderby_,
+			apply_,
+			select_,
+			args...,
+		)
+	})
 }
 
 func (c *clientWrapper) ListStorageContainers(
+	ctx context.Context,
 	page_ *int,
 	limit_ *int,
 	filter_ *string,
@@ -307,38 +311,36 @@ func (c *clientWrapper) ListStorageContainers(
 	*clustermgmtv4.ListStorageContainersApiResponse,
 	error,
 ) {
-	resp, err := c.ListStorageContainersFunc(
-		page_,
-		limit_,
-		filter_,
-		orderby_,
-		select_,
-		args...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return callWithContext(ctx, func() (*clustermgmtv4.ListStorageContainersApiResponse, error) {
+		return c.ListStorageContainersFunc(
+			page_,
+			limit_,
+			filter_,
+			orderby_,
+			select_,
+			args...,
+		)
+	})
 }
 
 func (c *clientWrapper) GetSubnetById(
+	ctx context.Context,
 	uuid *string,
 	args ...map[string]interface{},
 ) (
 	*netv4.GetSubnetApiResponse,
 	error,
 ) {
-	resp, err := c.GetSubnetByIdFunc(
-		uuid,
-		args...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return callWithContext(ctx, func() (*netv4.GetSubnetApiResponse, error) {
+		return c.GetSubnetByIdFunc(
+			uuid,
+			args...,
+		)
+	})
 }
 
 func (c *clientWrapper) ListSubnets(
+	ctx context.Context,
 	page_ *int,
 	limit_ *int,
 	filter_ *string,
@@ -350,17 +352,47 @@ func (c *clientWrapper) ListSubnets(
 	*netv4.ListSubnetsApiResponse,
 	error,
 ) {
-	resp, err := c.ListSubnetsFunc(
-		page_,
-		limit_,
-		filter_,
-		orderby_,
-		expand_,
-		select_,
-		args...,
-	)
-	if err != nil {
-		return nil, err
+	return callWithContext(ctx, func() (*netv4.ListSubnetsApiResponse, error) {
+		return c.ListSubnetsFunc(
+			page_,
+			limit_,
+			filter_,
+			orderby_,
+			expand_,
+			select_,
+			args...,
+		)
+	})
+}
+
+// callWithContext is a helper function that immediately responds to context cancellation,
+// while calling a long-running, non-preemptible function. The long-running function always
+// runs to completion, but its result is only returned if the context is not cancelled.
+func callWithContext[T any](ctx context.Context, f func() (T, error)) (resp T, err error) {
+	respCh := make(chan T)
+	errCh := make(chan error)
+
+	go func() {
+		resp, err := f()
+		select {
+		case <-ctx.Done():
+			// Context was cancelled before function returned. We assume no one wants the result anymore.
+		default:
+			if err != nil {
+				errCh <- err
+			}
+			respCh <- resp
+		}
+		close(respCh)
+		close(errCh)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return resp, ctx.Err()
+	case err := <-errCh:
+		return resp, err
+	case resp := <-respCh:
+		return resp, nil
 	}
-	return resp, nil
 }

--- a/pkg/webhook/preflight/nutanix/clients_test.go
+++ b/pkg/webhook/preflight/nutanix/clients_test.go
@@ -5,6 +5,9 @@ package nutanix
 
 import (
 	"context"
+	"errors"
+	"testing"
+	"time"
 
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -31,4 +34,91 @@ func (m *mockKubeClient) Get(
 
 func (m *mockKubeClient) SubResource(subResource string) ctrlclient.SubResourceClient {
 	return m.SubResourceClient
+}
+
+func TestCallWithContext(t *testing.T) {
+	t.Parallel()
+	testSuccessValue := "success"
+	testError := errors.New("test error")
+
+	tests := []struct {
+		name        string
+		ctx         func() (context.Context, context.CancelFunc)
+		f           func() (string, error)
+		wantVal     string
+		wantErr     error
+		cancelAfter time.Duration
+	}{
+		{
+			name: "should return value on success",
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			f: func() (string, error) {
+				return testSuccessValue, nil
+			},
+			wantVal: testSuccessValue,
+			wantErr: nil,
+		},
+		{
+			name: "should return error when function fails",
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			f: func() (string, error) {
+				return "", testError
+			},
+			wantErr: testError,
+		},
+		{
+			name: "should return context error when context is cancelled during execution",
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.WithCancel(context.Background())
+			},
+			f: func() (string, error) {
+				time.Sleep(100 * time.Millisecond)
+				return testSuccessValue, nil
+			},
+			wantErr:     context.Canceled,
+			cancelAfter: 10 * time.Millisecond,
+		},
+		{
+			name: "should return context error when context is already cancelled",
+			ctx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, func() {}
+			},
+			f: func() (string, error) {
+				t.Log("this function should not have its result returned")
+				return testSuccessValue, nil
+			},
+			wantErr: context.Canceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := tt.ctx()
+			defer cancel()
+
+			if tt.cancelAfter > 0 {
+				go func() {
+					time.Sleep(tt.cancelAfter)
+					cancel()
+				}()
+			}
+
+			gotVal, gotErr := callWithContext(ctx, tt.f)
+
+			if !errors.Is(gotErr, tt.wantErr) {
+				t.Errorf("callWithContext() error = %v, wantErr %v", gotErr, tt.wantErr)
+			}
+
+			if gotVal != tt.wantVal {
+				t.Errorf("callWithContext() gotVal = %s, wantVal %s", gotVal, tt.wantVal)
+			}
+		})
+	}
 }

--- a/pkg/webhook/preflight/nutanix/clients_test.go
+++ b/pkg/webhook/preflight/nutanix/clients_test.go
@@ -6,72 +6,8 @@ package nutanix
 import (
 	"context"
 
-	clustermgmtv4 "github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/models/clustermgmt/v4/config"
-	netv4 "github.com/nutanix/ntnx-api-golang-clients/networking-go-client/v4/models/networking/v4/config"
-	vmmv4 "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/content"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	prismv3 "github.com/nutanix-cloud-native/prism-go-client/v3"
 )
-
-var _ = client(&mocknclient{})
-
-// mocknclient is a mock implementation of the client interface for testing purposes.
-type mocknclient struct {
-	user *prismv3.UserIntentResponse
-	err  error
-
-	getImageByIdFunc func(
-		uuid *string,
-	) (
-		*vmmv4.GetImageApiResponse, error,
-	)
-
-	listImagesFunc func(
-		page,
-		limit *int,
-		filter,
-		orderby,
-		select_ *string,
-		args ...map[string]interface{},
-	) (
-		*vmmv4.ListImagesApiResponse,
-		error,
-	)
-
-	getClusterByIdFunc func(id *string) (*clustermgmtv4.GetClusterApiResponse, error)
-
-	listClustersFunc func(
-		page,
-		limit *int,
-		filter,
-		orderby,
-		apply,
-		select_ *string,
-		args ...map[string]interface{},
-	) (*clustermgmtv4.ListClustersApiResponse, error)
-
-	listStorageContainersFunc func(
-		page,
-		limit *int,
-		filter,
-		orderby,
-		select_ *string,
-		args ...map[string]interface{},
-	) (*clustermgmtv4.ListStorageContainersApiResponse, error)
-
-	GetSubnetByIdFunc func(id *string) (*netv4.GetSubnetApiResponse, error)
-
-	ListSubnetsFunc func(
-		page_ *int,
-		limit_ *int,
-		filter_ *string,
-		orderby_ *string,
-		expand_ *string,
-		select_ *string,
-		args ...map[string]interface{},
-	) (*netv4.ListSubnetsApiResponse, error)
-}
 
 type mockKubeClient struct {
 	ctrlclient.Client
@@ -95,56 +31,4 @@ func (m *mockKubeClient) Get(
 
 func (m *mockKubeClient) SubResource(subResource string) ctrlclient.SubResourceClient {
 	return m.SubResourceClient
-}
-
-func (m *mocknclient) GetCurrentLoggedInUser(ctx context.Context) (*prismv3.UserIntentResponse, error) {
-	return m.user, m.err
-}
-
-func (m *mocknclient) GetImageById(uuid *string) (*vmmv4.GetImageApiResponse, error) {
-	return m.getImageByIdFunc(uuid)
-}
-
-func (m *mocknclient) ListImages(
-	page, limit *int,
-	filter, orderby, select_ *string,
-	args ...map[string]interface{},
-) (*vmmv4.ListImagesApiResponse, error) {
-	return m.listImagesFunc(page, limit, filter, orderby, select_)
-}
-
-func (m *mocknclient) GetClusterById(id *string) (*clustermgmtv4.GetClusterApiResponse, error) {
-	return m.getClusterByIdFunc(id)
-}
-
-func (m *mocknclient) ListClusters(
-	page, limit *int,
-	filter, orderby, apply, select_ *string,
-	args ...map[string]interface{},
-) (*clustermgmtv4.ListClustersApiResponse, error) {
-	return m.listClustersFunc(page, limit, filter, orderby, apply, select_, args...)
-}
-
-func (m *mocknclient) ListStorageContainers(
-	page, limit *int,
-	filter, orderby, select_ *string,
-	args ...map[string]interface{},
-) (*clustermgmtv4.ListStorageContainersApiResponse, error) {
-	return m.listStorageContainersFunc(page, limit, filter, orderby, select_, args...)
-}
-
-func (m *mocknclient) GetSubnetById(id *string) (*netv4.GetSubnetApiResponse, error) {
-	return m.GetSubnetByIdFunc(id)
-}
-
-func (m *mocknclient) ListSubnets(
-	page_ *int,
-	limit_ *int,
-	filter_ *string,
-	orderby_ *string,
-	expand_ *string,
-	select_ *string,
-	args ...map[string]interface{},
-) (*netv4.ListSubnetsApiResponse, error) {
-	return m.ListSubnetsFunc(page_, limit_, filter_, orderby_, expand_, select_, args...)
 }

--- a/pkg/webhook/preflight/nutanix/failuredomain_test.go
+++ b/pkg/webhook/preflight/nutanix/failuredomain_test.go
@@ -45,7 +45,7 @@ func TestInitFailureDomainChecks(t *testing.T) {
 			name:                     "nil cluster config",
 			nutanixClusterConfigSpec: nil,
 			machineDeployments:       nil,
-			nclient:                  &mocknclient{},
+			nclient:                  &clientWrapper{},
 			kclient:                  getK8sClient(),
 			expectedChecksCount:      0,
 		},
@@ -57,7 +57,7 @@ func TestInitFailureDomainChecks(t *testing.T) {
 				},
 			},
 			machineDeployments:  []clusterv1.MachineDeploymentTopology{},
-			nclient:             &mocknclient{},
+			nclient:             &clientWrapper{},
 			kclient:             getK8sClient(),
 			expectedChecksCount: 0,
 		},
@@ -71,7 +71,7 @@ func TestInitFailureDomainChecks(t *testing.T) {
 				},
 			},
 			machineDeployments:  []clusterv1.MachineDeploymentTopology{},
-			nclient:             &mocknclient{},
+			nclient:             &clientWrapper{},
 			kclient:             getK8sClient(),
 			expectedChecksCount: 3,
 		},
@@ -83,7 +83,7 @@ func TestInitFailureDomainChecks(t *testing.T) {
 				Name:          "md-1",
 				FailureDomain: ptr.To("fd-w1"),
 			}},
-			nclient:             &mocknclient{},
+			nclient:             &clientWrapper{},
 			kclient:             getK8sClient(),
 			expectedChecksCount: 1,
 		},
@@ -101,7 +101,7 @@ func TestInitFailureDomainChecks(t *testing.T) {
 				Name:          "md-1",
 				FailureDomain: ptr.To("fd-w1"),
 			}},
-			nclient:             &mocknclient{},
+			nclient:             &clientWrapper{},
 			kclient:             getK8sClient(),
 			expectedChecksCount: 4,
 		},
@@ -158,7 +158,7 @@ func TestFailureDomainCheck(t *testing.T) {
 			name:                  "failureDomain object not found",
 			fdName:                failureDomainName,
 			kclient:               fake.NewFakeClient(),
-			nclient:               &mocknclient{},
+			nclient:               &clientWrapper{},
 			expectedAllowed:       false,
 			expectedInternalError: true,
 			expectedCauseMessage:  "Failed to get NutanixFailureDomain",
@@ -168,11 +168,11 @@ func TestFailureDomainCheck(t *testing.T) {
 			name:    "failureDomain check failed at PE cluster validation",
 			fdName:  failureDomainName,
 			kclient: getK8sClient(),
-			nclient: &mocknclient{
-				getClusterByIdFunc: func(id *string) (*clustermgmtv4.GetClusterApiResponse, error) {
+			nclient: &clientWrapper{
+				GetClusterByIdFunc: func(uuid *string, args ...map[string]interface{}) (*clustermgmtv4.GetClusterApiResponse, error) {
 					return nil, nil
 				},
-				listClustersFunc: func(
+				ListClustersFunc: func(
 					page,
 					limit *int,
 					filter,
@@ -196,8 +196,8 @@ func TestFailureDomainCheck(t *testing.T) {
 			name:    "failureDomain check failed at subnets validation",
 			fdName:  failureDomainName,
 			kclient: getK8sClient(),
-			nclient: &mocknclient{
-				listClustersFunc: func(
+			nclient: &clientWrapper{
+				ListClustersFunc: func(
 					page,
 					limit *int,
 					filter,
@@ -221,7 +221,7 @@ func TestFailureDomainCheck(t *testing.T) {
 					require.NoError(t, err)
 					return resp, nil
 				},
-				GetSubnetByIdFunc: func(id *string) (*netv4.GetSubnetApiResponse, error) {
+				GetSubnetByIdFunc: func(uuid *string, args ...map[string]interface{}) (*netv4.GetSubnetApiResponse, error) {
 					return nil, nil
 				},
 				ListSubnetsFunc: func(
@@ -245,8 +245,8 @@ func TestFailureDomainCheck(t *testing.T) {
 			name:    "failureDomain check success",
 			fdName:  failureDomainName,
 			kclient: getK8sClient(),
-			nclient: &mocknclient{
-				listClustersFunc: func(
+			nclient: &clientWrapper{
+				ListClustersFunc: func(
 					page,
 					limit *int,
 					filter,
@@ -270,7 +270,7 @@ func TestFailureDomainCheck(t *testing.T) {
 					require.NoError(t, err)
 					return resp, nil
 				},
-				GetSubnetByIdFunc: func(id *string) (*netv4.GetSubnetApiResponse, error) {
+				GetSubnetByIdFunc: func(uuid *string, args ...map[string]interface{}) (*netv4.GetSubnetApiResponse, error) {
 					return nil, nil
 				},
 				ListSubnetsFunc: func(

--- a/pkg/webhook/preflight/nutanix/failuredomain_test.go
+++ b/pkg/webhook/preflight/nutanix/failuredomain_test.go
@@ -169,7 +169,13 @@ func TestFailureDomainCheck(t *testing.T) {
 			fdName:  failureDomainName,
 			kclient: getK8sClient(),
 			nclient: &clientWrapper{
-				GetClusterByIdFunc: func(uuid *string, args ...map[string]interface{}) (*clustermgmtv4.GetClusterApiResponse, error) {
+				GetClusterByIdFunc: func(
+					uuid *string,
+					args ...map[string]interface{},
+				) (
+					*clustermgmtv4.GetClusterApiResponse,
+					error,
+				) {
 					return nil, nil
 				},
 				ListClustersFunc: func(

--- a/pkg/webhook/preflight/nutanix/image.go
+++ b/pkg/webhook/preflight/nutanix/image.go
@@ -39,7 +39,7 @@ func (c *imageCheck) Run(ctx context.Context) preflight.CheckResult {
 	}
 
 	if c.machineDetails.Image != nil {
-		images, err := getVMImages(c.nclient, c.machineDetails.Image)
+		images, err := getVMImages(ctx, c.nclient, c.machineDetails.Image)
 		if err != nil {
 			result.Allowed = false
 			result.InternalError = true
@@ -116,12 +116,13 @@ func newVMImageChecks(
 }
 
 func getVMImages(
+	ctx context.Context,
 	client client,
 	id *capxv1.NutanixResourceIdentifier,
 ) ([]vmmv4.Image, error) {
 	switch {
 	case id.IsUUID():
-		resp, err := client.GetImageById(id.UUID)
+		resp, err := client.GetImageById(ctx, id.UUID)
 		if err != nil {
 			return nil, err
 		}
@@ -136,7 +137,7 @@ func getVMImages(
 		return []vmmv4.Image{image}, nil
 	case id.IsName():
 		filter_ := fmt.Sprintf("name eq '%s'", *id.Name)
-		resp, err := client.ListImages(nil, nil, &filter_, nil, nil)
+		resp, err := client.ListImages(ctx, nil, nil, &filter_, nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/webhook/preflight/nutanix/image_test.go
+++ b/pkg/webhook/preflight/nutanix/image_test.go
@@ -29,7 +29,7 @@ func TestVMImageCheck(t *testing.T) {
 	}{
 		{
 			name:    "imageLookup not yet supported",
-			nclient: &mocknclient{},
+			nclient: &clientWrapper{},
 			machineDetails: &carenv1.NutanixMachineDetails{
 				ImageLookup: &capxv1.NutanixImageLookup{
 					Format: ptr.To("test-format"),
@@ -45,8 +45,8 @@ func TestVMImageCheck(t *testing.T) {
 		},
 		{
 			name: "image found by uuid",
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					assert.Equal(t, "test-uuid", *uuid)
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
@@ -69,8 +69,8 @@ func TestVMImageCheck(t *testing.T) {
 		},
 		{
 			name: "image found by name",
-			nclient: &mocknclient{
-				listImagesFunc: func(page,
+			nclient: &clientWrapper{
+				ListImagesFunc: func(page,
 					limit *int,
 					filter,
 					orderby,
@@ -102,8 +102,8 @@ func TestVMImageCheck(t *testing.T) {
 		},
 		{
 			name: "image not found by name",
-			nclient: &mocknclient{
-				listImagesFunc: func(page,
+			nclient: &clientWrapper{
+				ListImagesFunc: func(page,
 					limit *int,
 					filter,
 					orderby,
@@ -134,8 +134,8 @@ func TestVMImageCheck(t *testing.T) {
 		},
 		{
 			name: "multiple images found by name",
-			nclient: &mocknclient{
-				listImagesFunc: func(page,
+			nclient: &clientWrapper{
+				ListImagesFunc: func(page,
 					limit *int,
 					filter,
 					orderby,
@@ -176,8 +176,8 @@ func TestVMImageCheck(t *testing.T) {
 		},
 		{
 			name: "error getting image by id",
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					return nil, fmt.Errorf("api error")
 				},
 			},
@@ -200,8 +200,8 @@ func TestVMImageCheck(t *testing.T) {
 		},
 		{
 			name: "error listing images",
-			nclient: &mocknclient{
-				listImagesFunc: func(page,
+			nclient: &clientWrapper{
+				ListImagesFunc: func(page,
 					limit *int,
 					filter,
 					orderby,
@@ -233,8 +233,8 @@ func TestVMImageCheck(t *testing.T) {
 		},
 		{
 			name: "listing images returns an error response",
-			nclient: &mocknclient{
-				listImagesFunc: func(page,
+			nclient: &clientWrapper{
+				ListImagesFunc: func(page,
 					limit *int,
 					filter,
 					orderby,
@@ -269,7 +269,7 @@ func TestVMImageCheck(t *testing.T) {
 		},
 		{
 			name:           "neither image nor imageLookup specified",
-			nclient:        &mocknclient{},
+			nclient:        &clientWrapper{},
 			machineDetails: &carenv1.NutanixMachineDetails{
 				// both Image and ImageLookup are nil
 			},
@@ -302,7 +302,7 @@ func TestVMImageCheck(t *testing.T) {
 func TestGetVMImages(t *testing.T) {
 	testCases := []struct {
 		name     string
-		client   *mocknclient
+		client   *clientWrapper
 		id       *capxv1.NutanixResourceIdentifier
 		want     []vmmv4.Image
 		wantErr  bool
@@ -310,8 +310,8 @@ func TestGetVMImages(t *testing.T) {
 	}{
 		{
 			name: "get image by uuid success",
-			client: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			client: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					assert.Equal(t, "test-uuid", *uuid)
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
@@ -336,8 +336,8 @@ func TestGetVMImages(t *testing.T) {
 		},
 		{
 			name: "get image by name success",
-			client: &mocknclient{
-				listImagesFunc: func(page,
+			client: &clientWrapper{
+				ListImagesFunc: func(page,
 					limit *int,
 					filter,
 					orderby,
@@ -372,8 +372,8 @@ func TestGetVMImages(t *testing.T) {
 		},
 		{
 			name: "get image by uuid error",
-			client: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			client: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					return nil, fmt.Errorf("api error")
 				},
 			},
@@ -386,8 +386,8 @@ func TestGetVMImages(t *testing.T) {
 		},
 		{
 			name: "get image by name error",
-			client: &mocknclient{
-				listImagesFunc: func(page,
+			client: &clientWrapper{
+				ListImagesFunc: func(page,
 					limit *int,
 					filter,
 					orderby,
@@ -409,7 +409,7 @@ func TestGetVMImages(t *testing.T) {
 		},
 		{
 			name:   "neither name nor uuid specified",
-			client: &mocknclient{},
+			client: &clientWrapper{},
 			id:     &capxv1.NutanixResourceIdentifier{
 				// Both Name and UUID are not set
 			},
@@ -418,8 +418,8 @@ func TestGetVMImages(t *testing.T) {
 		},
 		{
 			name: "no image found by uuid",
-			client: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			client: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					return nil, nil
 				},
 			},
@@ -432,8 +432,8 @@ func TestGetVMImages(t *testing.T) {
 		},
 		{
 			name: "invalid data from GetImageById",
-			client: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			client: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					return &vmmv4.GetImageApiResponse{
 						Data: &vmmv4.OneOfGetImageApiResponseData{
 							ObjectType_: ptr.To("wrong-type"),
@@ -450,8 +450,8 @@ func TestGetVMImages(t *testing.T) {
 		},
 		{
 			name: "empty response from ListImages",
-			client: &mocknclient{
-				listImagesFunc: func(page,
+			client: &clientWrapper{
+				ListImagesFunc: func(page,
 					limit *int,
 					filter,
 					orderby,
@@ -513,7 +513,7 @@ func TestNewVMImageChecks(t *testing.T) {
 			name:                                   "no nutanix configuration",
 			nutanixClusterConfigSpec:               nil,
 			nutanixWorkerNodeConfigSpecByMDName:    nil,
-			nclient:                                &mocknclient{},
+			nclient:                                &clientWrapper{},
 			expectedChecks:                         0,
 			expectedControlPlaneCheckFieldIncluded: false,
 			expectedWorkerNodeCheckFieldPatternExists: false,
@@ -533,8 +533,8 @@ func TestNewVMImageChecks(t *testing.T) {
 				},
 			},
 			nutanixWorkerNodeConfigSpecByMDName: nil,
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					assert.Equal(t, "test-uuid", *uuid)
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
@@ -564,8 +564,8 @@ func TestNewVMImageChecks(t *testing.T) {
 					},
 				},
 			},
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					assert.Equal(t, "test-uuid", *uuid)
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
@@ -616,8 +616,8 @@ func TestNewVMImageChecks(t *testing.T) {
 					},
 				},
 			},
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					assert.Equal(t, "test-uuid", *uuid)
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
@@ -650,8 +650,8 @@ func TestNewVMImageChecks(t *testing.T) {
 					},
 				},
 			},
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					assert.Equal(t, "test-uuid", *uuid)
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
@@ -684,7 +684,7 @@ func TestNewVMImageChecks(t *testing.T) {
 				ControlPlane: nil, // null control plane
 			},
 			nutanixWorkerNodeConfigSpecByMDName:       nil,
-			nclient:                                   &mocknclient{},
+			nclient:                                   &clientWrapper{},
 			expectedChecks:                            0,
 			expectedControlPlaneCheckFieldIncluded:    false,
 			expectedWorkerNodeCheckFieldPatternExists: false,

--- a/pkg/webhook/preflight/nutanix/image_test.go
+++ b/pkg/webhook/preflight/nutanix/image_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	vmmv4 "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/content"
@@ -477,7 +478,9 @@ func TestGetVMImages(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := getVMImages(tc.client, tc.id)
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			got, err := getVMImages(ctx, tc.client, tc.id)
 
 			if tc.wantErr {
 				require.Error(t, err)

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck.go
@@ -39,7 +39,7 @@ func (c *imageKubernetesVersionCheck) Run(ctx context.Context) preflight.CheckRe
 	}
 
 	if c.machineDetails.Image != nil {
-		images, err := getVMImages(c.nclient, c.machineDetails.Image)
+		images, err := getVMImages(ctx, c.nclient, c.machineDetails.Image)
 		if err != nil {
 			return preflight.CheckResult{
 				Allowed:       false,

--- a/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
+++ b/pkg/webhook/preflight/nutanix/imagekubernetesversioncheck_test.go
@@ -30,8 +30,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 	}{
 		{
 			name: "kubernetes version matches",
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
 						ObjectType_: ptr.To("vmm.v4.content.Image"),
@@ -55,8 +55,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 		},
 		{
 			name: "kubernetes version mismatch",
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
 						ObjectType_: ptr.To("vmm.v4.content.Image"),
@@ -87,8 +87,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 		},
 		{
 			name: "kubernetes version with build metadata matches",
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
 						ObjectType_: ptr.To("vmm.v4.content.Image"),
@@ -112,8 +112,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 		},
 		{
 			name: "custom image name has no Kubernetes version",
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
 						ObjectType_: ptr.To("vmm.v4.content.Image"),
@@ -144,8 +144,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 		},
 		{
 			name: "invalid kubernetes version",
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
 						ObjectType_: ptr.To("vmm.v4.content.Image"),
@@ -176,8 +176,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 		},
 		{
 			name: "empty image name",
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					resp := &vmmv4.GetImageApiResponse{}
 					err := resp.SetData(vmmv4.Image{
 						ObjectType_: ptr.To("vmm.v4.content.Image"),
@@ -208,7 +208,7 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 		},
 		{
 			name:    "imageLookup not yet supported",
-			nclient: &mocknclient{},
+			nclient: &clientWrapper{},
 			machineDetails: &carenv1.NutanixMachineDetails{
 				ImageLookup: &capxv1.NutanixImageLookup{
 					Format: ptr.To("test-format"),
@@ -224,8 +224,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 		},
 		{
 			name: "no images found",
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					return nil, nil
 				},
 			},
@@ -241,8 +241,8 @@ func TestVMImageCheckWithKubernetesVersion(t *testing.T) {
 		},
 		{
 			name: "error getting images",
-			nclient: &mocknclient{
-				getImageByIdFunc: func(uuid *string) (*vmmv4.GetImageApiResponse, error) {
+			nclient: &clientWrapper{
+				GetImageByIdFunc: func(uuid *string, args ...map[string]interface{}) (*vmmv4.GetImageApiResponse, error) {
 					return nil, fmt.Errorf("some error")
 				},
 			},
@@ -302,7 +302,7 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 			},
 			expectedVersion: "1.32.3",
 			expectedChecks:  2,
-			nclient:         &mocknclient{},
+			nclient:         &clientWrapper{},
 		},
 		{
 			name: "cluster with topology version without v prefix",
@@ -315,7 +315,7 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 			},
 			expectedVersion: "1.32.3",
 			expectedChecks:  2,
-			nclient:         &mocknclient{},
+			nclient:         &clientWrapper{},
 		},
 		{
 			name: "cluster without topology",
@@ -326,7 +326,7 @@ func TestNewVMImageChecksWithKubernetesVersion(t *testing.T) {
 			},
 			expectedVersion: "",
 			expectedChecks:  0,
-			nclient:         &mocknclient{},
+			nclient:         &clientWrapper{},
 		},
 		{
 			name: "client not initialized",

--- a/pkg/webhook/preflight/nutanix/storagecontainer.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer.go
@@ -94,7 +94,7 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 	// to ensure that we only call getClusters once, even if there are multiple storage
 	// class configs.
 	getClustersOnce := sync.OnceValues(func() ([]clustermgmtv4.Cluster, error) {
-		return getClusters(c.nclient, clusterIdentifier)
+		return getClusters(ctx, c.nclient, clusterIdentifier)
 	})
 
 	for _, storageClassConfig := range c.csiSpec.StorageClassConfigs {
@@ -139,7 +139,7 @@ func (c *storageContainerCheck) Run(ctx context.Context) preflight.CheckResult {
 		// Found exactly one cluster.
 		cluster := &clusters[0]
 
-		containers, err := getStorageContainers(c.nclient, *cluster.ExtId, storageContainerName)
+		containers, err := getStorageContainers(ctx, c.nclient, *cluster.ExtId, storageContainerName)
 		if err != nil {
 			result.Allowed = false
 			result.InternalError = true
@@ -297,12 +297,13 @@ func newStorageContainerChecks(cd *checkDependencies) []preflight.Check {
 }
 
 func getStorageContainers(
+	ctx context.Context,
 	client client,
 	clusterUUID string,
 	storageContainerName string,
 ) ([]clustermgmtv4.StorageContainer, error) {
 	fltr := fmt.Sprintf("name eq '%s' and clusterExtId eq '%s'", storageContainerName, clusterUUID)
-	resp, err := client.ListStorageContainers(nil, nil, &fltr, nil, nil)
+	resp, err := client.ListStorageContainers(ctx, nil, nil, &fltr, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -318,12 +319,13 @@ func getStorageContainers(
 }
 
 func getClusters(
+	ctx context.Context,
 	client client,
 	clusterIdentifier *capxv1.NutanixResourceIdentifier,
 ) ([]clustermgmtv4.Cluster, error) {
 	switch {
 	case clusterIdentifier.IsUUID():
-		resp, err := client.GetClusterById(clusterIdentifier.UUID)
+		resp, err := client.GetClusterById(ctx, clusterIdentifier.UUID)
 		if err != nil {
 			return nil, err
 		}
@@ -334,7 +336,7 @@ func getClusters(
 		return []clustermgmtv4.Cluster{cluster}, nil
 	case clusterIdentifier.IsName():
 		filter := fmt.Sprintf("name eq '%s'", *clusterIdentifier.Name)
-		resp, err := client.ListClusters(nil, nil, &filter, nil, nil, nil)
+		resp, err := client.ListClusters(ctx, nil, nil, &filter, nil, nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/webhook/preflight/nutanix/storagecontainer_test.go
+++ b/pkg/webhook/preflight/nutanix/storagecontainer_test.go
@@ -1614,7 +1614,7 @@ func TestGetClusters(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			clusters, err := getClusters(tc.client, tc.clusterIdentifier)
+			clusters, err := getClusters(context.Background(), tc.client, tc.clusterIdentifier)
 
 			if tc.expectError {
 				require.Error(t, err)


### PR DESCRIPTION
**What problem does this PR solve?**:
This allows us to handle context cancellation when using the Nutanix v4 go client, which itself does not support context. That, together with #1235, allows us to return check results before the API server webhook timeout. This means the client sees results, instead of an uninformative (and misleading) "failed to call webhook" error.

## Before

Notice that no results are returned.

```
│ kubectl apply --dry-run=server -f invalid-bad-prismcentral-url.yaml -v=4
I0723 12:12:17.523594 2625398 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0723 12:12:17.523624 2625398 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0723 12:12:17.523627 2625398 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I0723 12:12:17.523630 2625398 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0723 12:12:17.523633 2625398 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0723 12:12:27.582271 2625398 helpers.go:246] server response object: %s[{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "error when creating \"invalid-bad-prismcentral-url.yaml\": Internal error occurred: failed calling webhook \"preflight.cluster.caren.nutanix.com\": failed to call webhook: Post \"https://cluster-api-runtime-extensions-nutanix-admission.default.svc:443/preflight-v1beta1-cluster?timeout=10s\": context deadline exceeded",
  "reason": "InternalError",
  "details": {
    "causes": [
      {
        "message": "failed calling webhook \"preflight.cluster.caren.nutanix.com\": failed to call webhook: Post \"https://cluster-api-runtime-extensions-nutanix-admission.default.svc:443/preflight-v1beta1-cluster?timeout=10s\": context deadline exceeded"
      }
    ]
  },
  "code": 500
}]
Error from server (InternalError): error when creating "invalid-bad-prismcentral-url.yaml": Internal error occurred: failed calling webhook "preflight.cluster.caren.nutanix.com": failed to call webhook: Post "https://cluster-api-runtime-extensions-nutanix-admission.default.svc:443/preflight-v1beta1-cluster?timeout=10s": context deadline exceeded
```

## After

Notice that the results are returned.

```
│ kubectl apply --dry-run=server -f invalid-bad-prismcentral-url.yaml -v=4
I0723 12:06:59.458667 2603987 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0723 12:06:59.458703 2603987 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0723 12:06:59.458706 2603987 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0723 12:06:59.458709 2603987 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I0723 12:06:59.458711 2603987 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0723 12:07:07.583019 2603987 helpers.go:246] server response object: %s[{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "error when creating \"invalid-bad-prismcentral-url.yaml\": admission webhook \"preflight.cluster.caren.nutanix.com\" denied the request: preflight checks failed due to an internal error",
  "reason": "InternalError",
  "details": {
    "causes": [
      {
        "reason": "NutanixCredentials",
        "message": "Failed to validate credentials: Get \"https://example.com:9441/api/nutanix/v3/users/me\": context deadline exceeded. This is usually a temporary error. Please retry.",
        "field": "$.spec.topology.variables[?@.name==\"clusterConfig\"].value.nutanix.prismCentralEndpoint"
      }
    ]
  },
  "code": 500
}]
Error from server (InternalError): error when creating "invalid-bad-prismcentral-url.yaml": admission webhook "preflight.cluster.caren.nutanix.com" denied the request: preflight checks failed due to an internal error
```
 
**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
