### PR TITLE
feat: Make the Nutanix top-level node specs required

### DIFF
--- a/api/v1alpha1/controlplane_types.go
+++ b/api/v1alpha1/controlplane_types.go
@@ -31,7 +31,7 @@ type DockerControlPlaneSpec struct {
 
 // NutanixControlPlaneSpec defines the desired state of the control plane for a Nutanix cluster.
 type NutanixControlPlaneSpec struct {
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	Nutanix *NutanixControlPlaneNodeSpec `json:"nutanix,omitempty"`
 
 	GenericControlPlaneSpec `json:",inline"`

--- a/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_nutanixclusterconfigs.yaml
@@ -341,6 +341,7 @@ spec:
                           type: array
                           x-kubernetes-list-type: set
                         machineDetails:
+                          description: machineDetails specifies the details of the Nutanix machine that will be created
                           properties:
                             additionalCategories:
                               description: |-
@@ -553,6 +554,8 @@ spec:
                           - key
                         type: object
                       type: array
+                  required:
+                    - nutanix
                   type: object
                 dns:
                   description: DNS defines the DNS configuration for the cluster.

--- a/api/v1alpha1/crds/caren.nutanix.com_nutanixworkernodeconfigs.yaml
+++ b/api/v1alpha1/crds/caren.nutanix.com_nutanixworkernodeconfigs.yaml
@@ -61,6 +61,7 @@ spec:
                 nutanix:
                   properties:
                     machineDetails:
+                      description: machineDetails specifies the details of the Nutanix machine that will be created
                       properties:
                         additionalCategories:
                           description: |-
@@ -273,6 +274,8 @@ spec:
                       - key
                     type: object
                   type: array
+              required:
+                - nutanix
               type: object
           type: object
       served: true

--- a/api/v1alpha1/nodeconfig_types.go
+++ b/api/v1alpha1/nodeconfig_types.go
@@ -96,7 +96,7 @@ func (s NutanixWorkerNodeConfig) VariableSchema() clusterv1.VariableSchema { //n
 
 // NutanixWorkerNodeConfigSpec defines the desired state of NutanixWorkerNodeSpec.
 type NutanixWorkerNodeConfigSpec struct {
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	Nutanix *NutanixWorkerNodeSpec `json:"nutanix,omitempty"`
 
 	GenericNodeSpec `json:",inline"`

--- a/api/v1alpha1/nutanix_node_types.go
+++ b/api/v1alpha1/nutanix_node_types.go
@@ -10,6 +10,8 @@ import (
 )
 
 type NutanixControlPlaneNodeSpec struct {
+	// machineDetails specifies the details of the Nutanix machine that will be created
+	// +kubebuilder:validation:Required
 	MachineDetails NutanixMachineDetails `json:"machineDetails"`
 
 	// failureDomains specifies a list of NutanixFailureDomains (by names)
@@ -20,6 +22,8 @@ type NutanixControlPlaneNodeSpec struct {
 }
 
 type NutanixWorkerNodeSpec struct {
+	// machineDetails specifies the details of the Nutanix machine that will be created
+	// +kubebuilder:validation:Required
 	MachineDetails NutanixMachineDetails `json:"machineDetails"`
 }
 

--- a/pkg/handlers/generic/mutation/autorenewcerts/variables_test.go
+++ b/pkg/handlers/generic/mutation/autorenewcerts/variables_test.go
@@ -6,8 +6,10 @@ package autorenewcerts
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
+	capxv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/api/v1beta1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
@@ -20,6 +22,7 @@ var nutanixTestDefs = []capitest.VariableTestDef{
 		Vals: v1alpha1.NutanixClusterConfigSpec{
 			ControlPlane: &v1alpha1.NutanixControlPlaneSpec{
 				GenericControlPlaneSpec: v1alpha1.GenericControlPlaneSpec{},
+				Nutanix:                 minimalNutanixControlPlaneNodeSpec(),
 			},
 		},
 	},
@@ -32,6 +35,7 @@ var nutanixTestDefs = []capitest.VariableTestDef{
 						DaysBeforeExpiry: 0,
 					},
 				},
+				Nutanix: minimalNutanixControlPlaneNodeSpec(),
 			},
 		},
 	},
@@ -44,6 +48,7 @@ var nutanixTestDefs = []capitest.VariableTestDef{
 						DaysBeforeExpiry: 7,
 					},
 				},
+				Nutanix: minimalNutanixControlPlaneNodeSpec(),
 			},
 		},
 	},
@@ -56,6 +61,7 @@ var nutanixTestDefs = []capitest.VariableTestDef{
 						DaysBeforeExpiry: 1,
 					},
 				},
+				Nutanix: minimalNutanixControlPlaneNodeSpec(),
 			},
 		},
 		ExpectError: true,
@@ -73,4 +79,31 @@ func TestVariableValidation_Nutanix(t *testing.T) {
 		},
 		nutanixTestDefs...,
 	)
+}
+
+func minimalNutanixControlPlaneNodeSpec() *v1alpha1.NutanixControlPlaneNodeSpec {
+	return &v1alpha1.NutanixControlPlaneNodeSpec{
+		MachineDetails: v1alpha1.NutanixMachineDetails{
+			BootType:       capxv1.NutanixBootTypeLegacy,
+			VCPUSockets:    2,
+			VCPUsPerSocket: 1,
+			Image: &capxv1.NutanixResourceIdentifier{
+				Type: capxv1.NutanixIdentifierName,
+				Name: ptr.To("fake-image"),
+			},
+			ImageLookup: nil,
+			Cluster: &capxv1.NutanixResourceIdentifier{
+				Type: capxv1.NutanixIdentifierName,
+				Name: ptr.To("fake-pe-cluster"),
+			},
+			MemorySize:     resource.MustParse("8Gi"),
+			SystemDiskSize: resource.MustParse("40Gi"),
+			Subnets: []capxv1.NutanixResourceIdentifier{
+				{
+					Type: capxv1.NutanixIdentifierName,
+					Name: ptr.To("fake-subnet"),
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
**What problem does this PR solve?**:
The current schema marks the Nutanix top-level node specs optional. (The same is true for top-level specs of other providers, such as AWS and Docker, but I'll get to those in the future).

This excerpt tries to demonstrate what I mean:
````yaml
        controlPlane:
          nutanix: # <- This is marked optional! But if it is missing, no VMs can be created.
            machineDetails:
              bootType: uefi
              cluster:
                name: example
                type: name
              image:
                name: example
                type: name
              memorySize: 16Gi
              subnets:
              - name: example
                type: name
              systemDiskSize: 80Gi
              vcpuSockets: 4
              vcpusPerSocket: 1
````

This draft PR marks the specs required. This is a breaking API change. I have not bumped the API version, because I want to first understand the code changes that are required, but are unrelated an API version change.    
 
**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
