### PR TITLE
fix: metro preflights

### DIFF
--- a/pkg/webhook/preflight/nutanix/metro.go
+++ b/pkg/webhook/preflight/nutanix/metro.go
@@ -394,23 +394,22 @@ func (c *metroVHACategoryNameCheck) Run(_ context.Context) preflight.CheckResult
 	result := preflight.CheckResult{Allowed: true}
 
 	// CAPX synthesizes a single "default" movement group and one category per
-	// metro failure domain (index 0 and 1).
+	// metro failure domain. Indexes 0 and 1 are single-digit, so length is the
+	// same; check idx 0 only to avoid duplicate causes.
 	for _, metroName := range c.metroNames {
 		domainName := vhaDomainName(c.clusterName, metroName)
-		for idx := range metroPrismElementCount {
-			value := vhaCategoryValue(domainName, vhaDefaultMovementGroup, idx)
-			if len(value) <= prismCategoryValueMaxLen {
-				continue
-			}
-			failCheck(&result, c.field, fmt.Sprintf(
-				"Generated Prism Central category value %q is %d characters; Prism Central limits category values to %d. CAPX names metro categories k8s-vha-capx-{cluster}-{metro}-default-{idx} and does not hash or truncate them. Shorten the Cluster name %q or NutanixMetro name %q and retry.", //nolint:lll // Message is long.
-				value,
-				len(value),
-				prismCategoryValueMaxLen,
-				c.clusterName,
-				metroName,
-			))
+		value := vhaCategoryValue(domainName, vhaDefaultMovementGroup, 0)
+		if len(value) <= prismCategoryValueMaxLen {
+			continue
 		}
+		failCheck(&result, c.field, fmt.Sprintf(
+			"Generated Prism Central category value %q is %d characters; Prism Central limits category values to %d. CAPX names metro categories k8s-vha-capx-{cluster}-{metro}-default-{idx} and does not hash or truncate them. Shorten the Cluster name %q or NutanixMetro name %q and retry.", //nolint:lll // Message is long.
+			value,
+			len(value),
+			prismCategoryValueMaxLen,
+			c.clusterName,
+			metroName,
+		))
 	}
 
 	return result

--- a/pkg/webhook/preflight/nutanix/metro.go
+++ b/pkg/webhook/preflight/nutanix/metro.go
@@ -28,6 +28,13 @@ const (
 	// milliseconds, supported between the two Prism Elements of a metro
 	// configuration for safe synchronous replication.
 	metroMaxRTTMillis = 5.0
+
+	// vhaDefaultMovementGroup is the movement group CAPX synthesizes when a
+	// NutanixVirtualHADomain has none. See cluster-api-provider-nutanix
+	// controllers/nutanixvirtualhadomain_controller.go.
+	vhaDefaultMovementGroup = "default"
+	// prismCategoryValueMaxLen is Prism Central's maximum length for category values.
+	prismCategoryValueMaxLen = 64
 )
 
 type metroCheck struct {
@@ -143,6 +150,23 @@ func newMetroChecks(cd *checkDependencies) []preflight.Check {
 				nodePools: clusterNodePools(cd),
 				field:     firstField,
 			},
+			// Metro sites of the same NutanixMetro must prefer distinct failure
+			// domains and use distinct groupNameLabels. Otherwise both sites pin
+			// to the same Prism Element (or the same topology segment).
+			&metroSitesIdentityCheck{
+				metroNames: metroNames,
+				namespace:  cd.cluster.Namespace,
+				field:      firstField,
+				kclient:    cd.kclient,
+			},
+			// CAPX generates Prism Central category values as
+			// k8s-vha-capx-{cluster}-{metro}-{group}-{idx} and fails if the
+			// result exceeds 64 characters. Catch that before admission.
+			&metroVHACategoryNameCheck{
+				clusterName: cd.cluster.Name,
+				metroNames:  metroNames,
+				field:       firstField,
+			},
 		)
 	}
 
