### PR TITLE
build: Allow arbitrary line length in markdown documents

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,6 @@
 {
   "heading-style": { "style": "atx" },
   "ul-style": { "style": "dash" },
-  "line-length": { "line_length": 120, "code_blocks": false },
+  "line-length": false,
   "hr-style": { "style": "---" }
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
Maintaining a maximum line length is not necessary.

We view Markdown documents using clients that can (and do) automatically wrap text to the width of the display.

Moreover, when we render Markdown to HTML using Hugo, the most important use case for most of Markdown documentation, the line wrapping is discarded.  

We already disabled line length for code blocks. This PR just extends it to text.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
