### PR TITLE
feat: enable Cilium source IP preservation

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
@@ -36,4 +36,8 @@ envoy:
 k8sServiceHost: auto
 {{- if .EnableKubeProxyReplacement }}
 kubeProxyReplacement: true
+tunnelProtocol: geneve
+loadBalancer:
+  mode: dsr
+  dsrDispatch: geneve
 {{- end }}

--- a/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
@@ -37,6 +37,9 @@ k8sServiceHost: auto
 {{- if .EnableKubeProxyReplacement }}
 kubeProxyReplacement: true
 tunnelProtocol: geneve
+# Always set the port to what it is is for vxlan (the defeault tunnel protocol).
+# This avoids new port requirements when updating existing clusters from vxlan to geneve.
+tunnelPort: 8472
 loadBalancer:
   mode: dsr
   dsrDispatch: geneve

--- a/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
@@ -37,9 +37,6 @@ k8sServiceHost: auto
 {{- if .EnableKubeProxyReplacement }}
 kubeProxyReplacement: true
 tunnelProtocol: geneve
-# Always set the port to what it is is for vxlan (the defeault tunnel protocol).
-# This avoids new port requirements when updating existing clusters from vxlan to geneve.
-tunnelPort: 8472
 loadBalancer:
   mode: dsr
   dsrDispatch: geneve


### PR DESCRIPTION
**What problem does this PR solve?**:
Set Cilium's configuration to preserve source IPs from external connections. See https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#client-source-ip-preservation 

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
