### PR TITLE
fix: ignore service load balancer ranges in Nutanix CCM

### DIFF
--- a/pkg/handlers/lifecycle/ccm/nutanix/handler.go
+++ b/pkg/handlers/lifecycle/ccm/nutanix/handler.go
@@ -132,7 +132,7 @@ func (p *provider) Apply(
 		),
 		p.client,
 		helmChart,
-	).WithValueTemplater(templateValuesFunc(clusterConfig.Nutanix))
+	).WithValueTemplater(templateValuesFunc(clusterConfig))
 
 	if err = applier.Apply(ctx, cluster, p.config.DefaultsNamespace(), log); err != nil {
 		return fmt.Errorf("failed to apply nutanix-ccm installation HelmChartProxy: %w", err)
@@ -142,9 +142,14 @@ func (p *provider) Apply(
 }
 
 func templateValuesFunc(
-	nutanixConfig *v1alpha1.NutanixSpec,
+	clusterConfig *apivariables.ClusterConfigSpec,
 ) func(*clusterv1.Cluster, string) (string, error) {
 	return func(_ *clusterv1.Cluster, valuesTemplate string) (string, error) {
+		nutanixConfig := clusterConfig.Nutanix
+		var addonsConfig *v1alpha1.GenericAddons
+		if clusterConfig.Addons != nil {
+			addonsConfig = &clusterConfig.Addons.GenericAddons
+		}
 		joinQuoted := template.FuncMap{
 			"joinQuoted": func(items []string) string {
 				for i, item := range items {
@@ -178,7 +183,7 @@ func templateValuesFunc(
 			PrismCentralPort:                  port,
 			PrismCentralInsecure:              nutanixConfig.PrismCentralEndpoint.Insecure,
 			PrismCentralAdditionalTrustBundle: nutanixConfig.PrismCentralEndpoint.AdditionalTrustBundle,
-			IPsToIgnore:                       ipsToIgnore(nutanixConfig),
+			IPsToIgnore:                       ipsToIgnore(nutanixConfig, addonsConfig),
 			ControlPlaneEndpoint:              nutanixConfig.ControlPlaneEndpoint,
 		}
 
@@ -192,16 +197,40 @@ func templateValuesFunc(
 	}
 }
 
-func ipsToIgnore(nutanixConfig *v1alpha1.NutanixSpec) []string {
-	toIgnore := []string{nutanixConfig.ControlPlaneEndpoint.Host}
+func ipsToIgnore(
+	nutanixConfig *v1alpha1.NutanixSpec,
+	addonsConfig *v1alpha1.GenericAddons,
+) []string {
+	toIgnore := make([]string, 0, 2)
+	seen := map[string]struct{}{}
+	appendIfUnique := func(ip string) {
+		if ip == "" {
+			return
+		}
+		if _, exists := seen[ip]; exists {
+			return
+		}
+		seen[ip] = struct{}{}
+		toIgnore = append(toIgnore, ip)
+	}
+
+	appendIfUnique(nutanixConfig.ControlPlaneEndpoint.Host)
+
 	// Also ignore the virtual IP if it is set.
 	if nutanixConfig.ControlPlaneEndpoint.VirtualIPSpec != nil &&
 		nutanixConfig.ControlPlaneEndpoint.VirtualIPSpec.Configuration != nil &&
 		nutanixConfig.ControlPlaneEndpoint.VirtualIPSpec.Configuration.Address != "" {
-		toIgnore = append(
-			toIgnore,
-			nutanixConfig.ControlPlaneEndpoint.VirtualIPSpec.Configuration.Address,
-		)
+		appendIfUnique(nutanixConfig.ControlPlaneEndpoint.VirtualIPSpec.Configuration.Address)
 	}
+
+	// If Service LB ranges are configured (e.g. MetalLB), ignore those ranges for CCM node IP detection.
+	if addonsConfig != nil &&
+		addonsConfig.ServiceLoadBalancer != nil &&
+		addonsConfig.ServiceLoadBalancer.Configuration != nil {
+		for _, ipRange := range addonsConfig.ServiceLoadBalancer.Configuration.AddressRanges {
+			appendIfUnique(fmt.Sprintf("%s-%s", ipRange.Start, ipRange.End))
+		}
+	}
+
 	return toIgnore
 }

--- a/pkg/handlers/lifecycle/ccm/nutanix/handler_test.go
+++ b/pkg/handlers/lifecycle/ccm/nutanix/handler_test.go
@@ -68,6 +68,21 @@ extraEnv:
   - name: KUBERNETES_SERVICE_PORT
     value: "6443"
 `
+
+	expectedWithServiceLoadBalancerRanges = `prismCentralEndPoint: prism-central.nutanix.com
+prismCentralPort: 9440
+prismCentralInsecure: true
+ignoredNodeIPs: [ "1.2.3.4", "10.176.64.10-10.176.64.30", "10.176.65.10-10.176.65.20" ]
+
+# The Secret containing the credentials will be created by the handler.
+createSecret: false
+secretName: nutanix-ccm-credentials
+extraEnv:
+  - name: KUBERNETES_SERVICE_HOST
+    value: "1.2.3.4"
+  - name: KUBERNETES_SERVICE_PORT
+    value: "6443"
+`
 )
 
 var valuesTemplateFile = func() string {
@@ -197,11 +212,51 @@ func Test_templateValues(t *testing.T) {
 			in:       valuesTemplate,
 			expected: expectedWithVirtualIPSet,
 		},
+		{
+			name: "With ServiceLoadBalancer ranges",
+			clusterConfig: &apivariables.ClusterConfigSpec{
+				Addons: &apivariables.Addons{
+					GenericAddons: v1alpha1.GenericAddons{
+						CCM: &v1alpha1.CCM{
+							Credentials: &v1alpha1.CCMCredentials{
+								SecretRef: v1alpha1.LocalObjectReference{
+									Name: "creds",
+								},
+							},
+						},
+						ServiceLoadBalancer: &v1alpha1.ServiceLoadBalancer{
+							Provider: "MetalLB",
+							Configuration: &v1alpha1.ServiceLoadBalancerConfiguration{
+								AddressRanges: []v1alpha1.AddressRange{
+									{Start: "10.176.64.10", End: "10.176.64.30"},
+									{Start: "10.176.65.10", End: "10.176.65.20"},
+								},
+							},
+						},
+					},
+				},
+				Nutanix: &v1alpha1.NutanixSpec{
+					PrismCentralEndpoint: v1alpha1.NutanixPrismCentralEndpointSpec{
+						URL: fmt.Sprintf(
+							"https://prism-central.nutanix.com:%d",
+							v1alpha1.DefaultPrismCentralPort,
+						),
+						Insecure: true,
+					},
+					ControlPlaneEndpoint: v1alpha1.ControlPlaneEndpointSpec{
+						Host: "1.2.3.4",
+						Port: 6443,
+					},
+				},
+			},
+			in:       valuesTemplate,
+			expected: expectedWithServiceLoadBalancerRanges,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			out, err := templateValuesFunc(tt.clusterConfig.Nutanix)(nil, tt.in)
+			out, err := templateValuesFunc(tt.clusterConfig)(nil, tt.in)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, out)
 		})


### PR DESCRIPTION
## Summary

- Update Nutanix CCM values templating to append ServiceLoadBalancer address ranges to `ignoredNodeIPs`.
- Keep scope limited to LB range handling only (no new API fields).
- Add/adjust unit tests in the Nutanix CCM handler to validate LB range rendering.

## Why

CCM node address discovery should not consider load balancer service IP pools/ranges as valid node IPs.
This change ensures configured LB ranges are explicitly ignored.

## What changed

- `pkg/handlers/lifecycle/ccm/nutanix/handler.go`
  - `ipsToIgnore(...)` now includes ServiceLoadBalancer `addressRanges` as `start-end` entries.
- `pkg/handlers/lifecycle/ccm/nutanix/handler_test.go`
  - adds/keeps test coverage verifying LB ranges are present in `ignoredNodeIPs`.
- Removed unrelated `IgnoredNodeIPs` API-field work to keep this patch strict.

## Expected behavior

When ServiceLoadBalancer ranges are configured, Nutanix CCM receives those ranges in `ignoredNodeIPs`,
preventing them from being used during node IP discovery.