### PR TITLE
test: Verify preflight check when cluster is both paused and unpaused

### DIFF
--- a/pkg/webhook/preflight/preflight_test.go
+++ b/pkg/webhook/preflight/preflight_test.go
@@ -515,7 +515,26 @@ func TestHandle(t *testing.T) {
 			},
 		},
 		{
-			name:      "update operation changes only the paused state, allowed",
+			name:      "update operation unpauses the cluster, without changing the spec, allowed response",
+			operation: admissionv1.Update,
+			oldCluster: func() *clusterv1beta2.Cluster {
+				cluster := topologyCluster()
+				cluster.Spec.Paused = ptr.To(true)
+				return cluster
+			}(),
+			cluster: func() *clusterv1beta2.Cluster {
+				cluster := topologyCluster()
+				cluster.Spec.Paused = ptr.To(false)
+				return cluster
+			}(),
+			expectedResponse: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: true,
+				},
+			},
+		},
+		{
+			name:      "update operation pauses the cluster, without changing the spec, allowed response",
 			operation: admissionv1.Update,
 			oldCluster: func() *clusterv1beta2.Cluster {
 				cluster := topologyCluster()


### PR DESCRIPTION
**What problem does this PR solve?**:
The existing test did not cover the case where the cluster was being unpaused, i.e. when it transitions from being paused, to not being paused.

The code was correct, and did not change. The coverage was incomplete, and is now 100%.

**Which issue(s) this PR fixes**:
Fixes #

**How Has This Been Tested?**:
<!--
Please describe the tests that you ran to verify your changes.
Provide output from the tests and any manual steps needed to replicate the tests.
-->

**Special notes for your reviewer**:
<!--
Use this to provide any additional information to the reviewers.
This may include:
- Best way to review the PR.
- Where the author wants the most review attention on.
- etc.
-->
