### PR TITLE
fix: Ciliums kube-proxy replacement rollout and wait

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml
@@ -33,11 +33,7 @@ socketLB:
 envoy:
   image:
     useDigest: false
-{{- with .ControlPlane }}
-{{- range $key, $val := .metadata.annotations }}
-{{- if eq $key "controlplane.cluster.x-k8s.io/skip-kube-proxy" }}
 k8sServiceHost: auto
-kubeProxyReplacement: true{{ break }}
-{{- end }}
-{{- end }}
+{{- if .EnableKubeProxyReplacement }}
+kubeProxyReplacement: true
 {{- end }}

--- a/hack/addons/update-cilium-manifests.sh
+++ b/hack/addons/update-cilium-manifests.sh
@@ -24,7 +24,7 @@ mkdir -p "${ASSETS_DIR}/cilium"
 envsubst -no-unset <"${KUSTOMIZE_BASE_DIR}/kustomization.yaml.tmpl" >"${ASSETS_DIR}/kustomization.yaml"
 
 cat <<EOF >"${ASSETS_DIR}/gomplate-context.yaml"
-ControlPlane: {}
+EnableKubeProxyReplacement: false
 EOF
 gomplate -f "${GIT_REPO_ROOT}/charts/cluster-api-runtime-extensions-nutanix/addons/cni/cilium/values-template.yaml" \
   --context .="${ASSETS_DIR}/gomplate-context.yaml" \

--- a/hack/tools/fetch-images/main.go
+++ b/hack/tools/fetch-images/main.go
@@ -266,16 +266,10 @@ func getValuesFileForChartIfNeeded(chartName, carenChartDirectory string) (strin
 		}
 
 		type input struct {
-			ControlPlane map[string]interface{}
+			EnableKubeProxyReplacement bool
 		}
 		templateInput := input{
-			ControlPlane: map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"annotations": map[string]interface{}{
-						"controlplane.cluster.x-k8s.io/skip-kube-proxy": "",
-					},
-				},
-			},
+			EnableKubeProxyReplacement: true,
 		}
 
 		err = template.Must(template.New(defaultHelmAddonFilename).ParseFiles(f)).Execute(tempFile, &templateInput)

--- a/pkg/handlers/generic/lifecycle/cni/cilium/handler.go
+++ b/pkg/handlers/generic/lifecycle/cni/cilium/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/pflag"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
@@ -228,6 +229,7 @@ func (c *CiliumCNI) apply(
 			c.client,
 			helmChart,
 		).
+			WithValueTemplater(templateValues).
 			WithDefaultWaiter()
 	case "":
 		resp.SetStatus(runtimehooksv1.ResponseStatusFailure)
@@ -259,23 +261,58 @@ func runApply(
 		return err
 	}
 
+	// It is possible to disable kube-proxy and migrate to Cilium's kube-proxy replacement feature in a running cluster.
+	// In this case, we need to wait for Cilium to be restated with new configuration and then cleanup kube-proxy.
+
 	// If skip kube-proxy is not set, return early.
-	// Otherwise, wait for Cilium to be rolled out and then cleanup kube-proxy if installed.
 	if !capiutils.ShouldSkipKubeProxy(cluster) {
 		return nil
 	}
 