@@ -237,6 +261,154 @@ func (c *allNodePoolsMetroCheck) Run(_ context.Context) preflight.CheckResult {
 				"%s uses failure domain %q, which is not a NutanixMetro or NutanixMetroSite failure domain. In a metro configuration, every Control Plane and Worker node pool must be placed on a NutanixMetro or NutanixMetroSite failure domain so that all nodes are protected by synchronous replication. Use a NutanixMetro or NutanixMetroSite failure domain and retry.", //nolint:lll // Message is long.
 				np.description,
 				fd,
+			))
+		}
+	}
+
+	return result
+}
+
+// metroSitesIdentityCheck enforces that NutanixMetroSite objects belonging to
+// the same NutanixMetro have distinct preferred failure domains and, when set,
+// distinct groupNameLabels. Sharing either value would pin both sites to the
+// same Prism Element or the same topology segment.
+type metroSitesIdentityCheck struct {
+	metroNames []string
+	namespace  string
+	field      string
+	kclient    ctrlclient.Client
+}
+
+func (c *metroSitesIdentityCheck) Name() string {
+	return nutanixMetroName
+}
+
+func (c *metroSitesIdentityCheck) Run(ctx context.Context) preflight.CheckResult {
+	result := preflight.CheckResult{Allowed: true}
+
+	siteList := &capxv1.NutanixMetroSiteList{}
+	if err := c.kclient.List(ctx, siteList, ctrlclient.InNamespace(c.namespace)); err != nil {
+		failCheckInternal(&result, c.field, fmt.Sprintf(
+			"Failed to list NutanixMetroSite objects: %s. This is usually a temporary error. Please retry.",
+			err,
+		))
+		return result
+	}
+
+	metroNameSet := map[string]struct{}{}
+	for _, name := range c.metroNames {
+		metroNameSet[name] = struct{}{}
+	}
+
+	sitesByMetro := map[string][]metroSiteIdentity{}
+	for i := range siteList.Items {
+		site := &siteList.Items[i]
+		metro := site.Spec.MetroRef.Name
+		if _, ok := metroNameSet[metro]; !ok {
+			continue
+		}
+		groupLabel := ""
+		if site.Spec.GroupNameLabel != nil {
+			groupLabel = *site.Spec.GroupNameLabel
+		}
+		sitesByMetro[metro] = append(sitesByMetro[metro], metroSiteIdentity{
+			name:        site.Name,
+			preferredFD: site.Spec.PreferredFailureDomain.Name,
+			groupLabel:  groupLabel,
+		})
+	}
+
+	for _, metroName := range c.metroNames {
+		sites := sitesByMetro[metroName]
+		reportDuplicateSiteField(&result, c.field, metroName, sites, func(s metroSiteIdentity) string {
+			return s.preferredFD
+		}, "preferredFailureDomain")
+		reportDuplicateSiteField(&result, c.field, metroName, sites, func(s metroSiteIdentity) string {
+			return s.groupLabel
+		}, "groupNameLabel")
+	}
+
+	return result
+}
+
+type metroSiteIdentity struct {
+	name        string
+	preferredFD string
+	groupLabel  string
+}
+
+func reportDuplicateSiteField(
+	result *preflight.CheckResult,
+	field, metroName string,
+	sites []metroSiteIdentity,
+	value func(metroSiteIdentity) string,
+	fieldName string,
+) {
+	seen := map[string]string{}
+	for _, site := range sites {
+		v := value(site)
+		if v == "" {
+			continue
+		}
+		if other, ok := seen[v]; ok {
+			failCheck(result, field, fmt.Sprintf(
+				"NutanixMetroSite %q and %q of NutanixMetro %q share %s %q. Each metro site must have a distinct %s so that sites pin to different Prism Elements and topology segments. Use a unique %s per site and retry.", //nolint:lll // Message is long.
+				other,
+				site.name,
+				metroName,
+				fieldName,
+				v,
+				fieldName,
+				fieldName,
+			))
+			continue
+		}
+		seen[v] = site.name
+	}
+}
+
+// metroVHACategoryNameCheck enforces that the Prism Central category values CAPX
+// will generate for the default metro movement group stay within
+// prismCategoryValueMaxLen. CAPX names them
+// k8s-vha-capx-{cluster}-{metro}-default-{idx} and fails immediately if the
+// result is longer than 64 characters.
+type metroVHACategoryNameCheck struct {
+	clusterName string
+	metroNames  []string
+	field       string
+}
+
+func (c *metroVHACategoryNameCheck) Name() string {
+	return nutanixMetroName
+}
+
+func vhaDomainName(clusterName, metroName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, metroName)
+}
+
+func vhaCategoryValue(vHADomainName, group string, idx int) string {
+	return fmt.Sprintf("k8s-vha-capx-%s-%s-%d", vHADomainName, group, idx)
+}
+
+func (c *metroVHACategoryNameCheck) Run(_ context.Context) preflight.CheckResult {
+	result := preflight.CheckResult{Allowed: true}
+
+	// CAPX synthesizes a single "default" movement group and one category per
+	// metro failure domain (index 0 and 1).
+	for _, metroName := range c.metroNames {
+		domainName := vhaDomainName(c.clusterName, metroName)
+		for idx := range metroPrismElementCount {
+			value := vhaCategoryValue(domainName, vhaDefaultMovementGroup, idx)
+			if len(value) <= prismCategoryValueMaxLen {
+				continue
+			}
+			failCheck(&result, c.field, fmt.Sprintf(
+				"Generated Prism Central category value %q is %d characters; Prism Central limits category values to %d. CAPX names metro categories k8s-vha-capx-{cluster}-{metro}-default-{idx} and does not hash or truncate them. Shorten the Cluster name %q or NutanixMetro name %q and retry.", //nolint:lll // Message is long.
+				value,
+				len(value),
+				prismCategoryValueMaxLen,
+				c.clusterName,
+				metroName,
 			))
 		}
 	}

--- a/pkg/webhook/preflight/nutanix/metro_test.go
+++ b/pkg/webhook/preflight/nutanix/metro_test.go
@@ -705,7 +705,7 @@ func TestMetroSitesIdentityCheck(t *testing.T) {
 }
 
 func TestMetroVHACategoryNameCheck(t *testing.T) {
-	// k8s-vha-capx-{cluster}-{metro}-default-1 is 24 + len(cluster) + len(metro).
+	// k8s-vha-capx-{cluster}-{metro}-default-0 is 24 + len(cluster) + len(metro).
 	// 24 + 20 + 20 = 64; 24 + 21 + 20 = 65.
 	shortCluster := "cluster-1"
 	atLimitCluster := strings.Repeat("a", 20)
@@ -754,7 +754,7 @@ func TestMetroVHACategoryNameCheck(t *testing.T) {
 				assert.Empty(t, result.Causes)
 				return
 			}
-			require.NotEmpty(t, result.Causes)
+			require.Len(t, result.Causes, 1)
 			assert.Contains(t, result.Causes[0].Message, tc.expectedCauseMessage)
 			assert.Equal(t, field, result.Causes[0].Field)
 		})

