### PR TITLE
feat: add guardrail to avoid vpc for metro

### DIFF
--- a/pkg/webhook/preflight/nutanix/metro.go
+++ b/pkg/webhook/preflight/nutanix/metro.go
@@ -827,6 +827,8 @@ func (mc *metroCheck) resolvePrismElement(
 type metroSubnetAttributes struct {
 	// layers holds the distinct network layer names (VLAN, OVERLAY, ...).
 	layers map[string]struct{}
+	// vpcReferences holds distinct VPC references observed on subnets.
+	vpcReferences map[string]struct{}
 	// profilesByFailureDomain holds subnet profile sets keyed by failure domain.
 	profilesByFailureDomain map[string]map[string]struct{}
 }
@@ -834,6 +836,7 @@ type metroSubnetAttributes struct {
 func newMetroSubnetAttributes() *metroSubnetAttributes {
 	return &metroSubnetAttributes{
 		layers:                  map[string]struct{}{},
+		vpcReferences:           map[string]struct{}{},
 		profilesByFailureDomain: map[string]map[string]struct{}{},
 	}
 }
@@ -871,6 +874,9 @@ func (mc *metroCheck) collectSubnetAttributes(
 			}
 			profile := subnetProfileKey(s)
 			attrs.layers[subnetLayerName(s.SubnetType)] = struct{}{}
+			if s.VpcReference != nil && *s.VpcReference != "" {
+				attrs.vpcReferences[*s.VpcReference] = struct{}{}
+			}
 			if _, ok := attrs.profilesByFailureDomain[fdName]; !ok {
 				attrs.profilesByFailureDomain[fdName] = map[string]struct{}{}
 			}
@@ -885,6 +891,15 @@ func (mc *metroCheck) collectSubnetAttributes(
 // domain has the same set of subnet profiles (layer + VLAN/VNI + CIDR).
 func (mc *metroCheck) checkSubnetConsistency(attrs *metroSubnetAttributes, result *preflight.CheckResult) {
 	if len(attrs.layers) == 0 {
+		return
+	}
+
+	if len(attrs.vpcReferences) > 0 {
+		failCheck(result, mc.field, fmt.Sprintf(
+			"VPC-backed subnets are not supported for k8s-ha metro. NutanixMetro %q uses VPC reference(s): %s. Use non-VPC subnets and retry.", //nolint:lll // Message is long.
+			mc.metroName,
+			strings.Join(sortedKeys(attrs.vpcReferences), ", "),
+		))
 		return
 	}
 

--- a/pkg/webhook/preflight/nutanix/metro.go
+++ b/pkg/webhook/preflight/nutanix/metro.go
@@ -827,6 +827,8 @@ func (mc *metroCheck) resolvePrismElement(
 type metroSubnetAttributes struct {
 	// layers holds the distinct network layer names (VLAN, OVERLAY, ...).
 	layers map[string]struct{}
+	// vpcReferences holds distinct VPC references observed on subnets.
+	vpcReferences map[string]struct{}
 	// profilesByFailureDomain holds subnet profile sets keyed by failure domain.
 	profilesByFailureDomain map[string]map[string]struct{}
 }
@@ -834,6 +836,7 @@ type metroSubnetAttributes struct {
 func newMetroSubnetAttributes() *metroSubnetAttributes {
 	return &metroSubnetAttributes{
 		layers:                  map[string]struct{}{},
+		vpcReferences:           map[string]struct{}{},
 		profilesByFailureDomain: map[string]map[string]struct{}{},
 	}
 }
@@ -871,6 +874,9 @@ func (mc *metroCheck) collectSubnetAttributes(
 			}
 			profile := subnetProfileKey(s)
 			attrs.layers[subnetLayerName(s.SubnetType)] = struct{}{}
+			if s.VpcReference != nil && *s.VpcReference != "" {
+				attrs.vpcReferences[*s.VpcReference] = struct{}{}
+			}
 			if _, ok := attrs.profilesByFailureDomain[fdName]; !ok {
 				attrs.profilesByFailureDomain[fdName] = map[string]struct{}{}
 			}
@@ -885,6 +891,15 @@ func (mc *metroCheck) collectSubnetAttributes(
 // domain has the same set of subnet profiles (layer + VLAN/VNI + CIDR).
 func (mc *metroCheck) checkSubnetConsistency(attrs *metroSubnetAttributes, result *preflight.CheckResult) {
 	if len(attrs.layers) == 0 {
+		return
+	}
+
+	if len(attrs.vpcReferences) > 0 {
+		failCheck(result, mc.field, fmt.Sprintf(
+			"VPC-backed subnets are not supported for NKP Metro cluster. NutanixMetro %q uses VPC reference(s): %s. Use non-VPC subnets and retry.", //nolint:lll // Message is long.
+			mc.metroName,
+			strings.Join(sortedKeys(attrs.vpcReferences), ", "),
+		))
 		return
 	}
 

--- a/pkg/webhook/preflight/nutanix/metro_test.go
+++ b/pkg/webhook/preflight/nutanix/metro_test.go
@@ -85,6 +85,7 @@ type metroSubnetSpec struct {
 	subnetType netv4.SubnetType
 	networkID  *int
 	cidr       *string
+	vpcRef     *string
 }
 
 // metroNClient builds a mock Nutanix client that returns a PE cluster for each
@@ -119,6 +120,7 @@ func metroNClient(subnets map[string]metroSubnetSpec) *clientWrapper {
 			subnet.SubnetType = spec.subnetType.Ref()
 			subnet.NetworkId = spec.networkID
 			subnet.IpPrefix = spec.cidr
+			subnet.VpcReference = spec.vpcRef
 			resp := &netv4.GetSubnetApiResponse{
 				ObjectType_: ptr.To("networking.v4.config.GetSubnetApiResponse"),
 			}
@@ -321,6 +323,21 @@ func TestMetroCheck(t *testing.T) {
 			}),
 			expectedAllowed:      false,
 			expectedCauseMessage: "reside on multiple network layers",
+			expectedCauseCount:   1,
+		},
+		{
+			name: "vpc-backed subnets are rejected for metro",
+			objects: []ctrlclient.Object{
+				newMetroObject(metroName, metroFD1, metroFD2),
+				newMetroFailureDomain(metroFD1, metroPE1UUID, metroSubnet1),
+				newMetroFailureDomain(metroFD2, metroPE2UUID, metroSubnet2),
+			},
+			nclient: metroNClient(map[string]metroSubnetSpec{
+				metroSubnet1: {subnetType: netv4.SUBNETTYPE_OVERLAY, vpcRef: ptr.To("vpc-1")},
+				metroSubnet2: {subnetType: netv4.SUBNETTYPE_OVERLAY, vpcRef: ptr.To("vpc-1")},
+			}),
+			expectedAllowed:      false,
+			expectedCauseMessage: "VPC-backed subnets are not supported",
 			expectedCauseCount:   1,
 		},
 		{


### PR DESCRIPTION
- Add a preflight guardrail that blocks k8s-ha metro cluster deployments when any referenced metro subnet is VPC-backed.
- Return a clear validation error that explains VPC-backed subnets are intentionally unsupported in v1 and asks users to use non-VPC subnets.
- Extend metro preflight unit tests to cover VPC-backed subnet rejection while preserving existing metro validation behavior.

## Why

The first version of k8s-ha metro does not support VPC. Failing fast during preflight prevents unsupported
cluster topologies from being deployed and avoids later runtime failures.

## Risk and Rollout

- Scope is limited to Nutanix metro preflight validation.
- No behavior change for non-metro clusters.
- Metro clusters using non-VPC subnets continue to be allowed.
