### PR TITLE
perf: Enable compression of audit logs to increase retention, without changing disk space requirements

### DIFF
--- a/pkg/handlers/generic/mutation/auditpolicy/inject.go
+++ b/pkg/handlers/generic/mutation/auditpolicy/inject.go
@@ -69,10 +69,15 @@ func (h *auditPolicyPatchHandler) Mutate(
 				apiServer.ExtraArgs = make(map[string]string, 5)
 			}
 
+			// Originally, we had 1 log of 100MB, and 10 rotated logs of 100MB each, for a total of 1100MB.
+			// We wanted to increase retention, but keep the total disk usage about the same.
+			// Now, we have 1 log of 100MB, and 90 compressed, rotated logs of approximately 10MB each,
+			// for a total of approximately 1000MB.
 			apiServer.ExtraArgs["audit-log-path"] = "/var/log/audit/kube-apiserver-audit.log"
-			apiServer.ExtraArgs["audit-log-maxage"] = "30"
-			apiServer.ExtraArgs["audit-log-maxbackup"] = "10"
-			apiServer.ExtraArgs["audit-log-maxsize"] = "100"
+			apiServer.ExtraArgs["audit-log-maxage"] = "30"     // Maximum number of days to retain audit log files.
+			apiServer.ExtraArgs["audit-log-maxbackup"] = "90"  // Maximum number of audit log files to retain.
+			apiServer.ExtraArgs["audit-log-maxsize"] = "100"   // Maximum size of log file in MB before it is rotated.
+			apiServer.ExtraArgs["audit-log-compress"] = "true" // Compress (gzip) audit log file when it is rotated.
 			apiServer.ExtraArgs["audit-policy-file"] = auditPolicyPath
 
 			if apiServer.ExtraVolumes == nil {

--- a/pkg/handlers/generic/mutation/auditpolicy/inject_test.go
+++ b/pkg/handlers/generic/mutation/auditpolicy/inject_test.go
@@ -49,11 +49,12 @@ var _ = Describe("Generate Audit Policy patches", func() {
 						gomega.HaveKeyWithValue(
 							"extraArgs",
 							map[string]interface{}{
-								"audit-log-maxbackup": "10",
+								"audit-log-maxbackup": "90",
 								"audit-log-maxsize":   "100",
 								"audit-log-path":      "/var/log/audit/kube-apiserver-audit.log",
 								"audit-policy-file":   "/etc/kubernetes/audit-policy.yaml",
 								"audit-log-maxage":    "30",
+								"audit-log-compress":  "true",
 							},
 						),
 						gomega.HaveKeyWithValue(


### PR DESCRIPTION
**What problem does this PR solve?**:
Given our disk space requirements (about 1GB), the audit logs hold about 1-2 hours. By enabling compression, we can increase this by a factor of 12, i.e. 12-24 hours.

In this PR, we enable compression of audit logs. Whenever a log file is rotated, it is compressed.

Experiments show that gzip yields a compression factor of approximately 12 for audit logs, so we increase the maximum file size by that factor. We expect disk space requirements to remain the same.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->

fluent-bit should continue to work, because it supports reading log files compressed using gzip as of https://github.com/fluent/fluent-bit/pull/8585/, released in https://github.com/fluent/fluent-bit/releases/tag/v3.0.0.

However, I need to verify this!
