### PR TITLE
fix: bump up konnector to 1.4.2

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/helm-config.yaml
@@ -37,7 +37,7 @@ data:
     RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://mesosphere.github.io/charts/stable/{{ end }}'
   konnector-agent: |
     ChartName: konnector-agent
-    ChartVersion: 1.4.1
+    ChartVersion: 1.4.2
     RepositoryURL: '{{ if .Values.helmRepository.enabled }}oci://helm-repository.{{ .Release.Namespace }}.svc/charts{{ else }}https://nutanix.github.io/helm-releases/{{ end }}'
   local-path-provisioner-csi: |
     ChartName: local-path-provisioner

--- a/docs/content/addons/konnector-agent.md
+++ b/docs/content/addons/konnector-agent.md
@@ -125,7 +125,7 @@ The addon uses the following default values:
 - **Agent Name**: `konnector-agent`
 - **Strategy**: `HelmAddon`
 - **Chart**: `konnector-agent`
-- **Version**: `1.4.1`
+- **Version**: `1.4.2`
 
 ## Pod Security Admission
 

--- a/hack/addons/helm-chart-bundler/repos.yaml
+++ b/hack/addons/helm-chart-bundler/repos.yaml
@@ -45,7 +45,7 @@ repositories:
     repoURL: https://nutanix.github.io/helm-releases/
     charts:
       konnector-agent:
-      - 1.4.1
+      - 1.4.2
   local-path-provisioner:
     repoURL: https://charts.containeroo.ch
     charts:

--- a/make/addons.mk
+++ b/make/addons.mk
@@ -139,11 +139,11 @@ export COSI_CONTROLLER_VERSION := 0.2.2
 # Konnector Agent
 #   Chart name:    konnector-agent
 #   Chart repo: 	 https://nutanix.github.io/helm-releases/index.yaml
-#   Chart version: 1.4.1
-#   App version:   v1.4.1
+#   Chart version: 1.4.2
+#   App version:   v1.4.2
 #   Repo:          https://github.com/nutanix-core/k8s-agent
-#   Release:       https://github.com/nutanix-core/k8s-agent/releases/tag/1.4.0
-export KONNECTOR_AGENT_VERSION := 1.4.1
+#   Release:       https://github.com/nutanix-core/k8s-agent/releases/tag/1.4.2
+export KONNECTOR_AGENT_VERSION := 1.4.2
 
 # Multus
 #   Chart name: multus


### PR DESCRIPTION
Bump up konnector agent to 1.4.2 release tag.

