### PR TITLE
build: use kustomize to generate failuredomain examples

### DIFF
--- a/examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-crs.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-crs.yaml
@@ -1,3 +1,39 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-1
+spec:
+  prismElementCluster:
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+    type: name
+  subnets:
+  - name: ${NUTANIX_SUBNET_NAME}
+    type: name
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-2
+spec:
+  prismElementCluster:
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+    type: name
+  subnets:
+  - name: ${NUTANIX_SUBNET_NAME}
+    type: name
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-3
+spec:
+  prismElementCluster:
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+    type: name
+  subnets:
+  - name: ${NUTANIX_SUBNET_NAME}
+    type: name
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -37,42 +73,6 @@ stringData:
         }
       }
     ]
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: NutanixFailureDomain
-metadata:
-  name: fd-1
-spec:
-  prismElementCluster:
-    type: name
-    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
-  subnets:
-  - type: name
-    name: ${NUTANIX_SUBNET_NAME}
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: NutanixFailureDomain
-metadata:
-  name: fd-2
-spec:
-  prismElementCluster:
-    type: name
-    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
-  subnets:
-  - type: name
-    name: ${NUTANIX_SUBNET_NAME}
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: NutanixFailureDomain
-metadata:
-  name: fd-3
-spec:
-  prismElementCluster:
-    type: name
-    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
-  subnets:
-  - type: name
-    name: ${NUTANIX_SUBNET_NAME}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -201,12 +201,12 @@ spec:
             cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "${WORKER_MACHINE_COUNT}"
         name: md-0
       - class: default-worker
+        failureDomain: fd-3
         metadata:
           annotations:
             cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "${WORKER_MACHINE_COUNT}"
             cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "${WORKER_MACHINE_COUNT}"
         name: md-1
-        failureDomain: fd-3
         variables:
           overrides:
           - name: workerConfig

--- a/examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-helm-addon.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-helm-addon.yaml
@@ -93,7 +93,9 @@ spec:
   topology:
     class: nutanix-quick-start
     controlPlane:
-      metadata: {}
+      metadata:
+        annotations:
+          controlplane.cluster.x-k8s.io/skip-kube-proxy: ""
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     variables:
     - name: clusterConfig

--- a/examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-helm-addon.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-failuredomain-cilium-helm-addon.yaml
@@ -1,3 +1,39 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-1
+spec:
+  prismElementCluster:
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+    type: name
+  subnets:
+  - name: ${NUTANIX_SUBNET_NAME}
+    type: name
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-2
+spec:
+  prismElementCluster:
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+    type: name
+  subnets:
+  - name: ${NUTANIX_SUBNET_NAME}
+    type: name
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-3
+spec:
+  prismElementCluster:
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+    type: name
+  subnets:
+  - name: ${NUTANIX_SUBNET_NAME}
+    type: name
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -37,42 +73,6 @@ stringData:
         }
       }
     ]
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: NutanixFailureDomain
-metadata:
-  name: fd-1
-spec:
-  prismElementCluster:
-    type: name
-    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
-  subnets:
-  - type: name
-    name: ${NUTANIX_SUBNET_NAME}
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: NutanixFailureDomain
-metadata:
-  name: fd-2
-spec:
-  prismElementCluster:
-    type: name
-    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
-  subnets:
-  - type: name
-    name: ${NUTANIX_SUBNET_NAME}
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: NutanixFailureDomain
-metadata:
-  name: fd-3
-spec:
-  prismElementCluster:
-    type: name
-    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
-  subnets:
-  - type: name
-    name: ${NUTANIX_SUBNET_NAME}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -198,12 +198,12 @@ spec:
             cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "${WORKER_MACHINE_COUNT}"
         name: md-0
       - class: default-worker
+        failureDomain: fd-3
         metadata:
           annotations:
             cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "${WORKER_MACHINE_COUNT}"
             cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "${WORKER_MACHINE_COUNT}"
         name: md-1
-        failureDomain: fd-3
         variables:
           overrides:
           - name: workerConfig

