### PR TITLE
test: Add a E2E test creating a Nutanix cluster with failure domains

### DIFF
--- a/examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-crs.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-crs.yaml
@@ -1,0 +1,223 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}-dockerhub-credentials
+stringData:
+  password: ${DOCKER_HUB_PASSWORD}
+  username: ${DOCKER_HUB_USERNAME}
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}-pc-creds-for-csi
+stringData:
+  key: ${NUTANIX_ENDPOINT}:${NUTANIX_PORT}:${NUTANIX_USER}:${NUTANIX_PASSWORD}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}-pc-creds
+stringData:
+  credentials: |
+    [
+      {
+        "type": "basic_auth",
+        "data": {
+          "prismCentral":{
+            "username": "${NUTANIX_USER}",
+            "password": "${NUTANIX_PASSWORD}"
+          }
+        }
+      }
+    ]
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-1
+spec:
+  prismElementCluster:
+    type: name
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+  subnets:
+  - type: name
+    name: ${NUTANIX_SUBNET_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-2
+spec:
+  prismElementCluster:
+    type: name
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+  subnets:
+  - type: name
+    name: ${NUTANIX_SUBNET_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-3
+spec:
+  prismElementCluster:
+    type: name
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+  subnets:
+  - type: name
+    name: ${NUTANIX_SUBNET_NAME}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - ${POD_CIDR:-192.168.0.0/16}
+    serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
+    services:
+      cidrBlocks:
+      - ${SERVICE_CIDR:-10.128.0.0/12}
+  topology:
+    class: nutanix-quick-start
+    controlPlane:
+      metadata: {}
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    variables:
+    - name: clusterConfig
+      value:
+        addons:
+          ccm:
+            credentials:
+              secretRef:
+                name: ${CLUSTER_NAME}-pc-creds
+            strategy: HelmAddon
+          clusterAutoscaler:
+            strategy: ClusterResourceSet
+          cni:
+            provider: Cilium
+            strategy: ClusterResourceSet
+          cosi: {}
+          csi:
+            defaultStorage:
+              provider: nutanix
+              storageClassConfig: volume
+            providers:
+              nutanix:
+                credentials:
+                  secretRef:
+                    name: ${CLUSTER_NAME}-pc-creds-for-csi
+                storageClassConfigs:
+                  volume:
+                    parameters:
+                      storageContainer: ${NUTANIX_STORAGE_CONTAINER_NAME}
+                strategy: HelmAddon
+            snapshotController:
+              strategy: HelmAddon
+          nfd:
+            strategy: ClusterResourceSet
+          serviceLoadBalancer:
+            configuration:
+              addressRanges:
+              - end: 198.18.1.10
+                start: 198.18.1.1
+              - end: 198.18.1.30
+                start: 198.18.1.21
+            provider: MetalLB
+        controlPlane:
+          nutanix:
+            failureDomains:
+            - fd-1
+            - fd-2
+            - fd-3
+            machineDetails:
+              bootType: uefi
+              imageLookup:
+                baseOS: ${NUTANIX_MACHINE_TEMPLATE_BASE_OS}
+                format: ${NUTANIX_MACHINE_TEMPLATE_LOOKUP_FORMAT}
+              memorySize: 4Gi
+              systemDiskSize: 40Gi
+              vcpuSockets: 2
+              vcpusPerSocket: 1
+        dns:
+          coreDNS: {}
+        encryptionAtRest:
+          providers:
+          - aescbc: {}
+        imageRegistries:
+        - credentials:
+            secretRef:
+              name: ${CLUSTER_NAME}-dockerhub-credentials
+          url: https://docker.io
+        nutanix:
+          controlPlaneEndpoint:
+            host: ${CONTROL_PLANE_ENDPOINT_IP}
+            port: 6443
+            virtualIP:
+              provider: KubeVIP
+          prismCentralEndpoint:
+            credentials:
+              secretRef:
+                name: ${CLUSTER_NAME}-pc-creds
+            insecure: ${NUTANIX_INSECURE}
+            url: https://${NUTANIX_ENDPOINT}:9440
+    - name: workerConfig
+      value:
+        nutanix:
+          machineDetails:
+            bootType: uefi
+            cluster:
+              name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+              type: name
+            imageLookup:
+              baseOS: ${NUTANIX_MACHINE_TEMPLATE_BASE_OS}
+              format: ${NUTANIX_MACHINE_TEMPLATE_LOOKUP_FORMAT}
+            memorySize: 4Gi
+            subnets:
+            - name: ${NUTANIX_SUBNET_NAME}
+              type: name
+            systemDiskSize: 40Gi
+            vcpuSockets: 2
+            vcpusPerSocket: 1
+    version: ${KUBERNETES_VERSION}
+    workers:
+      machineDeployments:
+      - class: default-worker
+        metadata:
+          annotations:
+            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "${WORKER_MACHINE_COUNT}"
+            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "${WORKER_MACHINE_COUNT}"
+        name: md-0
+      - class: default-worker
+        metadata:
+          annotations:
+            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "${WORKER_MACHINE_COUNT}"
+            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "${WORKER_MACHINE_COUNT}"
+        name: md-1
+        failureDomain: fd-3
+        variables:
+          overrides:
+          - name: workerConfig
+            value:
+              nutanix:
+                machineDetails:
+                  bootType: uefi
+                  imageLookup:
+                    baseOS: ${NUTANIX_MACHINE_TEMPLATE_BASE_OS}
+                    format: ${NUTANIX_MACHINE_TEMPLATE_LOOKUP_FORMAT}
+                  memorySize: 4Gi
+                  systemDiskSize: 40Gi
+                  vcpuSockets: 2
+                  vcpusPerSocket: 1

--- a/examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-helm-addon.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-helm-addon.yaml
@@ -1,0 +1,220 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}-dockerhub-credentials
+stringData:
+  password: ${DOCKER_HUB_PASSWORD}
+  username: ${DOCKER_HUB_USERNAME}
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}-pc-creds-for-csi
+stringData:
+  key: ${NUTANIX_ENDPOINT}:${NUTANIX_PORT}:${NUTANIX_USER}:${NUTANIX_PASSWORD}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}-pc-creds
+stringData:
+  credentials: |
+    [
+      {
+        "type": "basic_auth",
+        "data": {
+          "prismCentral":{
+            "username": "${NUTANIX_USER}",
+            "password": "${NUTANIX_PASSWORD}"
+          }
+        }
+      }
+    ]
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-1
+spec:
+  prismElementCluster:
+    type: name
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+  subnets:
+  - type: name
+    name: ${NUTANIX_SUBNET_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-2
+spec:
+  prismElementCluster:
+    type: name
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+  subnets:
+  - type: name
+    name: ${NUTANIX_SUBNET_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-3
+spec:
+  prismElementCluster:
+    type: name
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+  subnets:
+  - type: name
+    name: ${NUTANIX_SUBNET_NAME}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    cluster.x-k8s.io/provider: nutanix
+  name: ${CLUSTER_NAME}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - ${POD_CIDR:-192.168.0.0/16}
+    serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
+    services:
+      cidrBlocks:
+      - ${SERVICE_CIDR:-10.128.0.0/12}
+  topology:
+    class: nutanix-quick-start
+    controlPlane:
+      metadata: {}
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    variables:
+    - name: clusterConfig
+      value:
+        addons:
+          ccm:
+            credentials:
+              secretRef:
+                name: ${CLUSTER_NAME}-pc-creds
+            strategy: HelmAddon
+          clusterAutoscaler: {}
+          cni:
+            provider: Cilium
+          cosi: {}
+          csi:
+            defaultStorage:
+              provider: nutanix
+              storageClassConfig: volume
+            providers:
+              nutanix:
+                credentials:
+                  secretRef:
+                    name: ${CLUSTER_NAME}-pc-creds-for-csi
+                storageClassConfigs:
+                  volume:
+                    parameters:
+                      storageContainer: ${NUTANIX_STORAGE_CONTAINER_NAME}
+                strategy: HelmAddon
+            snapshotController:
+              strategy: HelmAddon
+          nfd: {}
+          serviceLoadBalancer:
+            configuration:
+              addressRanges:
+              - end: 198.18.1.10
+                start: 198.18.1.1
+              - end: 198.18.1.30
+                start: 198.18.1.21
+            provider: MetalLB
+        controlPlane:
+          nutanix:
+            failureDomains:
+            - fd-1
+            - fd-2
+            - fd-3
+            machineDetails:
+              bootType: uefi
+              imageLookup:
+                baseOS: ${NUTANIX_MACHINE_TEMPLATE_BASE_OS}
+                format: ${NUTANIX_MACHINE_TEMPLATE_LOOKUP_FORMAT}
+              memorySize: 4Gi
+              systemDiskSize: 40Gi
+              vcpuSockets: 2
+              vcpusPerSocket: 1
+        dns:
+          coreDNS: {}
+        encryptionAtRest:
+          providers:
+          - aescbc: {}
+        imageRegistries:
+        - credentials:
+            secretRef:
+              name: ${CLUSTER_NAME}-dockerhub-credentials
+          url: https://docker.io
+        nutanix:
+          controlPlaneEndpoint:
+            host: ${CONTROL_PLANE_ENDPOINT_IP}
+            port: 6443
+            virtualIP:
+              provider: KubeVIP
+          prismCentralEndpoint:
+            credentials:
+              secretRef:
+                name: ${CLUSTER_NAME}-pc-creds
+            insecure: ${NUTANIX_INSECURE}
+            url: https://${NUTANIX_ENDPOINT}:9440
+    - name: workerConfig
+      value:
+        nutanix:
+          machineDetails:
+            bootType: uefi
+            cluster:
+              name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+              type: name
+            imageLookup:
+              baseOS: ${NUTANIX_MACHINE_TEMPLATE_BASE_OS}
+              format: ${NUTANIX_MACHINE_TEMPLATE_LOOKUP_FORMAT}
+            memorySize: 4Gi
+            subnets:
+            - name: ${NUTANIX_SUBNET_NAME}
+              type: name
+            systemDiskSize: 40Gi
+            vcpuSockets: 2
+            vcpusPerSocket: 1
+    version: ${KUBERNETES_VERSION}
+    workers:
+      machineDeployments:
+      - class: default-worker
+        metadata:
+          annotations:
+            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "${WORKER_MACHINE_COUNT}"
+            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "${WORKER_MACHINE_COUNT}"
+        name: md-0
+      - class: default-worker
+        metadata:
+          annotations:
+            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "${WORKER_MACHINE_COUNT}"
+            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "${WORKER_MACHINE_COUNT}"
+        name: md-1
+        failureDomain: fd-3
+        variables:
+          overrides:
+          - name: workerConfig
+            value:
+              nutanix:
+                machineDetails:
+                  bootType: uefi
+                  imageLookup:
+                    baseOS: ${NUTANIX_MACHINE_TEMPLATE_BASE_OS}
+                    format: ${NUTANIX_MACHINE_TEMPLATE_LOOKUP_FORMAT}
+                  memorySize: 4Gi
+                  systemDiskSize: 40Gi
+                  vcpuSockets: 2
+                  vcpusPerSocket: 1

--- a/test/e2e/config/caren.yaml
+++ b/test/e2e/config/caren.yaml
@@ -110,6 +110,10 @@ providers:
       targetName: cluster-template-topology-cilium-helm-addon.yaml
     - sourcePath: "../../../examples/capi-quick-start/nutanix-cluster-cilium-crs.yaml"
       targetName: cluster-template-topology-cilium-crs.yaml
+    - sourcePath: "../../../examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-helm-addon.yaml"
+      targetName: cluster-template-topology-failuredomain-cilium-helm-addon.yaml
+    - sourcePath: "../../../examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-crs.yaml"
+      targetName: cluster-template-topology-failuredomain-cilium-crs.yaml
     - sourcePath: "../../../examples/capi-quick-start/nutanix-cluster-calico-helm-addon.yaml"
       targetName: cluster-template-topology-calico-helm-addon.yaml
     - sourcePath: "../../../examples/capi-quick-start/nutanix-cluster-calico-crs.yaml"


### PR DESCRIPTION
https://jira.nutanix.com/browse/NCN-107139
Add a E2E test creating a Nutanix cluster with failure domains

The FD e2e tests are added to and run as part of [checks / e2e-quick-start (Nutanix provider)].
