### PR TITLE
fix: use the core Kubernetes version in registry syncer Pods

### DIFF
--- a/api/versions/versions.go
+++ b/api/versions/versions.go
@@ -1,0 +1,20 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package versions
+
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+)
+
+// GetCoreKubernetesVersion returns the Kubernetes version in the format "vX.Y.Z", stripping any build metadata.
+func GetCoreKubernetesVersion(kubernetesVersion string) (string, error) {
+	ver, err := semver.ParseTolerant(kubernetesVersion)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("v%d.%d.%d", ver.Major, ver.Minor, ver.Patch), nil
+}

--- a/pkg/handlers/generic/lifecycle/registry/syncer/syncer.go
+++ b/pkg/handlers/generic/lifecycle/registry/syncer/syncer.go
@@ -17,6 +17,7 @@ import (
 	caaphv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-addon-provider-helm/api/v1alpha1"
 	carenv1 "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/variables"
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/versions"
 	capiutils "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/utils"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/feature"
 	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/lifecycle/addons"
@@ -223,9 +224,14 @@ func templateValues(cluster *clusterv1.Cluster, text string) (string, error) {
 		RegistryCASecretName string
 	}
 
+	coreKubernetesVersion, err := versions.GetCoreKubernetesVersion(cluster.Spec.Topology.Version)
+	if err != nil {
+		return "", fmt.Errorf("failed to get core Kubernetes version: %w", err)
+	}
+
 	templateInput := input{
 		CusterName:        cluster.Name,
-		KubernetesVersion: cluster.Spec.Topology.Version,
+		KubernetesVersion: coreKubernetesVersion,
 		// FIXME: This assumes that the source and destination registry names are the same.
 		// This is true now with a single registry addon provider, but may not be true in the future.
 		SourceRegistryAddress:                       registryMetadata.AddressFromClusterNetwork,

--- a/pkg/handlers/generic/lifecycle/registry/syncer/syncer_integration_test.go
+++ b/pkg/handlers/generic/lifecycle/registry/syncer/syncer_integration_test.go
@@ -169,7 +169,7 @@ func createTestCluster(
 			},
 			Topology: &clusterv1.Topology{
 				Class:   "dummy-class",
-				Version: "dummy-version",
+				Version: "v1.30.100",
 				Variables: []clusterv1.ClusterVariable{
 					*variable,
 				},


### PR DESCRIPTION
**What problem does this PR solve?**:
Better handle when the Kubernetes version has a build ID. I understand we may want to "harcode" a version, but that adds more maintenance overhead on having to update it and keep it compatible across minor releases.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