-	log.Info(
-		fmt.Sprintf("Waiting for Cilium to be ready for cluster %s", ctrlclient.ObjectKeyFromObject(cluster)),
+	remoteClient, err := remote.NewClusterClient(
+		ctx,
+		"",
+		client,
+		ctrlclient.ObjectKeyFromObject(cluster),
 	)
-	if err := waitForCiliumToBeReady(ctx, client, cluster); err != nil {
-		return fmt.Errorf("failed to wait for Cilium to be ready: %w", err)
+	if err != nil {
+		return fmt.Errorf("error creating remote cluster client: %w", err)
+	}
+
+	// If kube-proxy is not installed,
+	// assume that the one-time migration of kube-proxy is complete and return early.
+	isKubeProxyInstalled, err := isKubeProxyInstalled(ctx, remoteClient)
+	if err != nil {
+		return fmt.Errorf("failed to check if kube-proxy is installed: %w", err)
+	}
+	if !isKubeProxyInstalled {
+		return nil
+	}
+
+	log.Info(
+		fmt.Sprintf(
+			"Waiting for Cilium ConfigMap to be updated with new configuration for cluster %s",
+			ctrlclient.ObjectKeyFromObject(cluster),
+		),
+	)
+	if err := waitForCiliumConfigMapToBeUpdatedWithKubeProxyReplacement(ctx, remoteClient); err != nil {
+		return fmt.Errorf("failed to wait for Cilium ConfigMap to be updated: %w", err)
+	}
+
+	log.Info(
+		fmt.Sprintf(
+			"Trigger a rollout of Cilium DaemonSet Pods for cluster %s",
+			ctrlclient.ObjectKeyFromObject(cluster),
+		),
+	)
+	if err := forceCiliumRollout(ctx, remoteClient); err != nil {
+		return fmt.Errorf("failed to force trigger a rollout of Cilium DaemonSet Pods: %w", err)
 	}
 
 	log.Info(
 		fmt.Sprintf("Cleaning up kube-proxy for cluster %s", ctrlclient.ObjectKeyFromObject(cluster)),
 	)
-	if err := cleanupKubeProxy(ctx, client, cluster); err != nil {
+	if err := cleanupKubeProxy(ctx, remoteClient); err != nil {
 		return fmt.Errorf("failed to cleanup kube-proxy: %w", err)
 	}
 
@@ -283,41 +320,86 @@ func runApply(
 }
 
 const (
+	kubeProxyReplacementConfigKey = "kube-proxy-replacement"
+	ciliumConfigMapName           = "cilium-config"
+
+	restartedAtAnnotation = "caren.nutanix.com/restartedAt"
+
 	kubeProxyName      = "kube-proxy"
 	kubeProxyNamespace = "kube-system"
 )
 
-func waitForCiliumToBeReady(
-	ctx context.Context,
-	c ctrlclient.Client,
-	cluster *clusterv1.Cluster,
-) error {
-	remoteClient, err := remote.NewClusterClient(
-		ctx,
-		"",
-		c,
-		ctrlclient.ObjectKeyFromObject(cluster),
-	)
-	if err != nil {
-		return fmt.Errorf("error creating remote cluster client: %w", err)
-	}
+// Use vars to override in integration tests.
+var (
+	waitInterval = 1 * time.Second
+	waitTimeout  = 30 * time.Second
+)
 
+func waitForCiliumConfigMapToBeUpdatedWithKubeProxyReplacement(ctx context.Context, c ctrlclient.Client) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ciliumConfigMapName,
+			Namespace: defaultCiliumNamespace,
+		},
+	}
+	if err := wait.ForObject(
+		ctx,
+		wait.ForObjectInput[*corev1.ConfigMap]{
+			Reader: c,
+			Target: cm.DeepCopy(),
+			Check: func(_ context.Context, obj *corev1.ConfigMap) (bool, error) {
+				return obj.Data[kubeProxyReplacementConfigKey] == "true", nil
+			},
+			Interval: waitInterval,
+			Timeout:  waitTimeout,
+		},
+	); err != nil {
+		return fmt.Errorf("failed to wait for ConfigMap %s to be updated: %w", ctrlclient.ObjectKeyFromObject(cm), err)
+	}
+	return nil
+}
+
+func forceCiliumRollout(ctx context.Context, c ctrlclient.Client) error {
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      defaultCiliumReleaseName,
 			Namespace: defaultCiliumNamespace,
 		},
 	}
