### PR TITLE
ci: Upgrade CAPI core minor releases in own dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      # CAPI core minor upgrades get dedicated PRs via the capi-core-minor group below,
+      # while patch upgrades are handled by the all-go-mod-patch-and-minor group.
+      # This helps us handle breaking changes in CAPI core that happen frequently on minor releases.
+      # From Dependabot docs:
+      #    > If a dependency matches more than one rule, it's included in the first group that it matches.
+      capi-core-minor:
+        patterns: [ "sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test" ]
+        update-types: [ "minor" ]
       all-go-mod-patch-and-minor:
         patterns: [ "*" ]
         update-types: [ "patch", "minor" ]


### PR DESCRIPTION
**What problem does this PR solve?**:

This helps handle breaking changes in CAPI core in separate PR rather than bundling with all other dependency upgrades.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
