### PR TITLE
feat: [NCN-115862] Upgrade Flow CNI to 1.1.0

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
@@ -61,7 +61,7 @@ data:
     RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix.github.io/helm/{{ end }}'
   nutanix-flow-cni: |
     ChartName: nutanix-flow-cni
-    ChartVersion: 1.0.0
+    ChartVersion: 1.1.0
     RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix.github.io/helm-releases{{ end }}'
   nutanix-storage-csi: |
     ChartName: nutanix-csi-storage

--- a/docs/content/addons/cni.md
+++ b/docs/content/addons/cni.md
@@ -138,6 +138,9 @@ deploying cluster-api-runtime-extensions-nutanix chart:
 Flow CNI is available for Nutanix clusters only. It uses the `HelmAddon` strategy exclusively
 (`ClusterResourceSet` is not supported).
 
+Flow CNI and OVN-Kubernetes need more node CPU and memory than Cilium or Calico. The Nutanix
+Flow quick-start example uses 4 vCPU / 8Gi machines.
+
 Flow CNI images are hosted on a private Docker Hub registry (`docker.io/nutanix`). If your
 environment does not use a mirror or registry credentials configured via `imageRegistries`, you
 must provide an image pull secret so the workload cluster can pull the Flow CNI images.
@@ -207,8 +210,9 @@ spec:
                   name: nutanix-docker-hub-credentials
 ```
 
-The handler copies the Secret to the workload cluster and configures the Flow CNI Helm chart to
-use it for pulling images.
+The handler copies the Secret to the `flow-cni-system`, `flow-cns-system`, and
+`ovn-kubernetes` namespaces on the workload cluster and configures the Flow CNI
+Helm chart to use it for pulling images.
 
 ### Flow Example With Custom Values
 

--- a/examples/capi-quick-start/nutanix-cluster-flow-helm-addon.yaml
+++ b/examples/capi-quick-start/nutanix-cluster-flow-helm-addon.yaml
@@ -140,12 +140,12 @@ spec:
               imageLookup:
                 baseOS: ${NUTANIX_MACHINE_TEMPLATE_BASE_OS}
                 format: ${NUTANIX_MACHINE_TEMPLATE_LOOKUP_FORMAT}
-              memorySize: 4Gi
+              memorySize: 8Gi
               subnets:
               - name: ${NUTANIX_SUBNET_NAME}
                 type: name
               systemDiskSize: 40Gi
-              vcpuSockets: 2
+              vcpuSockets: 4
               vcpusPerSocket: 1
         dns:
           coreDNS: {}
@@ -182,12 +182,12 @@ spec:
             imageLookup:
               baseOS: ${NUTANIX_MACHINE_TEMPLATE_BASE_OS}
               format: ${NUTANIX_MACHINE_TEMPLATE_LOOKUP_FORMAT}
-            memorySize: 4Gi
+            memorySize: 8Gi
             subnets:
             - name: ${NUTANIX_SUBNET_NAME}
               type: name
             systemDiskSize: 40Gi
-            vcpuSockets: 2
+            vcpuSockets: 4
             vcpusPerSocket: 1
     version: ${KUBERNETES_VERSION}
     workers:

--- a/hack/addons/helm-chart-bundler/repos.yaml
+++ b/hack/addons/helm-chart-bundler/repos.yaml
@@ -80,7 +80,7 @@ repositories:
     repoURL: https://nutanix.github.io/helm-releases
     charts:
       nutanix-flow-cni:
-      - 1.0.0
+      - 1.1.0
   registry-syncer:
     repoURL: https://mesosphere.github.io/charts/staging/
     charts:

--- a/hack/examples/patches/nutanix-flow.yaml
+++ b/hack/examples/patches/nutanix-flow.yaml
@@ -1,5 +1,8 @@
 # Copyright 2026 Nutanix. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Flow + OVN need more CPU/memory than Cilium/Calico. 2 vCPU / 4Gi leaves ovs-node
+# unschedulable (Insufficient cpu) and nodes stuck NetworkPluginNotReady.
 
 - op: "add"
   path: "/spec/topology/variables/0/value/addons/cni"
@@ -8,3 +11,15 @@
     imagePullCredentials:
       secretRef:
         name: "${CLUSTER_NAME}-flow-image-pull-secret"
+- op: "replace"
+  path: "/spec/topology/variables/0/value/controlPlane/nutanix/machineDetails/memorySize"
+  value: 8Gi
+- op: "replace"
+  path: "/spec/topology/variables/0/value/controlPlane/nutanix/machineDetails/vcpuSockets"
+  value: 4
+- op: "replace"
+  path: "/spec/topology/variables/1/value/nutanix/machineDetails/memorySize"
+  value: 8Gi
+- op: "replace"
+  path: "/spec/topology/variables/1/value/nutanix/machineDetails/vcpuSockets"
+  value: 4

--- a/make/addons.mk
+++ b/make/addons.mk
@@ -157,11 +157,11 @@ export MULTUS_CHART_VERSION := 0.1.1
 # Nutanix Flow CNI
 #   Chart name: nutanix-flow-cni
 #   Chart repo: https://nutanix.github.io/helm-releases/index.yaml
-#   Chart version:   1.0.0
-#   App version:     1.0.0
+#   Chart version:   1.1.0
+#   App version:     1.1.0
 #   Repo:            https://github.com/nutanix-core/flow-k8s-cni
-#   Release:         https://github.com/nutanix-core/flow-k8s-cni/releases/tag/1.0.0
-export NUTANIX_FLOW_CNI_VERSION := 1.0.0
+#   Release:         https://github.com/nutanix-core/flow-k8s-cni/releases/tag/1.1.0
+export NUTANIX_FLOW_CNI_VERSION := 1.1.0
 
 # Kube-vip (container image, not Helm - latest version can be checked via crane ls ghcr.io/kube-vip/kube-vip)
 #   Repo:        https://github.com/kube-vip/kube-vip

--- a/pkg/handlers/lifecycle/cni/nutanixflow/handler.go
+++ b/pkg/handlers/lifecycle/cni/nutanixflow/handler.go
@@ -34,6 +34,7 @@ const (
 
 var imagePullSecretNamespaces = []string{
 	"flow-cni-system",
+	"flow-cns-system",
 	"ovn-kubernetes",
 }
 

--- a/pkg/handlers/lifecycle/cni/nutanixflow/handler_test.go
+++ b/pkg/handlers/lifecycle/cni/nutanixflow/handler_test.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Nutanix. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nutanixflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImagePullSecretNamespaces(t *testing.T) {
+	t.Parallel()
+
+	// Flow CNI 1.1.0 deploys private images into three namespaces. The handler
+	// copies imagePullCredentials into each so kubelet can pull them.
+	assert.ElementsMatch(t, []string{
+		"flow-cni-system",
+		"flow-cns-system",
+		"ovn-kubernetes",
+	}, imagePullSecretNamespaces)
+}

--- a/test/e2e/addon_helpers.go
+++ b/test/e2e/addon_helpers.go
@@ -39,6 +39,7 @@ func WaitForAddonsToBeReadyInWorkloadCluster(
 			ClusterProxy:                input.ClusterProxy,
 			DeploymentIntervals:         input.DeploymentIntervals,
 			DaemonSetIntervals:          input.DaemonSetIntervals,
+			StatefulSetIntervals:        input.StatefulSetIntervals,
 			HelmReleaseIntervals:        input.HelmReleaseIntervals,
 			ClusterResourceSetIntervals: input.ClusterResourceSetIntervals,
 		},

--- a/test/e2e/cni_helpers.go
+++ b/test/e2e/cni_helpers.go
@@ -27,6 +27,7 @@ type WaitForCNIToBeReadyInWorkloadClusterInput struct {
 	ClusterProxy                framework.ClusterProxy
 	DeploymentIntervals         []interface{}
 	DaemonSetIntervals          []interface{}
+	StatefulSetIntervals        []interface{}
 	HelmReleaseIntervals        []interface{}
 	ClusterResourceSetIntervals []interface{}
 }
@@ -75,6 +76,7 @@ func WaitForCNIToBeReadyInWorkloadCluster(
 				clusterProxy:                input.ClusterProxy,
 				deploymentIntervals:         input.DeploymentIntervals,
 				daemonSetIntervals:          input.DaemonSetIntervals,
+				statefulSetIntervals:        input.StatefulSetIntervals,
 				helmReleaseIntervals:        input.HelmReleaseIntervals,
 				clusterResourceSetIntervals: input.ClusterResourceSetIntervals,
 			},
@@ -301,6 +303,7 @@ type waitForFlowToBeReadyInWorkloadClusterInput struct {
 	clusterProxy                framework.ClusterProxy
 	deploymentIntervals         []interface{}
 	daemonSetIntervals          []interface{}
+	statefulSetIntervals        []interface{}
 	helmReleaseIntervals        []interface{}
 	clusterResourceSetIntervals []interface{}
 }
@@ -346,6 +349,15 @@ func waitForFlowToBeReadyInWorkloadCluster(
 		Getter: workloadClusterClient,
 		Deployment: &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
+				Name:      "flow-cni-flow-processor",
+				Namespace: "flow-cns-system",
+			},
+		},
+	}, input.deploymentIntervals...)
+	WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+		Getter: workloadClusterClient,
+		Deployment: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "ovnkube-db",
 				Namespace: "ovn-kubernetes",
 			},
@@ -360,6 +372,24 @@ func waitForFlowToBeReadyInWorkloadCluster(
 			},
 		},
 	}, input.deploymentIntervals...)
+	WaitForStatefulSetsAvailable(ctx, WaitForStatefulSetAvailableInput{
+		Getter: workloadClusterClient,
+		StatefulSet: &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "flow-cni-nats",
+				Namespace: "flow-cni-system",
+			},
+		},
+	}, input.statefulSetIntervals...)
+	WaitForDaemonSetsAvailable(ctx, WaitForDaemonSetsAvailableInput{
+		Getter: workloadClusterClient,
+		DaemonSet: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "flow-cni-conntrack-collector",
+				Namespace: "flow-cni-system",
+			},
+		},
+	}, input.daemonSetIntervals...)
 	WaitForDaemonSetsAvailable(ctx, WaitForDaemonSetsAvailableInput{
 		Getter: workloadClusterClient,
 		DaemonSet: &appsv1.DaemonSet{


### PR DESCRIPTION
## Summary
- Bump Nutanix Flow CNI Helm chart from 1.0.0 to 1.1.0 (addons.mk, helm-config, mindthegap repos)
- Copy image-pull secrets into `flow-cns-system` for the new flow-processor workload
- Extend e2e readiness waits for flow-processor, NATS, and conntrack-collector; raise Flow example machine size to 4 vCPU / 8Gi
- Allow cluster delete to proceed if Konnector Agent helm uninstall times out (unblocks Flow e2e teardown)

## Test plan
- [x] `go test ./pkg/handlers/lifecycle/cni/nutanixflow/`
- [x] Confirm chart `nutanix-flow-cni` 1.1.0 pulls from `https://nutanix.github.io/helm-releases`
- [x] Run Nutanix Flow CNI e2e (quick-start) and verify new components become ready, including cluster delete

Made with [Cursor](https://cursor.com)