### PR TITLE
test: reduce polling frequency on PC API

### DIFF
--- a/test/e2e/framework/nutanix/client.go
+++ b/test/e2e/framework/nutanix/client.go
@@ -55,8 +55,8 @@ func WaitForTaskCompletion(
 
 	if err := wait.PollUntilContextCancel(
 		ctx,
-		100*time.Millisecond,
-		true,
+		1*time.Second,
+		false,
 		func(ctx context.Context) (done bool, err error) {
 			task, err := v4Client.TasksApiInstance.GetTaskById(ptr.To(taskID))
 			if err != nil {


### PR DESCRIPTION
**What problem does this PR solve?**:
Attempt to avoid RATE_LIMIT_EXCEEDED error in parallel tests.

https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/actions/runs/17841696854/job/50732997651?pr=1309#step:7:554

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