+	if err := c.Get(ctx, ctrlclient.ObjectKeyFromObject(ds), ds); err != nil {
+		return fmt.Errorf("failed to get cilium daemon set: %w", err)
+	}
+
+	// Update the DaemonSet to force a rollout.
+	annotations := ds.Spec.Template.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if _, ok := annotations[restartedAtAnnotation]; !ok {
+		// Only set the annotation once to avoid a race conditition where rollouts are triggered repeatedly.
+		annotations[restartedAtAnnotation] = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	ds.Spec.Template.Annotations = annotations
+	if err := c.Update(ctx, ds); err != nil {
+		return fmt.Errorf("failed to update cilium daemon set: %w", err)
+	}
+
 	if err := wait.ForObject(
 		ctx,
 		wait.ForObjectInput[*appsv1.DaemonSet]{
-			Reader: remoteClient,
+			Reader: c,
 			Target: ds.DeepCopy(),
 			Check: func(_ context.Context, obj *appsv1.DaemonSet) (bool, error) {
-				return obj.Status.NumberAvailable == obj.Status.DesiredNumberScheduled && obj.Status.NumberUnavailable == 0, nil
+				if obj.Generation != obj.Status.ObservedGeneration {
+					return false, nil
+				}
+				isUpdated := obj.Status.NumberAvailable == obj.Status.DesiredNumberScheduled &&
+					// We're forcing a rollout so we expect the UpdatedNumberScheduled to be always set.
+					obj.Status.UpdatedNumberScheduled == obj.Status.DesiredNumberScheduled
+				return isUpdated, nil
 			},
-			Interval: 1 * time.Second,
-			Timeout:  30 * time.Second,
+			Interval: waitInterval,
+			Timeout:  waitTimeout,
 		},
 	); err != nil {
 		return fmt.Errorf(
@@ -331,17 +413,7 @@ func waitForCiliumToBeReady(
 }
 
 // cleanupKubeProxy cleans up kube-proxy DaemonSet and ConfigMap on the remote cluster when kube-proxy is disabled.
-func cleanupKubeProxy(ctx context.Context, c ctrlclient.Client, cluster *clusterv1.Cluster) error {
-	remoteClient, err := remote.NewClusterClient(
-		ctx,
-		"",
-		c,
-		ctrlclient.ObjectKeyFromObject(cluster),
-	)
-	if err != nil {
-		return fmt.Errorf("error creating remote cluster client: %w", err)
-	}
-
+func cleanupKubeProxy(ctx context.Context, c ctrlclient.Client) error {
 	objs := []ctrlclient.Object{
 		&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -357,10 +429,27 @@ func cleanupKubeProxy(ctx context.Context, c ctrlclient.Client, cluster *cluster
 		},
 	}
 	for _, obj := range objs {
-		if err := ctrlclient.IgnoreNotFound(remoteClient.Delete(ctx, obj)); err != nil {
+		if err := ctrlclient.IgnoreNotFound(c.Delete(ctx, obj)); err != nil {
 			return fmt.Errorf("failed to delete %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
 		}
 	}
 
 	return nil
+}
+
+func isKubeProxyInstalled(ctx context.Context, c ctrlclient.Client) (bool, error) {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeProxyName,
+			Namespace: kubeProxyNamespace,
+		},
+	}
+	err := c.Get(ctx, ctrlclient.ObjectKeyFromObject(ds), ds)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }

--- a/pkg/handlers/generic/lifecycle/cni/cilium/template.go
+++ b/pkg/handlers/generic/lifecycle/cni/cilium/template.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cilium
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	capiutils "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/common/pkg/capi/utils"
+)
+
+// templateValues enables kube-proxy replacement when kube-proxy is disabled.
+func templateValues(cluster *clusterv1.Cluster, text string) (string, error) {
+	ciliumTemplate, err := template.New("").Parse(text)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	type input struct {
+		EnableKubeProxyReplacement bool
+	}
+
+	// Assume when kube-proxy is skipped, we should enable Cilium's kube-proxy replacement feature.
+	templateInput := input{
+		EnableKubeProxyReplacement: capiutils.ShouldSkipKubeProxy(cluster),
+	}
+
+	var b bytes.Buffer
+	err = ciliumTemplate.Execute(&b, templateInput)
+	if err != nil {
+		return "", fmt.Errorf(
+			"`failed setting target Cluster name and namespa`ce in template: %w",
+			err,
+		)
+	}
+
+	return b.String(), nil
+}

--- a/test-deployment-service.yaml
+++ b/test-deployment-service.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - name: test-app
+        image: k8s.gcr.io/e2e-test-images/agnhost:2.33
+        args:
+        - netexec
+        - --http-port=8080
+        ports:
+        - name: http
+          containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app
+  namespace: default
+spec:
+  type: LoadBalancer
+  selector:
+    app: test-app
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080

--- a/test/e2e/serviceloadbalancer_helpers.go
+++ b/test/e2e/serviceloadbalancer_helpers.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -168,8 +169,10 @@ func EnsureLoadBalancerService(
 		Host:   getLoadBalancerAddress(svc),
 		Path:   "/clientip",
 	}
+	klog.Infof("Testing the LoadBalancer Service on: %q", getClientIPURL.String())
 	output := testServiceLoadBalancer(ctx, getClientIPURL, input.ServiceIntervals)
 	Expect(output).ToNot(BeEmpty())
+	klog.Infof("Got output from Kubernetes LoadBalancer Service: %q", output)
 }
 
 func createTestService(


### PR DESCRIPTION
**What problem does this PR solve?**:
Make the migration process from kube-proxy to Cilium's kube-proxy replacement more resilient.
Just setting `kubeProxyReplacement: true` is not enough for the Cilium operator to restart the DaemonSet Pods and pickup the new configuration. Instead of relying on `k8sServiceHost` to cause a rollout, this change forces a rollout during the migration process.
This also fixes a potential race where the Cilium DaemonSet wait returned early and delete kube-proxy before all the Pods were restarted.

Another fix here is that this whole migration process is now safer and only done once when kube-proxy is installed.

Pulled out from https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/1295

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