--- a/pkg/webhook/preflight/nutanix/metro_test.go
+++ b/pkg/webhook/preflight/nutanix/metro_test.go
@@ -5,6 +5,7 @@ package nutanix
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -169,8 +170,9 @@ func TestNewMetroChecks(t *testing.T) {
 			},
 			nclient: &clientWrapper{},
 			// 1 per-metro check + 1 cluster PE-scale check + 1 PC-hosting check
-			// + 1 latency check + 1 all-node-pools check.
-			expectedChecksCount: 5,
+			// + 1 latency check + 1 all-node-pools check + 1 metro-sites identity
+			// check + 1 vHA category name check.
+			expectedChecksCount: 7,
 		},
 		{
 			name: "same metro referenced by control plane and worker is de-duplicated",
@@ -187,8 +189,9 @@ func TestNewMetroChecks(t *testing.T) {
 			}},
 			nclient: &clientWrapper{},
 			// 1 per-metro check + 1 cluster PE-scale check + 1 PC-hosting check
-			// + 1 latency check + 1 all-node-pools check.
-			expectedChecksCount: 5,
+			// + 1 latency check + 1 all-node-pools check + 1 metro-sites identity
+			// check + 1 vHA category name check.
+			expectedChecksCount: 7,
 		},
 		{
 			name: "two distinct metros add a single-metro check",
@@ -205,8 +208,9 @@ func TestNewMetroChecks(t *testing.T) {
 			}},
 			nclient: &clientWrapper{},
 			// 2 per-metro checks + 1 single-metro check + 1 cluster PE-scale check
