### PR TITLE
feat: create 2 storageClass for metro cluster

### DIFF
--- a/pkg/handlers/lifecycle/csi/nutanix/handler.go
+++ b/pkg/handlers/lifecycle/csi/nutanix/handler.go
@@ -35,6 +35,9 @@ const (
 const (
 	defaultHelmReleaseName      = "nutanix-csi"
 	defaultHelmReleaseNamespace = "ntnx-system"
+	computeAffinityParameterKey = "computeAffinity"
+	computeAffinityDisabled     = "DISABLED"
+	metroStorageClassSuffix     = "-site-affinity"
 
 	//nolint:gosec // Does not contain hard coded credentials.
 	defaultCredentialsSecretName = "nutanix-csi-credentials"
@@ -184,10 +187,18 @@ func (n *NutanixCSI) Apply(
 		return fmt.Errorf("failed to apply nutanix CSI addon: %w", err)
 	}
 
+	storageClassConfigs := provider.StorageClassConfigs
+	if isMetroCluster(cluster) && defaultStorage.Provider == v1alpha1.CSIProviderNutanix {
+		storageClassConfigs = metroStorageClassConfigs(
+			provider.StorageClassConfigs,
+			defaultStorage.StorageClassConfig,
+		)
+	}
+
 	err = csiutils.CreateStorageClassesOnRemote(
 		ctx,
 		n.client,
-		provider.StorageClassConfigs,
+		storageClassConfigs,
 		cluster,
 		defaultStorage,
 		v1alpha1.CSIProviderNutanix,
@@ -198,6 +209,38 @@ func (n *NutanixCSI) Apply(
 		return fmt.Errorf("error creating StorageClasses for the Nutanix CSI driver: %w", err)
 	}
 	return nil
+}
+
+func metroStorageClassName(baseName string) string {
+	return baseName + metroStorageClassSuffix
+}
+
+func metroStorageClassConfigs(
+	configs map[string]v1alpha1.StorageClassConfig,
+	defaultStorageClassName string,
+) map[string]v1alpha1.StorageClassConfig {
+	metroConfigs := make(map[string]v1alpha1.StorageClassConfig, len(configs)+1)
+	for name, config := range configs {
+		metroConfigs[name] = *config.DeepCopy()
+	}
+
+	defaultConfig, found := metroConfigs[defaultStorageClassName]
+	if !found {
+		return metroConfigs
+	}
+
+	availabilityOptimized := *defaultConfig.DeepCopy()
+	if availabilityOptimized.Parameters == nil {
+		availabilityOptimized.Parameters = map[string]string{}
+	}
+	availabilityOptimized.Parameters[computeAffinityParameterKey] = computeAffinityDisabled
+	metroConfigs[defaultStorageClassName] = availabilityOptimized
+
+	siteAffinityConfig := *defaultConfig.DeepCopy()
+	delete(siteAffinityConfig.Parameters, computeAffinityParameterKey)
+	metroConfigs[metroStorageClassName(defaultStorageClassName)] = siteAffinityConfig
+
+	return metroConfigs
 }
 
 func templateValuesFunc(

--- a/pkg/handlers/lifecycle/csi/nutanix/handler_test.go
+++ b/pkg/handlers/lifecycle/csi/nutanix/handler_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nutanix
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+
+	"github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	apivariables "github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/api/variables"
+)
+
+func TestStorageClassParameters(t *testing.T) {
+	t.Run("keeps default class name and adds site-affinity variant for metro", func(t *testing.T) {
+		original := map[string]v1alpha1.StorageClassConfig{
+			"volume": {
+				Parameters: map[string]string{
+					"storageContainer": "sc1",
+				},
+			},
+			"fast": {},
+		}
+		metroConfigs := metroStorageClassConfigs(original, "volume")
+
+		if got, want := metroConfigs["volume"].Parameters[computeAffinityParameterKey], computeAffinityDisabled; got != want {
+			t.Fatalf("expected default volume config to set computeAffinity to disabled, got %q", got)
+		}
+		if got := metroConfigs["fast"].Parameters[computeAffinityParameterKey]; got != "" {
+			t.Fatalf("expected non-default fast config to remain unchanged, got computeAffinity %q", got)
+		}
+		siteName := metroStorageClassName("volume")
+		siteConfig, exists := metroConfigs[siteName]
+		if !exists {
+			t.Fatalf("expected site-affinity class %q", siteName)
+		}
+		if got := siteConfig.Parameters[computeAffinityParameterKey]; got != "" {
+			t.Fatalf("expected site-affinity class to omit computeAffinity, got %q", got)
+		}
+		if got, want := siteConfig.Parameters["storageContainer"], "sc1"; got != want {
+			t.Fatalf("expected site-affinity class to copy storageContainer %q, got %q", want, got)
+		}
+		if _, exists := original["volume"].Parameters[computeAffinityParameterKey]; exists {
+			t.Fatalf("did not expect original config to be mutated")
+		}
+	})
+
+	t.Run("site-affinity omits computeAffinity even when default config already has it", func(t *testing.T) {
+		original := map[string]v1alpha1.StorageClassConfig{
+			"volume": {
+				Parameters: map[string]string{
+					computeAffinityParameterKey: computeAffinityDisabled,
+					"storageContainer":          "sc1",
+				},
+			},
+		}
+
+		metroConfigs := metroStorageClassConfigs(original, "volume")
+
+		if got := metroConfigs[metroStorageClassName("volume")].Parameters[computeAffinityParameterKey]; got != "" {
+			t.Fatalf("expected site-affinity class to omit computeAffinity, got %q", got)
+		}
+		if got, want := original["volume"].Parameters[computeAffinityParameterKey], computeAffinityDisabled; got != want {
+			t.Fatalf("did not expect original config to be mutated, got %q", got)
+		}
+	})
+
+	t.Run("does not add site-affinity class when default class key is missing", func(t *testing.T) {
+		original := map[string]v1alpha1.StorageClassConfig{
+			"fast": {},
+		}
+
+		metroConfigs := metroStorageClassConfigs(original, "volume")
+
+		if _, exists := metroConfigs["volume"+metroStorageClassSuffix]; exists {
+			t.Fatalf("did not expect site-affinity class when default key is absent")
+		}
+		if got := metroConfigs["fast"].Parameters[computeAffinityParameterKey]; got != "" {
+			t.Fatalf("expected existing config to remain unchanged, got computeAffinity %q", got)
+		}
+	})
+}
+
+func TestIsMetroCluster(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *clusterv1.Cluster
+		want    bool
+	}{
+		{
+			name: "metro control plane",
+			cluster: clusterWithTopologyVariableAndWorkers(
+				t,
+				"mgmt",
+				"default",
+				[]string{metroFailureDomainPrefix + "metro-1"},
+				nil,
+			),
+			want: true,
+		},
+		{
+			name: "metro site on worker",
+			cluster: clusterWithTopologyVariableAndWorkers(
+				t,
+				"mgmt",
+				"default",
+				nil,
+				[]clusterv1.MachineDeploymentTopology{
+					{Name: "md-1", FailureDomain: metroSiteFailureDomainPrefix + "site-1"},
+				},
+			),
+			want: true,
+		},
+		{
+			name: "metro workload cluster",
+			cluster: clusterWithTopologyVariableAndWorkers(
+				t,
+				"workload",
+				"default",
+				[]string{metroFailureDomainPrefix + "metro-1"},
+				nil,
+			),
+			want: true,
+		},
+		{
+			name: "non metro cluster",
+			cluster: clusterWithTopologyVariableAndWorkers(
+				t,
+				"mgmt",
+				"default",
+				[]string{"plain-fd"},
+				nil,
+			),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isMetroCluster(tt.cluster)
+			if got != tt.want {
+				t.Fatalf("isMetroCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func clusterWithTopologyVariableAndWorkers(
+	t *testing.T,
+	name string,
+	namespace string,
+	controlPlaneFailureDomains []string,
+	machineDeployments []clusterv1.MachineDeploymentTopology,
+) *clusterv1.Cluster {
+	t.Helper()
+
+	clusterConfigVariable, err := apivariables.MarshalToClusterVariable(
+		v1alpha1.ClusterConfigVariableName,
+		apivariables.ClusterConfigSpec{
+			ControlPlane: &apivariables.ControlPlaneSpec{
+				Nutanix: &v1alpha1.NutanixControlPlaneNodeSpec{
+					FailureDomains: controlPlaneFailureDomains,
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("failed to marshal cluster config variable: %v", err)
+	}
+
+	return &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: clusterv1.ClusterSpec{
+			Topology: clusterv1.Topology{
+				Variables: []clusterv1.ClusterVariable{*clusterConfigVariable},
+				Workers: clusterv1.WorkersTopology{
+					MachineDeployments: machineDeployments,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
The Nutanix CSI lifecycle handler installs the Nutanix CSI driver and reconciles the provider storage classes on the
target cluster.

The metro storage-class adjustment is applied when the target cluster is a metro cluster (it uses `NutanixMetro/` or
`NutanixMetroSite/` failure domains). This applies to both management and workload clusters.

In that case, the default Nutanix storage class name stays unchanged (for example `nutanix-volume`) and remains the
Kubernetes default. The handler sets
`computeAffinity: DISABLED` on that default class.

The handler also creates one additional non-default storage class with the `-site-affinity` suffix (for example
`nutanix-volume-site-locality`) that omits `computeAffinity` so the CSI default (`ENABLED`) applies for workloads that
need site-local placement.


For metro clusters, the current flow in pkg/handlers/lifecycle/csi/nutanix/handler.go is:

- Start with provider.StorageClassConfigs from the addon config.
- Check isMetroCluster(cluster) and verify default storage provider is Nutanix.
- If true, transform configs via metroStorageClassConfigs(...):
           - Deep-copy all incoming configs (no input mutation).
           - For the configured default class key (for example volume), set computeAffinity=DISABLED.
           - Create one extra non-default class by appending the suffix -site-locality to the default key (for example           volume-site-locality).
           - On that extra class, remove computeAffinity so CSI default behavior applies.
- Pass the resulting map to CreateStorageClassesOnRemote(...) in pkg/handlers/lifecycle/csi/utils/scs.go.

Then in CreateStorageClassesOnRemote(...):

- For each config entry, build a Kubernetes StorageClass.
- Name format is <provider>-<configName> (for Nutanix: nutanix-<name>).
- Merge default parameters + user parameters.
- Mark only one class as Kubernetes default:
          - when provider matches defaultStorage.Provider, and
          - config key equals defaultStorage.StorageClassConfig.
- Apply each class to the target cluster using server-side apply.

So for a metro cluster with default key volume, you effectively get:

nutanix-volume (default class, forced computeAffinity: DISABLED)
nutanix-volume-site-locality (non-default class, computeAffinity omitted)