### PR TITLE
build: downgrade clusterctl version

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -2,7 +2,7 @@
   "packages": {
     "actionlint":                           "latest",
     "chart-testing":                        "latest",
-    "clusterctl":                           "latest",
+    "clusterctl":                           "1.10.4",
     "coreutils":                            "latest",
     "crane":                                "latest",
     "envsubst":                             "latest",

--- a/devbox.lock
+++ b/devbox.lock
@@ -125,51 +125,51 @@
         }
       }
     },
-    "clusterctl@latest": {
-      "last_modified": "2025-09-18T16:33:27Z",
-      "resolved": "github:NixOS/nixpkgs/f4b140d5b253f5e2a1ff4e5506edbf8267724bde#clusterctl",
+    "clusterctl@1.10.4": {
+      "last_modified": "2025-07-28T17:09:23Z",
+      "resolved": "github:NixOS/nixpkgs/648f70160c03151bc2121d179291337ad6bc564b#clusterctl",
       "source": "devbox-search",
-      "version": "1.11.1",
+      "version": "1.10.4",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/00iyfkai9ya3banvaskivcrmy56k20qi-clusterctl-1.11.1",
+              "path": "/nix/store/4hmmx17xj3m502w58zrpdaipxsdizhiz-clusterctl-1.10.4",
               "default": true
             }
           ],
-          "store_path": "/nix/store/00iyfkai9ya3banvaskivcrmy56k20qi-clusterctl-1.11.1"
+          "store_path": "/nix/store/4hmmx17xj3m502w58zrpdaipxsdizhiz-clusterctl-1.10.4"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/984vp8sncwdsyh0j9c1k79iqbhvzjwwx-clusterctl-1.11.1",
+              "path": "/nix/store/0c5y036gkl81n0rzsfzqix9awafapwhc-clusterctl-1.10.4",
               "default": true
             }
           ],
-          "store_path": "/nix/store/984vp8sncwdsyh0j9c1k79iqbhvzjwwx-clusterctl-1.11.1"
+          "store_path": "/nix/store/0c5y036gkl81n0rzsfzqix9awafapwhc-clusterctl-1.10.4"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/brrx4zdjwqk9dif4cq6dvnpv24lkbd8p-clusterctl-1.11.1",
+              "path": "/nix/store/v7jqgpj6zvinzjg814l9asklfjnyb967-clusterctl-1.10.4",
               "default": true
             }
           ],
-          "store_path": "/nix/store/brrx4zdjwqk9dif4cq6dvnpv24lkbd8p-clusterctl-1.11.1"
+          "store_path": "/nix/store/v7jqgpj6zvinzjg814l9asklfjnyb967-clusterctl-1.10.4"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/fzrjqvjzfbgmfg6980h6psshkprbywlk-clusterctl-1.11.1",
+              "path": "/nix/store/3kxrfw7ql2s1n83wmavdf8yhzy8a9cl3-clusterctl-1.10.4",
               "default": true
             }
           ],
-          "store_path": "/nix/store/fzrjqvjzfbgmfg6980h6psshkprbywlk-clusterctl-1.11.1"
+          "store_path": "/nix/store/3kxrfw7ql2s1n83wmavdf8yhzy8a9cl3-clusterctl-1.10.4"
         }
       }
     },


### PR DESCRIPTION

**What problem does this PR solve?**:
Newer version fails when running an older CAPI version: 
```
$ clusterctl get kubeconfig $CLUSTER_NAME
Error: this version of clusterctl could be used only with "v1beta2" management clusters, "v1beta1" detected
```

Can switch to latest once https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/pull/1325 is merged

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
