### PR TITLE
feat: custom url override for Helm AddOns

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/README.md
+++ b/charts/cluster-api-runtime-extensions-nutanix/README.md
@@ -36,6 +36,7 @@ A Helm chart for cluster-api-runtime-extensions-nutanix
 | failureDomainRollout.concurrency | int | `10` | Concurrency of the failure domain rollout controller |
 | failureDomainRollout.enabled | bool | `true` | Enable the failure domain rollout controller |
 | helmAddonsConfigMap | string | `"default-helm-addons-config"` |  |
+| helmAddonsOverrides | object | `{}` |  |
 | helmRepository.enabled | bool | `true` |  |
 | helmRepository.images.bundleInitializer.pullPolicy | string | `"IfNotPresent"` |  |
 | helmRepository.images.bundleInitializer.repository | string | `"ghcr.io/nutanix-cloud-native/cluster-api-runtime-extensions-helm-chart-bundle-initializer"` |  |

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/_helpers.tpl
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/_helpers.tpl
@@ -49,3 +49,20 @@ Certificate issuer name
 {{ required "A valid .Values.certificates.issuer.name is required!" .Values.certificates.issuer.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+  Resolve Helm addon repository URL: override (e.g. oci://harbor...) > internal OCI repo > default HTTPS.
+  Input: dict with "addonKey" (ConfigMap key, e.g. nutanix-storage-csi), "defaultURL" (default HTTPS URL), "context" (root .)
+*/}}
+{{- define "caren.helmAddonRepoURL" -}}
+{{- $ctx := .context }}
+{{- $overrides := default dict $ctx.Values.helmAddonsOverrides }}
+{{- $override := (and (hasKey $overrides .addonKey) (index $overrides .addonKey) (index (index $overrides .addonKey) "repositoryURL")) | default "" }}
+{{- if $override -}}
+{{ $override }}
+{{- else if $ctx.Values.helmRepository.enabled -}}
+oci://helm-repository.{{ $ctx.Release.Namespace }}.svc/charts
+{{- else -}}
+{{ .defaultURL }}
+{{- end -}}
+{{- end }}

--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
@@ -10,71 +10,71 @@ data:
   aws-ccm: |
     ChartName: aws-cloud-controller-manager
     ChartVersion: 0.0.9
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://kubernetes.github.io/cloud-provider-aws{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "aws-ccm" "defaultURL" "https://kubernetes.github.io/cloud-provider-aws" "context" .) }}'
   aws-ebs-csi: |
     ChartName: aws-ebs-csi-driver
     ChartVersion: 2.51.0
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://kubernetes-sigs.github.io/aws-ebs-csi-driver{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "aws-ebs-csi" "defaultURL" "https://kubernetes-sigs.github.io/aws-ebs-csi-driver" "context" .) }}'
   aws-load-balancer-controller: |
     ChartName: aws-load-balancer-controller
     ChartVersion: 1.13.4
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://aws.github.io/eks-charts{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "aws-load-balancer-controller" "defaultURL" "https://aws.github.io/eks-charts" "context" .) }}'
   cilium: |
     ChartName: cilium
     ChartVersion: 1.18.6
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://helm.cilium.io/{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "cilium" "defaultURL" "https://helm.cilium.io/" "context" .) }}'
   cluster-autoscaler: |
     ChartName: cluster-autoscaler
     ChartVersion: 9.52.0
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://kubernetes.github.io/autoscaler{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "cluster-autoscaler" "defaultURL" "https://kubernetes.github.io/autoscaler" "context" .) }}'
   cncf-distribution-registry: |
     ChartName: docker-registry
     ChartVersion: 2.3.5
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://mesosphere.github.io/charts/staging/{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "cncf-distribution-registry" "defaultURL" "https://mesosphere.github.io/charts/staging/" "context" .) }}'
   cosi-controller: |
     ChartName: cosi
     ChartVersion: 0.2.2
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://mesosphere.github.io/charts/stable/{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "cosi-controller" "defaultURL" "https://mesosphere.github.io/charts/stable/" "context" .) }}'
   konnector-agent: |
     ChartName: konnector-agent
     ChartVersion: 1.3.0
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix.github.io/helm-releases/{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "konnector-agent" "defaultURL" "https://nutanix.github.io/helm-releases/" "context" .) }}'
   local-path-provisioner-csi: |
     ChartName: local-path-provisioner
     ChartVersion: 0.0.32
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://charts.containeroo.ch{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "local-path-provisioner-csi" "defaultURL" "https://charts.containeroo.ch" "context" .) }}'
   metallb: |
     ChartName: metallb
     ChartVersion: 0.15.2
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://metallb.github.io/metallb{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "metallb" "defaultURL" "https://metallb.github.io/metallb" "context" .) }}'
   multus: |
     ChartName: multus
     ChartVersion: 0.1.0
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://mesosphere.github.io/charts/stable/{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "multus" "defaultURL" "https://mesosphere.github.io/charts/stable/" "context" .) }}'
   nfd: |
     ChartName: node-feature-discovery
     ChartVersion: 0.18.1
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://kubernetes-sigs.github.io/node-feature-discovery/charts{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "nfd" "defaultURL" "https://kubernetes-sigs.github.io/node-feature-discovery/charts" "context" .) }}'
   nutanix-ccm: |
     ChartName: nutanix-cloud-provider
     ChartVersion: 0.6.2
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix.github.io/helm/{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "nutanix-ccm" "defaultURL" "https://nutanix.github.io/helm/" "context" .) }}'
   nutanix-storage-csi: |
     ChartName: nutanix-csi-storage
     ChartVersion: 3.3.8
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix.github.io/helm-releases/{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "nutanix-storage-csi" "defaultURL" "https://nutanix.github.io/helm-releases/" "context" .) }}'
   registry-syncer: |
     ChartName: registry-syncer
     ChartVersion: 0.1.0
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://mesosphere.github.io/charts/staging/{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "registry-syncer" "defaultURL" "https://mesosphere.github.io/charts/staging/" "context" .) }}'
   snapshot-controller: |
     ChartName: snapshot-controller
     ChartVersion: 4.1.0
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://piraeus.io/helm-charts/{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "snapshot-controller" "defaultURL" "https://piraeus.io/helm-charts/" "context" .) }}'
   tigera-operator: |
     ChartName: tigera-operator
     ChartVersion: v3.29.6