-			// + 1 PC-hosting check + 1 latency check + 1 all-node-pools check.
-			expectedChecksCount: 7,
+			// + 1 PC-hosting check + 1 latency check + 1 all-node-pools check
+			// + 1 metro-sites identity check + 1 vHA category name check.
+			expectedChecksCount: 9,
 		},
 		{
 			name: "metro site failure domain resolves to its metro",
@@ -225,8 +229,9 @@ func TestNewMetroChecks(t *testing.T) {
 			},
 			nclient: &clientWrapper{},
 			// 1 per-metro check + 1 cluster PE-scale check + 1 PC-hosting check
-			// + 1 latency check + 1 all-node-pools check.
-			expectedChecksCount: 5,
+			// + 1 latency check + 1 all-node-pools check + 1 metro-sites identity
+			// check + 1 vHA category name check.
+			expectedChecksCount: 7,
 		},
 	}
 
@@ -571,6 +576,186 @@ func TestAllNodePoolsMetroCheck(t *testing.T) {
 			if tc.expectedCauseMessage != "" {
 				assert.Contains(t, result.Causes[0].Message, tc.expectedCauseMessage)
 			}
+			assert.Equal(t, field, result.Causes[0].Field)
+		})
+	}
+}
+
+func newMetroSite(name, metro, preferredFD string, groupNameLabel *string) *capxv1.NutanixMetroSite {
+	return &capxv1.NutanixMetroSite{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: capxv1.NutanixMetroSiteSpec{
+			MetroRef:               corev1.LocalObjectReference{Name: metro},
+			PreferredFailureDomain: corev1.LocalObjectReference{Name: preferredFD},
+			GroupNameLabel:         groupNameLabel,
+		},
+	}
+}
+
+func TestMetroSitesIdentityCheck(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		metroNames           []string
+		objects              []ctrlclient.Object
+		expectedAllowed      bool
+		expectedCauseCount   int
+		expectedCauseMessage string
+	}{
+		{
+			name:            "no metro sites is allowed",
+			metroNames:      []string{metroName},
+			expectedAllowed: true,
+		},
+		{
+			name:       "single metro site is allowed",
+			metroNames: []string{metroName},
+			objects: []ctrlclient.Object{
+				newMetroSite("site-1", metroName, metroFD1, ptr.To("dh1")),
+			},
+			expectedAllowed: true,
+		},
+		{
+			name:       "sites of the same metro with distinct preferred FDs and labels are allowed",
+			metroNames: []string{metroName},
+			objects: []ctrlclient.Object{
+				newMetroSite("site-1", metroName, metroFD1, ptr.To("dh1")),
+				newMetroSite("site-2", metroName, metroFD2, ptr.To("dh2")),
+			},
+			expectedAllowed: true,
+		},
+		{
+			name:       "sites of another metro are ignored",
+			metroNames: []string{metroName},
+			objects: []ctrlclient.Object{
+				newMetroSite("site-1", metroName, metroFD1, ptr.To("dh1")),
+				newMetroSite("other-1", "other-metro", metroFD1, ptr.To("dh1")),
+				newMetroSite("other-2", "other-metro", metroFD1, ptr.To("dh1")),
+			},
+			expectedAllowed: true,
+		},
+		{
+			name:       "duplicate preferred failure domain is rejected",
+			metroNames: []string{metroName},
+			objects: []ctrlclient.Object{
+				newMetroSite("metro0-s0", metroName, metroFD1, ptr.To("dh1")),
+				newMetroSite("metro0-s1", metroName, metroFD1, ptr.To("dh2")),
+			},
+			expectedAllowed:      false,
+			expectedCauseCount:   1,
+			expectedCauseMessage: "share preferredFailureDomain",
+		},
+		{
+			name:       "duplicate groupNameLabel is rejected",
+			metroNames: []string{metroName},
+			objects: []ctrlclient.Object{
+				newMetroSite("metro0-s0", metroName, metroFD1, ptr.To("dh1")),
+				newMetroSite("metro0-s1", metroName, metroFD2, ptr.To("dh1")),
+			},
+			expectedAllowed:      false,
+			expectedCauseCount:   1,
+			expectedCauseMessage: "share groupNameLabel",
+		},
+		{
+			name:       "duplicate preferred FD and groupNameLabel are both reported",
+			metroNames: []string{metroName},
+			objects: []ctrlclient.Object{
+				newMetroSite("metro0-s0", metroName, metroFD1, ptr.To("dh1")),
+				newMetroSite("metro0-s1", metroName, metroFD1, ptr.To("dh1")),
+			},
+			expectedAllowed:    false,
+			expectedCauseCount: 2,
+		},
+		{
+			name:       "unset groupNameLabel is not treated as a duplicate",
+			metroNames: []string{metroName},
+			objects: []ctrlclient.Object{
+				newMetroSite("site-1", metroName, metroFD1, nil),
+				newMetroSite("site-2", metroName, metroFD2, nil),
+			},
+			expectedAllowed: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(metroScheme())
+			if len(tc.objects) > 0 {
+				builder = builder.WithObjects(tc.objects...)
+			}
+			check := &metroSitesIdentityCheck{
+				metroNames: tc.metroNames,
+				namespace:  namespace,
+				field:      field,
+				kclient:    builder.Build(),
+			}
+			result := check.Run(context.TODO())
+
+			assert.Equal(t, tc.expectedAllowed, result.Allowed)
+			if tc.expectedAllowed {
+				assert.Empty(t, result.Causes)
+				return
+			}
+			require.Len(t, result.Causes, tc.expectedCauseCount)
+			if tc.expectedCauseMessage != "" {
+				assert.Contains(t, result.Causes[0].Message, tc.expectedCauseMessage)
+			}
+			assert.Equal(t, field, result.Causes[0].Field)
+		})
+	}
+}
+
+func TestMetroVHACategoryNameCheck(t *testing.T) {
+	// k8s-vha-capx-{cluster}-{metro}-default-1 is 24 + len(cluster) + len(metro).
+	// 24 + 20 + 20 = 64; 24 + 21 + 20 = 65.
+	shortCluster := "cluster-1"
+	atLimitCluster := strings.Repeat("a", 20)
+	overLimitCluster := strings.Repeat("a", 21)
+	metroAtLimit := strings.Repeat("b", 20)
+
+	testCases := []struct {
+		name                 string
+		clusterName          string
+		metroNames           []string
+		expectedAllowed      bool
+		expectedCauseMessage string
+	}{
+		{
+			name:            "short cluster and metro names are allowed",
+			clusterName:     shortCluster,
+			metroNames:      []string{metroName},
+			expectedAllowed: true,
+		},
+		{
+			name:            "category value of exactly 64 characters is allowed",
+			clusterName:     atLimitCluster,
+			metroNames:      []string{metroAtLimit},
+			expectedAllowed: true,
+		},
+		{
+			name:                 "category value longer than 64 characters is rejected",
+			clusterName:          overLimitCluster,
+			metroNames:           []string{metroAtLimit},
+			expectedAllowed:      false,
+			expectedCauseMessage: "Prism Central limits category values to 64",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			check := &metroVHACategoryNameCheck{
+				clusterName: tc.clusterName,
+				metroNames:  tc.metroNames,
+				field:       field,
+			}
+			result := check.Run(context.TODO())
+
+			assert.Equal(t, tc.expectedAllowed, result.Allowed)
+			if tc.expectedAllowed {
+				assert.Empty(t, result.Causes)
+				return
+			}
+			require.NotEmpty(t, result.Causes)
+			assert.Contains(t, result.Causes[0].Message, tc.expectedCauseMessage)
 			assert.Equal(t, field, result.Causes[0].Field)
 		})
 	}


### PR DESCRIPTION
- Reject metro Clusters whose NutanixMetroSite objects share a preferredFailureDomain or groupNameLabel, so both sites cannot pin to the same PE or topology segment (for example both sites preferring fd0).

- Reject names that would make CAPX’s default vHA category value longer than 64 characters: k8s-vha-capx-{cluster}-{metro}-default-{idx}. CAPX now fails fast on that limit ([cluster-api-provider-nutanix#782](https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/782)); this catches it at admission and asks to shorten the Cluster or metro name.