### PR TITLE
ci: Upload e2e test artifacts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,7 +86,6 @@ jobs:
       kubernetes-version: ${{ matrix.config.kubernetesVersion }}
       runs-on: ${{ matrix.config.provider == 'Nutanix' && 'self-hosted-nutanix-docker-medium' || 'ubuntu-24.04' }}
       base-os:  ${{ matrix.config.provider == 'Nutanix' && matrix.config.baseOS || '' }}
-      job-name: e2e-quick-start (${{ matrix.config.provider }} provider, Kubernetes ${{ matrix.config.kubernetesMinor }})
     secrets: inherit
     permissions:
       contents: read
@@ -116,7 +115,6 @@ jobs:
       provider: ${{ matrix.config.provider }}
       kubernetes-version: ${{ matrix.config.kubernetesVersion }}
       runs-on: ${{ matrix.config.provider == 'Nutanix' && 'self-hosted-nutanix-docker-medium' || 'ubuntu-24.04' }}
-      job-name: e2e-self-hosted (${{ matrix.config.provider }} provider, Kubernetes ${{ matrix.config.kubernetesMinor }})
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -86,6 +86,7 @@ jobs:
       kubernetes-version: ${{ matrix.config.kubernetesVersion }}
       runs-on: ${{ matrix.config.provider == 'Nutanix' && 'self-hosted-nutanix-docker-medium' || 'ubuntu-24.04' }}
       base-os:  ${{ matrix.config.provider == 'Nutanix' && matrix.config.baseOS || '' }}
+      job-name: e2e-quick-start (${{ matrix.config.provider }} provider, Kubernetes ${{ matrix.config.kubernetesMinor }})
     secrets: inherit
     permissions:
       contents: read
@@ -115,6 +116,7 @@ jobs:
       provider: ${{ matrix.config.provider }}
       kubernetes-version: ${{ matrix.config.kubernetesVersion }}
       runs-on: ${{ matrix.config.provider == 'Nutanix' && 'self-hosted-nutanix-docker-medium' || 'ubuntu-24.04' }}
+      job-name: e2e-self-hosted (${{ matrix.config.provider }} provider, Kubernetes ${{ matrix.config.kubernetesMinor }})
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,10 +26,6 @@ on:
         description: The OS image to use for the machine template
         type: string
         required: false
-      job-name:
-        description: Display name of the calling job, used to name the uploaded artifact
-        type: string
-        required: true
 
 jobs:
   e2e-test:
@@ -122,6 +118,6 @@ jobs:
         name: Upload test artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: "${{ github.workflow }} - ${{ inputs.job-name }}.zip"
+          name: "e2e-test-artifacts"
           path: ${{ env.ARTIFACTS }}
           retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,9 @@ on:
 
 jobs:
   e2e-test:
+    env:
+      # ARTIFACTS must be an absolute path, so we use the github.workspace variable.
+      ARTIFACTS: ${{ github.workspace }}/_artifacts
     runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: read
@@ -82,7 +85,7 @@ jobs:
           df -h
 
       - name: Run e2e tests
-        run: devbox run -- make e2e-test E2E_LABEL='provider:${{ inputs.provider }}' E2E_SKIP='${{ inputs.skip }}' E2E_FOCUS='${{ inputs.focus }}' E2E_VERBOSE=true
+        run: devbox run -- make e2e-test E2E_LABEL='provider:${{ inputs.provider }}' E2E_SKIP='${{ inputs.skip }}' E2E_FOCUS='${{ inputs.focus }}' E2E_VERBOSE=true ARTIFACTS='${{ env.ARTIFACTS }}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -102,7 +105,7 @@ jobs:
           KINDEST_IMAGE_TAG: ${{ inputs.kubernetes-version }}
           E2E_KUBERNETES_VERSION: ${{ inputs.kubernetes-version }}
 
-      - if: success() || failure() # always run even if the previous step fails
+      - if: "!cancelled()" # Do not run if the workflow is cancelled, but otherwise run, even if the previous step fails.
         name: Publish e2e test report
         uses: mikepenz/action-junit-report@v6
         with:
@@ -110,3 +113,11 @@ jobs:
           check_name: 'e2e test report'
           detailed_summary: true
           require_passed_tests: true
+
+      - if: "!cancelled()" # Do not run if the workflow is cancelled, but otherwise run, even if the previous step fails.
+        name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: "e2e-test-artifacts"
+          path: ${{ env.ARTIFACTS }}
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,6 +118,6 @@ jobs:
         name: Upload test artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: "e2e-test-artifacts"
+          name: "${{ inputs.focus }} - ${{ inputs.provider }} - ${{ inputs.kubernetes-version }} - ${{ inputs.base-os }}"
           path: ${{ env.ARTIFACTS }}
           retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,10 @@ on:
         description: The OS image to use for the machine template
         type: string
         required: false
+      job-name:
+        description: Display name of the calling job, used to name the uploaded artifact
+        type: string
+        required: true
 
 jobs:
   e2e-test:
@@ -118,6 +122,6 @@ jobs:
         name: Upload test artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: "e2e-test-artifacts"
+          name: "${{ github.workflow }} - ${{ inputs.job-name }}.zip"
           path: ${{ env.ARTIFACTS }}
           retention-days: 7


### PR DESCRIPTION
**What problem does this PR solve?**:
To triage flaky e2e tests, we need to upload the artifacts, so that we can review them. The test logs alone do not have enough information. For example, we can't figure out why a VM is not created within a timeout.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
