### PR TITLE
test: Add t.Helper() calls in nested tests

### DIFF
--- a/common/pkg/k8s/parser/parser_test.go
+++ b/common/pkg/k8s/parser/parser_test.go
@@ -141,6 +141,7 @@ func runUnstructuredTests(t *testing.T, fn func([]string) ([]client.Object, erro
 	t.Parallel()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Helper()
 			t.Parallel()
 			got, err := fn(tt.inputs)
 			if tt.wantErr != "" {

--- a/common/pkg/testutils/capitest/variables.go
+++ b/common/pkg/testutils/capitest/variables.go
@@ -79,6 +79,8 @@ func ValidateDiscoverVariablesAs[V mutation.DiscoverVariables, T any](
 
 	for _, tt := range variableTestDefs {
 		t.Run(tt.Name, func(t *testing.T) {
+			t.Helper()
+
 			t.Parallel()
 
 			g := gomega.NewWithT(t)


### PR DESCRIPTION
This fixes incorrect line numbers being reported in test failures. This was discovered as noted in https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/1257#issuecomment-3161379399.