-    RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://docs.tigera.io/calico/charts{{ end }}'
+    RepositoryURL: '{{ include "caren.helmAddonRepoURL" (dict "addonKey" "tigera-operator" "defaultURL" "https://docs.tigera.io/calico/charts" "context" .) }}'
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/charts/cluster-api-runtime-extensions-nutanix/values.schema.helmAddonsOverrides.json
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.schema.helmAddonsOverrides.json
@@ -1,0 +1,13 @@
+{
+  "description": "Optional per-addon overrides for Helm chart repository URL (e.g. OCI Harbor for nutanix-storage-csi). Keys match helm-config ConfigMap data keys.",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "repositoryURL": {
+        "type": "string",
+        "description": "Override repository URL (e.g. oci://harbor.eng.nutanix.com/project/chart-name)"
+      }
+    }
+  }
+}

--- a/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
@@ -1,779 +1,779 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "properties": {
-        "certificates": {
-            "type": "object",
-            "properties": {
-                "issuer": {
-                    "type": "object",
-                    "properties": {
-                        "kind": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "selfSigned": {
-                            "type": "boolean"
-                        }
-                    }
-                }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "certificates": {
+      "properties": {
+        "issuer": {
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "selfSigned": {
+              "type": "boolean"
             }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "deployDefaultClusterClasses": {
+      "type": "boolean"
+    },
+    "deployment": {
+      "properties": {
+        "replicas": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "enforceClusterAutoscalerLimits": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "env": {
+      "type": "object"
+    },
+    "failureDomainRollout": {
+      "description": "Runtime configuration for the failure domain rollout controller. This controller monitors cluster.status.failureDomains and triggers rollouts on KubeadmControlPlane when there are meaningful changes to failure domains. e.g. when an active failure domain is disabled or removed, or when adding a new failure domain can improve the distribution of control plane nodes across failure domains.",
+      "properties": {
+        "concurrency": {
+          "description": "Concurrency of the failure domain rollout controller",
+          "type": "integer"
         },
-        "deployDefaultClusterClasses": {
-            "type": "boolean"
-        },
-        "deployment": {
-            "type": "object",
-            "properties": {
-                "replicas": {
-                    "type": "integer"
-                }
-            }
-        },
-        "enforceClusterAutoscalerLimits": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "env": {
-            "type": "object"
-        },
-        "failureDomainRollout": {
-            "description": "Runtime configuration for the failure domain rollout controller. This controller monitors cluster.status.failureDomains and triggers rollouts on KubeadmControlPlane when there are meaningful changes to failure domains. e.g. when an active failure domain is disabled or removed, or when adding a new failure domain can improve the distribution of control plane nodes across failure domains.",
-            "type": "object",
-            "properties": {
-                "concurrency": {
-                    "description": "Concurrency of the failure domain rollout controller",
-                    "type": "integer"
-                },
-                "enabled": {
-                    "description": "Enable the failure domain rollout controller",
-                    "type": "boolean"
-                }
-            }
-        },
-        "helmAddonsConfigMap": {
+        "enabled": {
+          "description": "Enable the failure domain rollout controller",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "helmAddonsConfigMap": {
+      "type": "string"
+    },
+    "helmAddonsOverrides": {
+      "additionalProperties": {
+        "properties": {
+          "repositoryURL": {
+            "description": "Override repository URL (e.g. oci://harbor.eng.nutanix.com/project/chart-name)",
             "type": "string"
+          }
         },
-        "helmAddonsOverrides": {
-            "description": "Optional per-addon overrides for Helm chart repository URL (e.g. OCI Harbor for nutanix-storage-csi). Keys match helm-config ConfigMap data keys.",
-            "type": "object",
-            "additionalProperties": {
-                "type": "object",
-                "properties": {
-                    "repositoryURL": {
-                        "type": "string",
-                        "description": "Override repository URL (e.g. oci://harbor.eng.nutanix.com/project/chart-name)"
-                    }
-                }
-            }
+        "type": "object"
+      },
+      "description": "Optional per-addon overrides for Helm chart repository URL (e.g. OCI Harbor for nutanix-storage-csi). Keys match helm-config ConfigMap data keys.",
+      "type": "object"
+    },
+    "helmRepository": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
         },
-        "helmRepository": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "images": {
-                    "type": "object",
-                    "properties": {
-                        "bundleInitializer": {
-                            "type": "object",
-                            "properties": {
-                                "pullPolicy": {
-                                    "type": "string"
-                                },
-                                "repository": {
-                                    "type": "string"
-                                },
-                                "tag": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "mindthegap": {
-                            "type": "object",
-                            "properties": {
-                                "pullPolicy": {
-                                    "type": "string"
-                                },
-                                "repository": {
-                                    "type": "string"
-                                },
-                                "tag": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "securityContext": {
-                    "type": "object",
-                    "properties": {
-                        "fsGroup": {
-                            "type": "integer"
-                        },
-                        "runAsGroup": {
-                            "type": "integer"
-                        },
-                        "runAsUser": {
-                            "type": "integer"
-                        }
-                    }
-                }
-            }
-        },
-        "hooks": {
-            "type": "object",
-            "properties": {
-                "ccm": {
-                    "type": "object",
-                    "properties": {
-                        "aws": {
-                            "type": "object",
-                            "properties": {
-                                "helmAddonStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultValueTemplateConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "create": {
-                                                    "type": "boolean"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "k8sMinorVersionToCCMVersion": {
-                                    "type": "object",
-                                    "properties": {
-                                        "1.30": {
-                                            "type": "string"
-                                        },
-                                        "1.31": {
-                                            "type": "string"
-                                        },
-                                        "1.32": {
-                                            "type": "string"
-                                        },
-                                        "1.33": {
-                                            "type": "string"
-                                        },
-                                        "1.34": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "nutanix": {
-                            "type": "object",
-                            "properties": {
-                                "helmAddonStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultValueTemplateConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "create": {
-                                                    "type": "boolean"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "clusterAutoscaler": {
-                    "type": "object",
-                    "properties": {
-                        "crsStrategy": {
-                            "type": "object",
-                            "properties": {
-                                "defaultInstallationConfigMap": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "helmAddonStrategy": {
-                            "type": "object",
-                            "properties": {
-                                "defaultValueTemplateConfigMap": {
-                                    "type": "object",
-                                    "properties": {
-                                        "create": {
-                                            "type": "boolean"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "cni": {
-                    "type": "object",
-                    "properties": {
-                        "calico": {
-                            "type": "object",
-                            "properties": {
-                                "crsStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultInstallationConfigMaps": {
-                                            "type": "object",
-                                            "properties": {
-                                                "AWSCluster": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "configMap": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "content": {
-                                                                    "type": "string"
-                                                                },
-                                                                "name": {
-                                                                    "type": "string"
-                                                                }
-                                                            }
-                                                        },
-                                                        "create": {
-                                                            "type": "boolean"
-                                                        }
-                                                    }
-                                                },
-                                                "DockerCluster": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "configMap": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "content": {
-                                                                    "type": "string"
-                                                                },
-                                                                "name": {
-                                                                    "type": "string"
-                                                                }
-                                                            }
-                                                        },
-                                                        "create": {
-                                                            "type": "boolean"
-                                                        }
-                                                    }
-                                                },
-                                                "NutanixCluster": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "configMap": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "content": {
-                                                                    "type": "string"
-                                                                },
-                                                                "name": {
-                                                                    "type": "string"
-                                                                }
-                                                            }
-                                                        },
-                                                        "create": {
-                                                            "type": "boolean"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "defaultTigeraOperatorConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "defaultPodSubnet": {
-                                    "type": "string"
-                                },
-                                "helmAddonStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultValueTemplatesConfigMaps": {
-                                            "type": "object",
-                                            "properties": {
-                                                "AWSCluster": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "create": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                },
-                                                "DockerCluster": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "create": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                },
-                                                "NutanixCluster": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "create": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "name": {
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "cilium": {
-                            "type": "object",
-                            "properties": {
-                                "crsStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultCiliumConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "helmAddonStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultValueTemplateConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "create": {
-                                                    "type": "boolean"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "multus": {
-                            "type": "object",
-                            "properties": {
-                                "helmAddonStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultValueTemplateConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "create": {
-                                                    "type": "boolean"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "cosi": {
-                    "type": "object",
-                    "properties": {
-                        "controller": {
-                            "type": "object",
-                            "properties": {
-                                "helmAddonStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultValueTemplateConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "create": {
-                                                    "type": "boolean"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "csi": {
-                    "type": "object",
-                    "properties": {
-                        "aws-ebs": {
-                            "type": "object",
-                            "properties": {
-                                "helmAddonStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultValueTemplateConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "create": {
-                                                    "type": "boolean"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "local-path": {
-                            "type": "object",
-                            "properties": {
-                                "helmAddonStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultValueTemplateConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "create": {
-                                                    "type": "boolean"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "nutanix": {
-                            "type": "object",
-                            "properties": {
-                                "helmAddonStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultValueTemplateConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "create": {
-                                                    "type": "boolean"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "snapshot-controller": {
-                            "type": "object",
-                            "properties": {
-                                "helmAddonStrategy": {
-                                    "type": "object",
-                                    "properties": {
-                                        "defaultValueTemplateConfigMap": {
-                                            "type": "object",
-                                            "properties": {
-                                                "create": {
-                                                    "type": "boolean"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "ingress": {
-                    "type": "object",
-                    "properties": {
-                        "awsLoadBalancerController": {
-                            "type": "object",
-                            "properties": {
-                                "defaultValueTemplateConfigMap": {
-                                    "type": "object",
-                                    "properties": {
-                                        "create": {
-                                            "type": "boolean"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "konnectorAgent": {
-                    "type": "object",
-                    "properties": {
-                        "helmAddonStrategy": {
-                            "type": "object",
-                            "properties": {
-                                "defaultValueTemplateConfigMap": {
-                                    "type": "object",
-                                    "properties": {
-                                        "create": {
-                                            "type": "boolean"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "nfd": {
-                    "type": "object",
-                    "properties": {
-                        "crsStrategy": {
-                            "type": "object",
-                            "properties": {
-                                "defaultInstallationConfigMap": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "helmAddonStrategy": {
-                            "type": "object",
-                            "properties": {
-                                "defaultValueTemplateConfigMap": {
-                                    "type": "object",
-                                    "properties": {
-                                        "create": {
-                                            "type": "boolean"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "registry": {
-                    "type": "object",
-                    "properties": {
-                        "cncfDistribution": {
-                            "type": "object",
-                            "properties": {
-                                "defaultValueTemplateConfigMap": {
-                                    "type": "object",
-                                    "properties": {
-                                        "create": {
-                                            "type": "boolean"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "registrySyncer": {
-                    "type": "object",
-                    "properties": {
-                        "defaultValueTemplateConfigMap": {
-                            "type": "object",
-                            "properties": {
-                                "create": {
-                                    "type": "boolean"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "serviceLoadBalancer": {
-                    "type": "object",
-                    "properties": {
-                        "metalLB": {
-                            "type": "object",
-                            "properties": {
-                                "defaultValueTemplateConfigMap": {
-                                    "type": "object",
-                                    "properties": {
-                                        "create": {
-                                            "type": "boolean"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "image": {
-            "type": "object",
-            "properties": {
+        "images": {
+          "properties": {
+            "bundleInitializer": {
+              "properties": {
                 "pullPolicy": {
-                    "type": "string"
+                  "type": "string"
                 },
                 "repository": {
-                    "type": "string"
+                  "type": "string"
                 },
                 "tag": {
-                    "type": "string"
+                  "type": "string"
                 }
-            }
-        },
-        "imagePullSecrets": {
-            "description": "Optional secrets used for pulling the container image",
-            "type": "array"
-        },
-        "namespaceSync": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
+              },
+              "type": "object"
+            },
+            "mindthegap": {
+              "properties": {
+                "pullPolicy": {
+                  "type": "string"
                 },
-                "sourceNamespace": {
-                    "type": "string"
+                "repository": {
+                  "type": "string"
                 },
-                "targetNamespaceLabelKey": {
-                    "type": "string"
+                "tag": {
+                  "type": "string"
                 }
+              },
+              "type": "object"
             }
-        },
-        "nodeSelector": {
-            "type": "object"
-        },
-        "priorityClassName": {
-            "description": "Priority class to be used for the pod.",
-            "type": "string"
-        },
-        "resources": {
-            "type": "object",
-            "properties": {
-                "limits": {
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "type": "string"
-                        },
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "requests": {
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "type": "string"
-                        },
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+          },
+          "type": "object"
         },
         "securityContext": {
-            "type": "object",
-            "properties": {
-                "runAsUser": {
-                    "type": "integer"
-                }
+          "properties": {
+            "fsGroup": {
+              "type": "integer"
+            },
+            "runAsGroup": {
+              "type": "integer"
+            },
+            "runAsUser": {
+              "type": "integer"
             }
-        },
-        "service": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object"
-                },
-                "port": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "tolerations": {
-            "description": "Kubernetes pod tolerations",
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "effect": {
-                        "type": "string"
-                    },
-                    "key": {
-                        "type": "string"
-                    },
-                    "operator": {
-                        "type": "string"
-                    }
-                }
-            }
+          },
+          "type": "object"
         }
+      },
+      "type": "object"
+    },
+    "hooks": {
+      "properties": {
+        "ccm": {
+          "properties": {
+            "aws": {
+              "properties": {
+                "helmAddonStrategy": {
+                  "properties": {
+                    "defaultValueTemplateConfigMap": {
+                      "properties": {
+                        "create": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "k8sMinorVersionToCCMVersion": {
+                  "properties": {
+                    "1.30": {
+                      "type": "string"
+                    },
+                    "1.31": {
+                      "type": "string"
+                    },
+                    "1.32": {
+                      "type": "string"
+                    },
+                    "1.33": {
+                      "type": "string"
+                    },
+                    "1.34": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "nutanix": {
+              "properties": {
+                "helmAddonStrategy": {
+                  "properties": {
+                    "defaultValueTemplateConfigMap": {
+                      "properties": {
+                        "create": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "clusterAutoscaler": {
+          "properties": {
+            "crsStrategy": {
+              "properties": {
+                "defaultInstallationConfigMap": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "helmAddonStrategy": {
+              "properties": {
+                "defaultValueTemplateConfigMap": {
+                  "properties": {
+                    "create": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "cni": {
+          "properties": {
+            "calico": {
+              "properties": {
+                "crsStrategy": {
+                  "properties": {
+                    "defaultInstallationConfigMaps": {
+                      "properties": {
+                        "AWSCluster": {
+                          "properties": {
+                            "configMap": {
+                              "properties": {
+                                "content": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "create": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "DockerCluster": {
+                          "properties": {
+                            "configMap": {
+                              "properties": {
+                                "content": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "create": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "NutanixCluster": {
+                          "properties": {
+                            "configMap": {
+                              "properties": {
+                                "content": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "create": {
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "defaultTigeraOperatorConfigMap": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "defaultPodSubnet": {
+                  "type": "string"
+                },
+                "helmAddonStrategy": {
+                  "properties": {
+                    "defaultValueTemplatesConfigMaps": {
+                      "properties": {
+                        "AWSCluster": {
+                          "properties": {
+                            "create": {
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "DockerCluster": {
+                          "properties": {
+                            "create": {
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "NutanixCluster": {
+                          "properties": {
+                            "create": {
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "cilium": {
+              "properties": {
+                "crsStrategy": {
+                  "properties": {
+                    "defaultCiliumConfigMap": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "helmAddonStrategy": {
+                  "properties": {
+                    "defaultValueTemplateConfigMap": {
+                      "properties": {
+                        "create": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "multus": {
+              "properties": {
+                "helmAddonStrategy": {
+                  "properties": {
+                    "defaultValueTemplateConfigMap": {
+                      "properties": {
+                        "create": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "cosi": {
+          "properties": {
+            "controller": {
+              "properties": {
+                "helmAddonStrategy": {
+                  "properties": {
+                    "defaultValueTemplateConfigMap": {
+                      "properties": {
+                        "create": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "csi": {
+          "properties": {
+            "aws-ebs": {
+              "properties": {
+                "helmAddonStrategy": {
+                  "properties": {
+                    "defaultValueTemplateConfigMap": {
+                      "properties": {
+                        "create": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "local-path": {
+              "properties": {
+                "helmAddonStrategy": {
+                  "properties": {
+                    "defaultValueTemplateConfigMap": {
+                      "properties": {
+                        "create": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "nutanix": {
+              "properties": {
+                "helmAddonStrategy": {
+                  "properties": {
+                    "defaultValueTemplateConfigMap": {
+                      "properties": {
+                        "create": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "snapshot-controller": {
+              "properties": {
+                "helmAddonStrategy": {
+                  "properties": {
+                    "defaultValueTemplateConfigMap": {
+                      "properties": {
+                        "create": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "ingress": {
+          "properties": {
+            "awsLoadBalancerController": {
+              "properties": {
+                "defaultValueTemplateConfigMap": {
+                  "properties": {
+                    "create": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "konnectorAgent": {
+          "properties": {
+            "helmAddonStrategy": {
+              "properties": {
+                "defaultValueTemplateConfigMap": {
+                  "properties": {
+                    "create": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "nfd": {
+          "properties": {
+            "crsStrategy": {
+              "properties": {
+                "defaultInstallationConfigMap": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "helmAddonStrategy": {
+              "properties": {
+                "defaultValueTemplateConfigMap": {
+                  "properties": {
+                    "create": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "registry": {
+          "properties": {
+            "cncfDistribution": {
+              "properties": {
+                "defaultValueTemplateConfigMap": {
+                  "properties": {
+                    "create": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "registrySyncer": {
+          "properties": {
+            "defaultValueTemplateConfigMap": {
+              "properties": {
+                "create": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "serviceLoadBalancer": {
+          "properties": {
+            "metalLB": {
+              "properties": {
+                "defaultValueTemplateConfigMap": {
+                  "properties": {
+                    "create": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "image": {
+      "properties": {
+        "pullPolicy": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "imagePullSecrets": {
+      "description": "Optional secrets used for pulling the container image",
+      "type": "array"
+    },
+    "namespaceSync": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "sourceNamespace": {
+          "type": "string"
+        },
+        "targetNamespaceLabelKey": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "priorityClassName": {
+      "description": "Priority class to be used for the pod.",
+      "type": "string"
+    },
+    "resources": {
+      "properties": {
+        "limits": {
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "requests": {
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "securityContext": {
+      "properties": {
+        "runAsUser": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "service": {
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "tolerations": {
+      "description": "Kubernetes pod tolerations",
+      "items": {
+        "properties": {
+          "effect": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
     }
+  },
+  "type": "object"
 }

--- a/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.schema.json
@@ -60,6 +60,19 @@
         "helmAddonsConfigMap": {
             "type": "string"
         },
+        "helmAddonsOverrides": {
+            "description": "Optional per-addon overrides for Helm chart repository URL (e.g. OCI Harbor for nutanix-storage-csi). Keys match helm-config ConfigMap data keys.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "repositoryURL": {
+                        "type": "string",
+                        "description": "Override repository URL (e.g. oci://harbor.eng.nutanix.com/project/chart-name)"
+                    }
+                }
+            }
+        },
         "helmRepository": {
             "type": "object",
             "properties": {

--- a/charts/cluster-api-runtime-extensions-nutanix/values.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/values.yaml
@@ -135,6 +135,15 @@ hooks:
 
 helmAddonsConfigMap: default-helm-addons-config
 
+# Optional per-addon overrides for Helm chart repository URL (e.g. OCI Harbor for QA).
+# When set, the override is used instead of helmRepository.enabled or the default HTTPS URL.
+# Keys must match helm-config ConfigMap data keys (e.g. nutanix-storage-csi, aws-ccm).
+# Example for QA (nutanix-csi from Harbor OCI):
+#   helmAddonsOverrides:
+#     nutanix-storage-csi:
+#       repositoryURL: "oci://harbor.eng.nutanix.com/rachit-nutanix/nutanix-csi-storage"
+helmAddonsOverrides: {}
+
 deployDefaultClusterClasses: true
 
 # The ClusterClass and the Templates it references must be in the same namespace

--- a/hack/addons/inject-helm-repo-url-template.sh
+++ b/hack/addons/inject-helm-repo-url-template.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2024 Nutanix. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Injects the caren.helmAddonRepoURL include into each addon's RepositoryURL in
+# helm-config.yaml so that override (e.g. OCI Harbor) > internal OCI repo > default HTTPS.
+# Must run after generate-mindthegap-repofile so the repofile sees literal URLs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
+# shellcheck source=hack/common.sh
+source "${SCRIPT_DIR}/../common.sh"
+
+HELM_CONFIG="${GIT_REPO_ROOT}/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml"
+
+if [[ ! -f "${HELM_CONFIG}" ]]; then
+  echo "error: ${HELM_CONFIG} not found" >&2
+  exit 1
+fi
+
+yq -i '
+  .data |= with_entries(
+    .key as $k
+    | .value |= (
+        (. | from_yaml)
+        | .RepositoryURL as $url
+        | .RepositoryURL = ("{{ include \"caren.helmAddonRepoURL\" (dict \"addonKey\" \"" + $k + "\" \"defaultURL\" \"" + $url + "\" \"context\" .) }}")
+        | to_yaml
+      )
+  )
+' "${HELM_CONFIG}"

--- a/hack/addons/inject-helm-repo-url-template.sh
+++ b/hack/addons/inject-helm-repo-url-template.sh
@@ -15,11 +15,13 @@ source "${SCRIPT_DIR}/../common.sh"
 
 HELM_CONFIG="${GIT_REPO_ROOT}/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml"
 
-if [[ ! -f "${HELM_CONFIG}" ]]; then
+if [[ ! -f ${HELM_CONFIG} ]]; then
   echo "error: ${HELM_CONFIG} not found" >&2
   exit 1
 fi
 
+# Single quotes intentional: yq expression must be passed literally (no shell expansion)
+# shellcheck disable=SC2016
 yq -i '
   .data |= with_entries(
     .key as $k

--- a/make/addons.mk
+++ b/make/addons.mk
@@ -88,8 +88,8 @@ generate-mindthegap-repofile: generate-helm-configmap ; $(info $(M) generating h
 	./hack/addons/generate-mindthegap-repofile.sh
 
 .PHONY: template-helm-repository
-template-helm-repository: generate-mindthegap-repofile ## this is used by gorealeaser to set the helm value to this.
-	yq -i '.data |= (to_entries | map(.value |= (. | fromjson | .RepositoryURL |= "{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}" + . + "{{ end }}" | to_yaml)) | from_entries)' ./charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
+template-helm-repository: generate-mindthegap-repofile ## this is used by goreleaser to set the helm value to this.
+	./hack/addons/inject-helm-repo-url-template.sh
 
 .PHONY: list-images
 list-images:

--- a/make/addons.mk
+++ b/make/addons.mk
@@ -91,10 +91,16 @@ generate-mindthegap-repofile: generate-helm-configmap ; $(info $(M) generating h
 template-helm-repository: generate-mindthegap-repofile ## this is used by goreleaser to set the helm value to this.
 	./hack/addons/inject-helm-repo-url-template.sh
 
+# Rendered helm-config for list-images (templates use Helm include(), so we must render with helm template).
+LIST_IMAGES_HELM_CONFIG := $(shell mktemp)
+
 .PHONY: list-images
 list-images:
-	cd hack/tools/fetch-images && go run . \
+	helm template caren $(PWD)/charts/cluster-api-runtime-extensions-nutanix \
+	  --show-only templates/helm-config.yaml --set helmRepository.enabled=false > $(LIST_IMAGES_HELM_CONFIG) && \
+	(cd hack/tools/fetch-images && go run . \
 	  -chart-directory=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/ \
-	  -helm-chart-configmap=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml \
+	  -helm-chart-configmap=$(LIST_IMAGES_HELM_CONFIG) \
 	  -caren-version=$(CAREN_VERSION) \
-	  -additional-yaml-files=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
+	  -additional-yaml-files=$(PWD)/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml); \
+	rc=$$?; rm -f $(LIST_IMAGES_HELM_CONFIG); exit $$rc

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -17,10 +17,18 @@ lint-and-install-chart:
 	ct lint-and-install --config charts/ct-config.yaml
 	ct lint-and-install --config charts/ct-config.yaml --upgrade
 
+# helmAddonsOverrides has a hand-maintained schema (additionalProperties, descriptions) because
+# "helm schema" infers from values.yaml and only sees "helmAddonsOverrides: {}", so it emits
+# just "type": "object" and drops the rest. We merge it back after generation.
+HELM_ADDONS_OVERRIDES_SCHEMA := charts/cluster-api-runtime-extensions-nutanix/values.schema.helmAddonsOverrides.json
+VALUES_SCHEMA := charts/cluster-api-runtime-extensions-nutanix/values.schema.json
+
 .PHONY: schema-chart
 schema-chart: ## Updates helm values JSON schema
 schema-chart:
 	helm schema \
 	  --use-helm-docs \
 	  --values charts/cluster-api-runtime-extensions-nutanix/values.yaml \
-	  --output charts/cluster-api-runtime-extensions-nutanix/values.schema.json
+	  --output $(VALUES_SCHEMA)
+	gojq --slurpfile addonsSchema $(HELM_ADDONS_OVERRIDES_SCHEMA) \
+	  '.properties.helmAddonsOverrides = $$addonsSchema[0]' $(VALUES_SCHEMA) > $(VALUES_SCHEMA).tmp && mv $(VALUES_SCHEMA).tmp $(VALUES_SCHEMA)

--- a/pkg/handlers/lifecycle/addons/helmaddon.go
+++ b/pkg/handlers/lifecycle/addons/helmaddon.go
@@ -221,6 +221,8 @@ func (a *helmAddonApplier) Apply(
 		helmReleaseName = applyOpts.helmReleaseName
 	}
 
+	repoURL, chartName := handlersutils.NormalizeHelmChartOCIRepoURL(a.helmChart.Repository, a.helmChart.Name)
+
 	chartProxy := &caaphv1.HelmChartProxy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: caaphv1.GroupVersion.String(),
@@ -231,8 +233,8 @@ func (a *helmAddonApplier) Apply(
 			Name:      fmt.Sprintf("%s-%s", a.config.defaultHelmReleaseName, clusterUUID),
 		},
 		Spec: caaphv1.HelmChartProxySpec{
-			RepoURL:   a.helmChart.Repository,
-			ChartName: a.helmChart.Name,
+			RepoURL:   repoURL,
+			ChartName: chartName,
 			ClusterSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{clusterv1.ClusterNameLabel: targetCluster.Name},
 			},

--- a/pkg/handlers/utils/utils.go
+++ b/pkg/handlers/utils/utils.go
@@ -200,6 +200,24 @@ func RetrieveValuesTemplate(
 	return configMap.Data[configMapKey], nil
 }
 
+// NormalizeHelmChartOCIRepoURL normalizes OCI repository URLs for HelmChartProxy.
+// The CAPI Helm addon provider expects RepoURL to be the OCI registry base (e.g. oci://harbor.example.com/project)
+// and ChartName to be the chart name. When users override with a full OCI path (e.g. oci://harbor.example.com/project/chart-name),
+// we strip the chart name suffix so the provider receives the correct RepoURL and ChartName.
+func NormalizeHelmChartOCIRepoURL(repoURL, chartName string) (repoURLOut, chartNameOut string) {
+	repoURLOut = repoURL
+	chartNameOut = chartName
+	if !strings.HasPrefix(repoURL, "oci://") {
+		return
+	}
+	suffix := "/" + chartName
+	trimmed := strings.TrimSuffix(strings.TrimSuffix(repoURL, "/"), suffix)
+	if trimmed != repoURL {
+		repoURLOut = trimmed
+	}
+	return
+}
+
 func SetTLSConfigForHelmChartProxyIfNeeded(hcp *caaphv1.HelmChartProxy) {
 	if strings.Contains(hcp.Spec.RepoURL, "helm-repository") {
 		hcp.Spec.TLSConfig = &caaphv1.TLSConfig{

--- a/pkg/handlers/utils/utils.go
+++ b/pkg/handlers/utils/utils.go
@@ -201,9 +201,6 @@ func RetrieveValuesTemplate(
 }
 
 // NormalizeHelmChartOCIRepoURL normalizes OCI repository URLs for HelmChartProxy.
-// The CAPI Helm addon provider expects RepoURL to be the OCI registry base (e.g. oci://harbor.example.com/project)
-// and ChartName to be the chart name. When users override with a full OCI path (e.g. oci://harbor.example.com/project/chart-name),
-// we strip the chart name suffix so the provider receives the correct RepoURL and ChartName.
 func NormalizeHelmChartOCIRepoURL(repoURL, chartName string) (repoURLOut, chartNameOut string) {
 	repoURLOut = repoURL
 	chartNameOut = chartName


### PR DESCRIPTION
## How it works

### Resolution order

For each addon, the repository URL is chosen in this order:

1. **Override** – If you set `helmAddonsOverrides.<addonKey>.repositoryURL`, that value is used.
2. **Internal OCI** – If `helmRepository.enabled` is true and there is no override, the chart is pulled from the in-cluster Helm repository: `oci://helm-repository.<namespace>.svc/charts`.
3. **Default HTTPS** – Otherwise the chart is pulled from the addon’s default index (e.g. `https://nutanix.github.io/helm-releases/` for Nutanix CSI).

So: **override > internal OCI > default HTTPS**.

### OCI support

Charts can be pulled from **OCI registries** (e.g. Harbor) using `oci://` URLs. CAREN supports this in two ways:

- **Full path**: `oci://harbor.example.com/project/nutanix-csi-storage`  
  CAREN normalizes this to a base URL + chart name when creating the HelmChartProxy, so the Cluster API Helm addon provider can run `helm pull oci://...` correctly.

- **Base URL**: `oci://harbor.example.com/project`  
  Used as-is; the chart name comes from the addon’s default (e.g. `nutanix-csi-storage`).

For private OCI registries, ensure the workload cluster can authenticate (e.g. `helm registry login` or image pull secrets as required by your setup).

---

## Where to add a custom URL

### When installing CAREN via Helm

Set **`helmAddonsOverrides`** in the Helm values. The keys are the **addon keys** (same as in the helm-config ConfigMap).

**Example: Nutanix CSI from Harbor OCI (QA)**

```yaml
helmAddonsOverrides:
  nutanix-storage-csi:
    repositoryURL: "oci://harbor.eng.nutanix.com/k8s-ha/nutanix-csi-storage"
```

**Example: Override multiple addons**

```yaml
helmAddonsOverrides:
  nutanix-storage-csi:
    repositoryURL: "oci://harbor.eng.nutanix.com/k8s-ha/nutanix-csi-storage"
  nutanix-ccm:
    repositoryURL: "https://my-index.example.com/nutanix-ccm"
```

**Install command example**

```shell
helm upgrade --install caren caren/cluster-api-runtime-extensions-nutanix \
  --namespace caren-system \
  --create-namespace \
  --set helmAddonsOverrides.nutanix-storage-csi.repositoryURL="oci://harbor.eng.nutanix.com/k8s-ha/nutanix-csi-storage" \
  --wait
```

Or use a values file:

```yaml
# my-values.yaml
helmAddonsOverrides:
  nutanix-storage-csi:
    repositoryURL: "oci://harbor.eng.nutanix.com/k8s-ha/nutanix-csi-storage"
```

```shell
helm upgrade --install caren caren/cluster-api-runtime-extensions-nutanix \
  --namespace caren-system \
  --create-namespace \
  -f my-values.yaml \
  --wait
```

---

## Addon keys (where to add custom URL)

Use these keys under `helmAddonsOverrides` to override the repository URL for each addon:

| Addon key | Default chart source | Typical use |
|-----------|---------------------|-------------|
| `nutanix-storage-csi` | https://nutanix.github.io/helm-releases/ | Nutanix CSI (e.g. Harbor OCI for QA) |
| `nutanix-ccm` | https://nutanix.github.io/helm/ | Nutanix Cloud Controller Manager |
| `aws-ccm` | https://kubernetes.github.io/cloud-provider-aws | AWS Cloud Controller Manager |
| `aws-ebs-csi` | https://kubernetes-sigs.github.io/aws-ebs-csi-driver | AWS EBS CSI driver |
| `aws-load-balancer-controller` | https://aws.github.io/eks-charts | AWS Load Balancer Controller |
| `cilium` | https://helm.cilium.io/ | Cilium CNI |
| `cluster-autoscaler` | https://kubernetes.github.io/autoscaler | Cluster Autoscaler |
| `cncf-distribution-registry` | https://mesosphere.github.io/charts/staging/ | Docker registry |
| `cosi-controller` | https://mesosphere.github.io/charts/stable/ | COSI controller |
| `konnector-agent` | https://nutanix.github.io/helm-releases/ | Konnector agent |
| `local-path-provisioner-csi` | https://charts.containeroo.ch | Local path provisioner |
| `metallb` | https://metallb.github.io/metallb | MetalLB |
| `multus` | https://mesosphere.github.io/charts/stable/ | Multus |
| `nfd` | https://kubernetes-sigs.github.io/node-feature-discovery/charts | Node Feature Discovery |
| `registry-syncer` | https://mesosphere.github.io/charts/staging/ | Registry syncer |
| `snapshot-controller` | https://piraeus.io/helm-charts/ | Snapshot controller |
| `tigera-operator` | https://docs.tigera.io/calico/charts | Calico (Tigera operator) |

---

## Flow summary

1. **Helm install/upgrade** – You set `helmAddonsOverrides.<addonKey>.repositoryURL` (and/or install with a values file that contains it).
2. **Rendered ConfigMap** – The chart template resolves each addon’s `RepositoryURL` via the `caren.helmAddonRepoURL` helper (override → internal OCI → default).
3. **Runtime** – CAREN reads the ConfigMap and creates a `HelmChartProxy` per addon per cluster. For OCI URLs, it normalizes full paths to base URL + chart name so the Cluster API Helm addon provider can pull the chart correctly.
4. **Provider** – The Helm addon provider runs `helm pull` / install using the resolved URL and chart name.

This is how a custom URL (including OCI Harbor for nutanix-csi) is applied end-to-end.