--- a/hack/examples/additional-resources/nutanix/failure-domains.yaml
+++ b/hack/examples/additional-resources/nutanix/failure-domains.yaml
@@ -1,0 +1,39 @@
+# Copyright 2025 Nutanix. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-1
+spec:
+  prismElementCluster:
+    type: name
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+  subnets:
+  - type: name
+    name: ${NUTANIX_SUBNET_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-2
+spec:
+  prismElementCluster:
+    type: name
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+  subnets:
+  - type: name
+    name: ${NUTANIX_SUBNET_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: NutanixFailureDomain
+metadata:
+  name: fd-3
+spec:
+  prismElementCluster:
+    type: name
+    name: ${NUTANIX_PRISM_ELEMENT_CLUSTER_NAME}
+  subnets:
+  - type: name
+    name: ${NUTANIX_SUBNET_NAME}

--- a/hack/examples/overlays/clusters/nutanix-with-failuredomain/cilium/crs/kustomization.yaml.tmpl
+++ b/hack/examples/overlays/clusters/nutanix-with-failuredomain/cilium/crs/kustomization.yaml.tmpl
@@ -1,0 +1,23 @@
+# Copyright 2025 Nutanix. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../../../additional-resources/nutanix/failure-domains.yaml
+- ../../../../../bases/nutanix/cluster
+
+sortOptions:
+  order: fifo
+
+patches:
+  - target:
+      kind: Cluster
+    path: ../../../../../patches/cilium.yaml
+  - target:
+      kind: Cluster
+    path: ../../../../../patches/crs-strategy.yaml
+  - target:
+      kind: Cluster
+    path: ../../../../../patches/nutanix/use-failure-domains.yaml

--- a/hack/examples/overlays/clusters/nutanix-with-failuredomain/cilium/helm-addon/kustomization.yaml.tmpl
+++ b/hack/examples/overlays/clusters/nutanix-with-failuredomain/cilium/helm-addon/kustomization.yaml.tmpl
@@ -17,4 +17,7 @@ patches:
     path: ../../../../../patches/cilium.yaml
   - target:
       kind: Cluster
+    path: ../../../../../patches/skip-kube-proxy.yaml
+  - target:
+      kind: Cluster
     path: ../../../../../patches/nutanix/use-failure-domains.yaml

--- a/hack/examples/overlays/clusters/nutanix-with-failuredomain/cilium/helm-addon/kustomization.yaml.tmpl
+++ b/hack/examples/overlays/clusters/nutanix-with-failuredomain/cilium/helm-addon/kustomization.yaml.tmpl
@@ -1,0 +1,20 @@
+# Copyright 2025 Nutanix. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../../../additional-resources/nutanix/failure-domains.yaml
+- ../../../../../bases/nutanix/cluster
+
+sortOptions:
+  order: fifo
+
+patches:
+  - target:
+      kind: Cluster
+    path: ../../../../../patches/cilium.yaml
+  - target:
+      kind: Cluster
+    path: ../../../../../patches/nutanix/use-failure-domains.yaml

--- a/hack/examples/patches/nutanix/use-failure-domains.yaml
+++ b/hack/examples/patches/nutanix/use-failure-domains.yaml
@@ -1,0 +1,38 @@
+# Copyright 2025 Nutanix. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+- op: "add"
+  path: "/spec/topology/variables/0/value/controlPlane/nutanix/failureDomains"
+  value:
+    - fd-1
+    - fd-2
+    - fd-3
+- op: "remove"
+  path: "/spec/topology/variables/0/value/controlPlane/nutanix/machineDetails/cluster"
+- op: "remove"
+  path: "/spec/topology/variables/0/value/controlPlane/nutanix/machineDetails/subnets"
+
+- op: "add"
+  path: "/spec/topology/workers/machineDeployments/-"
+  value:
+    class: default-worker
+    metadata:
+      annotations:
+        cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "${WORKER_MACHINE_COUNT}"
+        cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "${WORKER_MACHINE_COUNT}"
+    name: md-1
+    failureDomain: fd-3
+    variables:
+      overrides:
+      - name: workerConfig
+        value:
+          nutanix:
+            machineDetails:
+              bootType: uefi
+              imageLookup:
+                baseOS: ${NUTANIX_MACHINE_TEMPLATE_BASE_OS}
+                format: ${NUTANIX_MACHINE_TEMPLATE_LOOKUP_FORMAT}
+              memorySize: 4Gi
+              systemDiskSize: 40Gi
+              vcpuSockets: 2
+              vcpusPerSocket: 1

--- a/hack/examples/sync.sh
+++ b/hack/examples/sync.sh
@@ -37,6 +37,18 @@ for provider in "aws" "docker" "nutanix"; do
   done
 done
 
+for provider in "nutanix"; do
+  for modifier in "failuredomain"; do
+    for cni in "cilium"; do
+      for strategy in "helm-addon" "crs"; do
+        kustomize build --load-restrictor LoadRestrictionsNone \
+            ./hack/examples/overlays/clusters/"${provider}"-with-"${modifier}"/"${cni}"/"${strategy}" \
+            >"${EXAMPLE_CLUSTERS_DIR}/${provider}-cluster-${modifier}-${cni}-${strategy}.yaml"
+        done
+    done
+  done
+done  
+
 # TODO Remove once kustomize supports retaining quotes in what will be numeric values.
 #shellcheck disable=SC2016
 sed -i'' 's/${AMI_LOOKUP_ORG}/"${AMI_LOOKUP_ORG}"/' "${EXAMPLE_CLUSTERS_DIR}"/*.yaml


### PR DESCRIPTION
**What problem does this PR solve?**:
Uses kustomize to generate the failuredomain example files and skip kube-proxy installation.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
